### PR TITLE
feat(config): delete some obsolete config items

### DIFF
--- a/main_net_config.conf
+++ b/main_net_config.conf
@@ -8,7 +8,7 @@ storage {
   db.engine = "LEVELDB",
   db.sync = false,
   db.directory = "database",
-  index.directory = "index",
+
   transHistory.switch = "on",
   # You can custom these 14 databases' configs:
 
@@ -75,16 +75,6 @@ storage {
     level0FileNumCompactionTrigger = 4
     targetFileSizeBase = 256  // n * MB
     targetFileSizeMultiplier = 1
-  }
-
-  //backup settings when using rocks db as the storage implement (db.engine="ROCKSDB").
-  //if you want to use the backup plugin, please confirm set the db.engine="ROCKSDB" above.
-  backup = {
-    enable = false  // indicate whether enable the backup plugin
-    propPath = "prop.properties" // record which bak directory is valid
-    bak1path = "bak1/database" // you must set two backup directories to prevent application halt unexpected(e.g. kill -9).
-    bak2path = "bak2/database"
-    frequency = 10000   // indicate backup db once every 10000 blocks processed.
   }
 
   balance.history.lookup = false

--- a/main_net_config.conf
+++ b/main_net_config.conf
@@ -152,8 +152,6 @@ node {
 
   fetchBlock.timeout = 200
 
-  tcpNettyWorkThreadNum = 0
-
   udpNettyWorkThreadNum = 1
 
   # Number of validate sign thread, default availableProcessors


### PR DESCRIPTION
delete obsolete config item, includes these:

- `storage.index.directory`. Since `getTransactionsToThis` and `getTransactionsFromThis` is obsolete, it shoule be deleted.
- `storage.backup`. Database backup consumes resources and has poor performance, making it practically unavailable
- `node.tcpNettyWorkThreadNum` it is not used now.