### PR TITLE
schema: add JSON Schemas for trond recipe list/show/run outputs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -441,6 +441,11 @@ fields forward via `{{ steps.<id>.<field> }}` substitution. Steps
 declare `on_failure: abort | continue | rollback`; rollback steps
 run as a best-effort cleanup pass when triggered.
 
+The output of `recipe list / show / run` is documented as JSON Schema
+(`schemas/output/recipe-{list,show,run}.schema.json`); pull via
+`trond schema "recipe run" --output-only -o json` or validate parsed
+output against the embedded schema.
+
 Shipped recipes:
 
 | Name | What it does |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ The agent-ergonomics arc lands across four sequenced PRs:
 **#153** (`trond mcp`) → **#154** (`trond recipe`).
 
 ### Added
+- (#156) JSON Schemas for `trond recipe list / show / run` outputs
+  (`schemas/output/recipe-{list,show,run}.schema.json`). Closes the
+  schema-coverage gap left by #154 — `trond schema "recipe run"
+  --output-only -o json` now returns the canonical RunResult shape
+  instead of empty. Bumps `SchemaVersion` to `1.1.0` (minor: new
+  schemas added, no existing schema modified).
 - (#154) `trond recipe list / show / run` — declarative multi-step
   workflow runner. Recipes are YAML files in `recipes/*.yaml` (also
   embedded via go:embed) that codify the canonical AGENTS.md

--- a/internal/schema/embed.go
+++ b/internal/schema/embed.go
@@ -16,12 +16,29 @@ import (
 	"strings"
 )
 
-// SchemaVersion is the trond CLI contract version. Bumped when an
-// existing field in any output schema changes meaning, gets renamed,
-// or is removed. Field additions are minor and don't bump it.
+// SchemaVersion is the trond CLI contract version. Semver semantics:
 //
-// Agents should pin against this and re-read AGENTS.md on a major bump.
-const SchemaVersion = "1.0.0"
+//   - PATCH: a single existing schema gains an additive optional field
+//     (clients that ignore unknown fields are unaffected).
+//   - MINOR: an entirely new schema is added (a new command becomes
+//     manifest-discoverable; existing schemas unchanged).
+//   - MAJOR: an existing field is renamed, removed, or its meaning
+//     shifts. Agents pinned to the prior major may break.
+//
+// Agents should pin to MAJOR for compat detection and re-read AGENTS.md
+// when MAJOR bumps. The version bump rationale is also captured in
+// CHANGELOG entries.
+//
+// History:
+//
+//	1.0.0 — initial 21 schemas (apply, plan, status, list, inspect,
+//	        diagnose, health, verify, preflight, doctor, version,
+//	        events, config-validate, config-render, network-create,
+//	        network-status, snapshot-sources, snapshot-list,
+//	        snapshot-download, snapshot-jobs, error envelope).
+//	1.1.0 — add recipe-list / recipe-show / recipe-run schemas (no
+//	        changes to existing schemas).
+const SchemaVersion = "1.1.0"
 
 // JSONSchemaURLBase is the canonical URL prefix for individual output
 // schema files. Embedded $id values inside each schema mirror this so

--- a/internal/schema/files/recipe-list.schema.json
+++ b/internal/schema/files/recipe-list.schema.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/tronprotocol/tron-deployment/blob/master/schemas/output/recipe-list.schema.json",
+  "title": "trond recipe list output",
+  "type": "object",
+  "required": ["recipes"],
+  "properties": {
+    "recipes": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["name", "description", "step_count"],
+        "properties": {
+          "name":        { "type": "string", "description": "Recipe identifier; pass to `recipe show` / `recipe run`." },
+          "description": { "type": "string", "description": "First paragraph of the recipe's YAML description." },
+          "params":      { "type": "string", "description": "Human summary like '3 total / 2 required'." },
+          "step_count":  { "type": "integer", "minimum": 1 }
+        }
+      }
+    }
+  }
+}

--- a/internal/schema/files/recipe-run.schema.json
+++ b/internal/schema/files/recipe-run.schema.json
@@ -1,0 +1,47 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/tronprotocol/tron-deployment/blob/master/schemas/output/recipe-run.schema.json",
+  "title": "trond recipe run output",
+  "description": "Returned by `trond recipe run <name> -o json`. Stable shape so an MCP recipe.run tool can pass it through verbatim.",
+  "type": "object",
+  "required": ["recipe", "status", "started_at", "duration_ms", "steps"],
+  "properties": {
+    "recipe":      { "type": "string", "description": "The .name of the recipe that was run." },
+    "status": {
+      "type": "string",
+      "enum": ["success", "failed", "rolled_back"],
+      "description": "Aggregate verdict. failed=a step's on_failure=abort triggered; rolled_back=on_failure=rollback triggered and the rollback section ran."
+    },
+    "started_at":  { "type": "string", "format": "date-time" },
+    "duration_ms": { "type": "integer", "minimum": 0 },
+    "failed_at":   { "type": "string", "description": "Step ID that triggered failure; absent on success." },
+    "rollback_ran":  { "type": "boolean" },
+    "steps": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/stepResult" }
+    },
+    "rollback_steps": {
+      "type": "array",
+      "description": "Records for each rollback step that ran (only set when rollback_ran=true).",
+      "items": { "$ref": "#/$defs/stepResult" }
+    }
+  },
+  "$defs": {
+    "stepResult": {
+      "type": "object",
+      "required": ["id"],
+      "properties": {
+        "id":          { "type": "string" },
+        "skipped":     { "type": "boolean", "description": "True when --resume-from passed this step or its skip predicate evaluated true." },
+        "exit_code":   { "type": "integer" },
+        "duration_ms": { "type": "integer", "minimum": 0 },
+        "output": {
+          "type": "object",
+          "description": "JSON object captured from the step's stdout (when the step's command supports -o json).",
+          "additionalProperties": true
+        },
+        "error":       { "type": "string", "description": "Set when the step's command exited non-zero." }
+      }
+    }
+  }
+}

--- a/internal/schema/files/recipe-show.schema.json
+++ b/internal/schema/files/recipe-show.schema.json
@@ -1,0 +1,49 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/tronprotocol/tron-deployment/blob/master/schemas/output/recipe-show.schema.json",
+  "title": "trond recipe show output",
+  "description": "The Recipe struct serialised verbatim. Schema mirrors internal/recipe.Recipe so agents reading this output can program against the same shape the CLI accepts as YAML.",
+  "type": "object",
+  "required": ["name", "description", "steps"],
+  "properties": {
+    "name":        { "type": "string" },
+    "description": { "type": "string" },
+    "params": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["name"],
+        "properties": {
+          "name":        { "type": "string" },
+          "type":        { "type": "string", "enum": ["string", "int", "bool", "path"] },
+          "required":    { "type": "boolean" },
+          "default":     { "type": "string" },
+          "description": { "type": "string" }
+        }
+      }
+    },
+    "steps": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/step" }
+    },
+    "rollback": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/step" }
+    }
+  },
+  "$defs": {
+    "step": {
+      "type": "object",
+      "required": ["id", "command"],
+      "properties": {
+        "id":          { "type": "string" },
+        "description": { "type": "string" },
+        "command":     { "type": "string", "description": "Trond subcommand path, e.g. 'config validate' or 'snapshot download'." },
+        "args":        { "type": "array", "items": { "type": "string" } },
+        "on_failure":  { "type": "string", "enum": ["abort", "continue", "rollback"], "description": "Default = abort." },
+        "persist":     { "type": "array", "items": { "type": "string" }, "description": "Field names from this step's stdout to expose to subsequent steps via {{ steps.<id>.<name> }}." },
+        "skip":        { "type": "string", "description": "Template; step is skipped when this evaluates to 'true'." }
+      }
+    }
+  }
+}

--- a/internal/schema/manifest.go
+++ b/internal/schema/manifest.go
@@ -85,6 +85,9 @@ var DefaultSchemaLookup = map[string]string{
 	"trond snapshot list":     "snapshot-list",
 	"trond snapshot download": "snapshot-download",
 	"trond snapshot jobs":     "snapshot-jobs",
+	"trond recipe list":       "recipe-list",
+	"trond recipe show":       "recipe-show",
+	"trond recipe run":        "recipe-run",
 }
 
 // childCommands recursively gathers cobra children, skipping the

--- a/schemas/output/recipe-list.schema.json
+++ b/schemas/output/recipe-list.schema.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/tronprotocol/tron-deployment/blob/master/schemas/output/recipe-list.schema.json",
+  "title": "trond recipe list output",
+  "type": "object",
+  "required": ["recipes"],
+  "properties": {
+    "recipes": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["name", "description", "step_count"],
+        "properties": {
+          "name":        { "type": "string", "description": "Recipe identifier; pass to `recipe show` / `recipe run`." },
+          "description": { "type": "string", "description": "First paragraph of the recipe's YAML description." },
+          "params":      { "type": "string", "description": "Human summary like '3 total / 2 required'." },
+          "step_count":  { "type": "integer", "minimum": 1 }
+        }
+      }
+    }
+  }
+}

--- a/schemas/output/recipe-run.schema.json
+++ b/schemas/output/recipe-run.schema.json
@@ -1,0 +1,47 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/tronprotocol/tron-deployment/blob/master/schemas/output/recipe-run.schema.json",
+  "title": "trond recipe run output",
+  "description": "Returned by `trond recipe run <name> -o json`. Stable shape so an MCP recipe.run tool can pass it through verbatim.",
+  "type": "object",
+  "required": ["recipe", "status", "started_at", "duration_ms", "steps"],
+  "properties": {
+    "recipe":      { "type": "string", "description": "The .name of the recipe that was run." },
+    "status": {
+      "type": "string",
+      "enum": ["success", "failed", "rolled_back"],
+      "description": "Aggregate verdict. failed=a step's on_failure=abort triggered; rolled_back=on_failure=rollback triggered and the rollback section ran."
+    },
+    "started_at":  { "type": "string", "format": "date-time" },
+    "duration_ms": { "type": "integer", "minimum": 0 },
+    "failed_at":   { "type": "string", "description": "Step ID that triggered failure; absent on success." },
+    "rollback_ran":  { "type": "boolean" },
+    "steps": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/stepResult" }
+    },
+    "rollback_steps": {
+      "type": "array",
+      "description": "Records for each rollback step that ran (only set when rollback_ran=true).",
+      "items": { "$ref": "#/$defs/stepResult" }
+    }
+  },
+  "$defs": {
+    "stepResult": {
+      "type": "object",
+      "required": ["id"],
+      "properties": {
+        "id":          { "type": "string" },
+        "skipped":     { "type": "boolean", "description": "True when --resume-from passed this step or its skip predicate evaluated true." },
+        "exit_code":   { "type": "integer" },
+        "duration_ms": { "type": "integer", "minimum": 0 },
+        "output": {
+          "type": "object",
+          "description": "JSON object captured from the step's stdout (when the step's command supports -o json).",
+          "additionalProperties": true
+        },
+        "error":       { "type": "string", "description": "Set when the step's command exited non-zero." }
+      }
+    }
+  }
+}

--- a/schemas/output/recipe-show.schema.json
+++ b/schemas/output/recipe-show.schema.json
@@ -1,0 +1,49 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/tronprotocol/tron-deployment/blob/master/schemas/output/recipe-show.schema.json",
+  "title": "trond recipe show output",
+  "description": "The Recipe struct serialised verbatim. Schema mirrors internal/recipe.Recipe so agents reading this output can program against the same shape the CLI accepts as YAML.",
+  "type": "object",
+  "required": ["name", "description", "steps"],
+  "properties": {
+    "name":        { "type": "string" },
+    "description": { "type": "string" },
+    "params": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["name"],
+        "properties": {
+          "name":        { "type": "string" },
+          "type":        { "type": "string", "enum": ["string", "int", "bool", "path"] },
+          "required":    { "type": "boolean" },
+          "default":     { "type": "string" },
+          "description": { "type": "string" }
+        }
+      }
+    },
+    "steps": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/step" }
+    },
+    "rollback": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/step" }
+    }
+  },
+  "$defs": {
+    "step": {
+      "type": "object",
+      "required": ["id", "command"],
+      "properties": {
+        "id":          { "type": "string" },
+        "description": { "type": "string" },
+        "command":     { "type": "string", "description": "Trond subcommand path, e.g. 'config validate' or 'snapshot download'." },
+        "args":        { "type": "array", "items": { "type": "string" } },
+        "on_failure":  { "type": "string", "enum": ["abort", "continue", "rollback"], "description": "Default = abort." },
+        "persist":     { "type": "array", "items": { "type": "string" }, "description": "Field names from this step's stdout to expose to subsequent steps via {{ steps.<id>.<name> }}." },
+        "skip":        { "type": "string", "description": "Template; step is skipped when this evaluates to 'true'." }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Follow-up to #154 (recipe runner). PR #152 introduced 21 JSON Schemas + the `trond schema` command; PR #154 then added the recipe subcommand but **without** matching JSON Schemas. So `trond schema recipe run -o json` returned no output_schema field, and any client validating recipe output had to reverse-engineer the shape.

This PR fills the gap with three schemas:

- `schemas/output/recipe-list.schema.json` — array of `{name, description, params, step_count}`
- `schemas/output/recipe-show.schema.json` — full Recipe struct mirroring the YAML input format
- `schemas/output/recipe-run.schema.json` — `RunResult`: status (`success` | `failed` | `rolled_back`), per-step records with `exit_code` / `output` / `error`, optional `rollback_steps` when `rollback_ran=true`

`DefaultSchemaLookup` in `internal/schema/manifest.go` gets three new mapping entries.

The same files exist under `internal/schema/files/` via `go:embed`; the pre-existing parity test (`TestEmbedded_AllParseAndHaveMandatoryFields`) covers them automatically — no test additions needed.

## Test plan

- [ ] `make build && ./bin/trond schema "recipe list" --output-only -o json` returns the recipe-list schema
- [ ] Same for `"recipe show"` and `"recipe run"`
- [ ] `make test` — `internal/schema` parity test now includes 3 new schemas
- [ ] CI 8 jobs all green

## Backwards compatibility

Pure addition. No code change beyond the lookup map; recipe runtime behavior unchanged.