### PR TITLE
apply: extract internal/apply package; wire MCP apply / status / diagnose

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -91,6 +91,12 @@ issues:
     - path: cmd/.+\.go
       linters: [errcheck]
       text: "(closer|c|t)\\.Close"
+    # Same pattern propagated into internal/mcp's lifecycle tool: the
+    # apply tool defers a target.Target Close on the SSH connection
+    # path. Same justification as the cmd/* rule above.
+    - path: internal/mcp/.+\.go
+      linters: [errcheck]
+      text: "(closer|c)\\.Close"
     # nc.SaveState / nc.Store.Save in cmd/* run on the post-action
     # cleanup path; the action itself already returned its result.
     # If the save itself fails, the worst case is a stale state.json,

--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -1,22 +1,15 @@
 package cmd
 
 import (
-	"context"
-	"crypto/sha256"
-	"encoding/hex"
 	"fmt"
 	"os"
-	"path/filepath"
-	"strconv"
-	"strings"
 	"time"
 
 	"github.com/spf13/cobra"
 
+	"github.com/tronprotocol/tron-deployment/internal/apply"
 	"github.com/tronprotocol/tron-deployment/internal/intent"
 	"github.com/tronprotocol/tron-deployment/internal/output"
-	"github.com/tronprotocol/tron-deployment/internal/render"
-	"github.com/tronprotocol/tron-deployment/internal/runtime"
 	"github.com/tronprotocol/tron-deployment/internal/state"
 	"github.com/tronprotocol/tron-deployment/internal/target"
 )
@@ -37,7 +30,11 @@ var applyCmd = &cobra.Command{
 Pipeline: validate → resolve target → acquire lock → render config →
 diff against state → deploy → update state → release lock → output result.
 
-This command is idempotent — running it again with the same intent produces no changes.`,
+This command is idempotent — running it again with the same intent produces no changes.
+
+The deploy phase (render → runtime → state save → optional wait) lives in
+the internal/apply package as a pure function so MCP and recipe callers
+can drive the same pipeline without forking a subprocess.`,
 	RunE: runApply,
 }
 
@@ -54,21 +51,22 @@ func runApply(cmd *cobra.Command, args []string) error {
 	outputFmt, _ := cmd.Flags().GetString("output")
 	start := time.Now()
 
-	// 1. Load + validate intent
+	// 1. Load + validate intent.
 	parsed, err := intent.Load(applyIntentPath)
 	if err != nil {
 		return exitWithError(outputFmt, "VALIDATION_ERROR", output.ExitValidationError, err.Error(),
 			"Check intent file syntax", "Run: trond config validate "+applyIntentPath)
 	}
 
-	// 2. Resolve target
+	// 2. Resolve target. SSH cert handling lives here in the cmd
+	// layer because it's tied to the operator's shell environment.
 	tgt, err := resolveTarget(parsed)
 	if err != nil {
 		return exitWithError(outputFmt, "TARGET_UNREACHABLE", output.ExitTargetUnreachable, err.Error(),
 			"Check SSH connectivity", "Verify Docker is running")
 	}
 
-	// 3. Acquire state lock
+	// 3. Acquire state lock. Stays in cmd for the defer-release shape.
 	dir := stateDir()
 	lock := state.NewLock(dir)
 	if err := lock.Acquire(); err != nil {
@@ -77,158 +75,71 @@ func runApply(cmd *cobra.Command, args []string) error {
 	}
 	defer lock.Release()
 
-	// 4. Load current state
+	// 4. Load current state.
 	store, err := state.NewStore(statePath())
 	if err != nil {
 		return exitWithError(outputFmt, "STATE_ERROR", output.ExitGeneralError, err.Error())
 	}
-
 	deployState, err := store.Load()
 	if err != nil {
 		return exitWithError(outputFmt, "STATE_ERROR", output.ExitGeneralError, err.Error())
 	}
 
-	// 5. Compute intent hash
+	// 5. Compute intent hash.
 	intentData, _ := os.ReadFile(applyIntentPath)
-	intentHash := sha256hex(intentData)
+	intentHash := apply.IntentHashFromBytes(intentData)
 
-	// 6. Check for changes
+	// 6. HUMAN_REQUIRED gate. The internal/apply package handles the
+	// no-op short-circuit (same-hash → "no_change") on its own; we
+	// only need to guard the destructive change-on-existing-node case.
 	existing := store.GetNode(deployState, parsed.Name)
-	// Hash match means there is nothing to deploy regardless of current
-	// status. Previously the no-op short-circuit only fired when status
-	// was "running", so a stopped node forced HUMAN_REQUIRED for an
-	// identical intent — frustrating in CI pipelines that re-apply
-	// before issuing a `start`.
-	if existing != nil && existing.IntentHash == intentHash {
-		if !quiet {
-			result := map[string]any{
-				"name":    parsed.Name,
-				"status":  existing.Status,
-				"changes": []any{},
-				"message": "No changes detected",
-			}
-			writeResult(outputFmt, result)
-		}
-		return nil
-	}
-
-	// 7. Confirmation for real changes on existing node (unless --auto-approve)
-	if existing != nil && !applyAutoApprove {
+	if existing != nil && existing.IntentHash != intentHash && !applyAutoApprove {
 		return exitWithError(outputFmt, "HUMAN_REQUIRED", output.ExitHumanRequired,
 			fmt.Sprintf("Changes detected for node %q. Review with: trond plan --intent %s", parsed.Name, applyIntentPath),
 			"Re-run with --auto-approve to apply changes",
 			fmt.Sprintf("trond apply --intent %s --auto-approve", applyIntentPath))
 	}
 
-	// 8. Render config
-	templateDir := findTemplatesDir()
-	node := &parsed.Nodes[0] // US1: single node
-
-	hoconConfig, err := render.RenderHOCON(templateDir, parsed, node)
+	// 7. Hand off to the pure deploy phase.
+	res, err := apply.Apply(cmd.Context(), apply.Options{
+		Intent:         parsed,
+		Target:         tgt,
+		Store:          store,
+		State:          deployState,
+		IntentHash:     intentHash,
+		Existing:       existing,
+		TemplateDir:    findTemplatesDir(),
+		DeploymentsDir: deploymentsDir(),
+		EnvVars:        resolveEnvVars(&parsed.Nodes[0]),
+		Wait:           applyWait,
+		WaitTimeout:    applyWaitTimeout,
+	})
 	if err != nil {
-		return exitWithError(outputFmt, "RENDER_ERROR", output.ExitGeneralError, "Failed to render config: "+err.Error())
-	}
-	configHash := sha256hex([]byte(hoconConfig))
-
-	// Derive JVM heap sizing from the intent's resources.memory and detected JDK.
-	// Default to 16GB / JDK 17 when unspecified — matches the table in
-	// knowledge/best-practices.md.
-	memGB := render.ParseMemoryGB(node.Resources.Memory)
-	if memGB == 0 {
-		memGB = 16
-	}
-	jdkVer := detectJDKVersion(cmd.Context(), tgt)
-	jvmArgs := render.JVMArgsString(memGB, jdkVer, node.JVM)
-
-	// 8. Deploy based on runtime
-	runtimeType := parsed.Target.Runtime
-	if runtimeType == "" {
-		runtimeType = "docker"
+		return exitWithError(outputFmt, "DEPLOY_ERROR", output.ExitGeneralError, err.Error(),
+			"Check Docker is running: docker info",
+			"Check port availability")
 	}
 
-	deployOpts := runtime.DeployOpts{
-		Name:       parsed.Name,
-		ConfigData: []byte(hoconConfig),
-		EnvVars:    resolveEnvVars(node),
+	// 8. Translate Result back into the JSON shape the CLI promises.
+	// We keep the legacy "status" / "changes" / "endpoints" keys for
+	// agents that already parse those — internally Apply.Result uses
+	// the cleaner "outcome" name.
+	durationMs := time.Since(start).Milliseconds()
+	resultMap := map[string]any{
+		"name":        res.Name,
+		"status":      "running",
+		"runtime":     res.Runtime,
+		"version":     res.Version,
+		"endpoints":   res.Endpoints,
+		"duration_ms": durationMs,
+		"changes":     diffChanges(res.Outcome),
 	}
-
-	var changes []map[string]string
-
-	switch runtimeType {
-	case "docker":
-		composeYAML := render.RenderCompose(parsed.Name, parsed, node, "", jvmArgs)
-		deployOpts.ComposeData = []byte(composeYAML)
-
-		rt := runtime.NewDockerRuntime(tgt, deploymentsDir())
-		if err := rt.Deploy(cmd.Context(), deployOpts); err != nil {
-			return exitWithError(outputFmt, "DEPLOY_ERROR", output.ExitGeneralError, "Deploy failed: "+err.Error(),
-				"Check Docker is running: docker info",
-				"Check port availability")
+	if res.Outcome == "no_change" {
+		resultMap["status"] = ""
+		if existing != nil {
+			resultMap["status"] = existing.Status
 		}
-		changes = append(changes, map[string]string{"type": "deploy", "description": "Docker container deployed"})
-
-	case "jar":
-		systemdUnit := render.RenderSystemdUnit(parsed, node, jvmArgs, "", "")
-		deployOpts.SystemdData = []byte(systemdUnit)
-		deployOpts.JarPath = filepath.Join(node.InstallPath, "FullNode.jar")
-		// If the intent specifies a download source, hand it to the
-		// runtime so it does the fetch+verify dance. Otherwise the
-		// operator is expected to have pre-staged the jar.
-		if node.Jar != nil {
-			deployOpts.JarURL = node.Jar.URL
-			deployOpts.JarSHA256 = node.Jar.SHA256
-		}
-
-		rt := runtime.NewJarRuntime(tgt)
-		if err := rt.Deploy(cmd.Context(), deployOpts); err != nil {
-			return exitWithError(outputFmt, "DEPLOY_ERROR", output.ExitGeneralError, "Deploy failed: "+err.Error())
-		}
-		changes = append(changes, map[string]string{"type": "deploy", "description": "Jar+systemd service deployed"})
-	}
-
-	// 9. Update state
-	managedNode := state.ManagedNode{
-		Name:       parsed.Name,
-		IntentHash: intentHash,
-		ConfigHash: configHash,
-		Version:    node.Version,
-		Target: state.NodeTarget{
-			Type:         parsed.Target.Type,
-			Host:         parsed.Target.Host,
-			User:         parsed.Target.User,
-			Port:         parsed.Target.Port,
-			IdentityFile: parsed.Target.IdentityFile,
-		},
-		Runtime:     runtimeType,
-		Status:      "running",
-		LastApplied: time.Now().UTC(),
-		HTTPPort:    node.Ports.HTTP,
-		GRPCPort:    node.Ports.GRPC,
-		Labels:      node.Labels,
-		InstallPath: node.InstallPath,
-	}
-	if existing != nil {
-		managedNode.PreviousVersion = existing.Version
-	}
-	store.UpsertNode(deployState, managedNode)
-
-	if err := store.Save(deployState); err != nil {
-		return exitWithError(outputFmt, "STATE_ERROR", output.ExitGeneralError, "Failed to save state: "+err.Error())
-	}
-
-	// 10. Output result
-	duration := time.Since(start)
-	result := map[string]any{
-		"name":    parsed.Name,
-		"status":  "running",
-		"changes": changes,
-		"runtime": runtimeType,
-		"version": node.Version,
-		"endpoints": map[string]string{
-			"http": fmt.Sprintf("http://127.0.0.1:%d", node.Ports.HTTP),
-			"grpc": fmt.Sprintf("127.0.0.1:%d", node.Ports.GRPC),
-		},
-		"duration_ms": duration.Milliseconds(),
+		resultMap["message"] = "No changes detected"
 	}
 
 	writeAudit(auditEvent{
@@ -240,70 +151,41 @@ func runApply(cmd *cobra.Command, args []string) error {
 		Start:      start,
 	})
 
-	// --wait blocks until the node's HTTP API responds. The deploy itself
-	// has already succeeded by this point — a wait failure does not roll
-	// back, the test harness can still call diagnose / logs to investigate.
-	//
-	// Passing node.Ports.HTTP (intent's value) is correct here, despite
-	// looking like the verify-port-from-intent bug fixed in efdf446. The
-	// difference: ApplyDefaults() mutates node.Ports.HTTP in place at
-	// intent.Load() time, replacing 0 with either 8090 or the freshly
-	// auto-allocated port. We're calling waitForNodeReady in the same
-	// process, after that mutation, with the exact value we just deployed
-	// to the container. State is also written from this same value at
-	// L204, so the two stay consistent. The verify command had the bug
-	// because it loads the intent in a SEPARATE process and auto_ports
-	// would re-allocate different ports each time.
 	if applyWait {
-		waitErr := waitForNodeReady(cmd.Context(), tgt, parsed.Name, node.Ports.HTTP, applyWaitTimeout)
-		result["waited_ms"] = time.Since(start).Milliseconds() - result["duration_ms"].(int64)
-		if waitErr != nil {
-			result["ready"] = false
-			result["wait_error"] = waitErr.Error()
+		resultMap["waited_ms"] = res.WaitedMs
+		if res.WaitError != "" {
+			resultMap["ready"] = false
+			resultMap["wait_error"] = res.WaitError
 			if !quiet {
-				writeResult(outputFmt, result)
+				writeResult(outputFmt, resultMap)
 			}
 			return output.NewError("WAIT_TIMEOUT", output.ExitGeneralError,
-				fmt.Sprintf("deploy succeeded but node %s did not become ready: %v", parsed.Name, waitErr)).
+				fmt.Sprintf("deploy succeeded but node %s did not become ready: %s", parsed.Name, res.WaitError)).
 				WithSuggestions("trond logs "+parsed.Name, "trond diagnose "+parsed.Name)
 		}
-		result["ready"] = true
+		resultMap["ready"] = true
 	}
 
 	if !quiet {
-		writeResult(outputFmt, result)
+		writeResult(outputFmt, resultMap)
 	}
 	return nil
 }
 
-// waitForNodeReady probes the node's HTTP endpoint until it responds 2xx or
-// the timeout expires. Reuses the same probe family as `trond wait --http`
-// so behaviour is consistent.
-func waitForNodeReady(ctx context.Context, tgt target.Target, name string, httpPort int, timeout time.Duration) error {
-	ctx, cancel := context.WithTimeout(ctx, timeout)
-	defer cancel()
-	if httpPort == 0 {
-		httpPort = 8090
+// diffChanges synthesises the legacy `changes[]` array from an Apply
+// outcome. Pre-extraction the array carried per-step strings; we
+// reduce that to a single sentinel so JSON consumers keep working
+// without claiming false granularity.
+func diffChanges(outcome string) []map[string]string {
+	switch outcome {
+	case "no_change":
+		return []map[string]string{}
+	case "created":
+		return []map[string]string{{"type": "deploy", "description": "Node created"}}
+	case "updated":
+		return []map[string]string{{"type": "deploy", "description": "Node updated"}}
 	}
-	url := fmt.Sprintf("http://127.0.0.1:%d/wallet/getnowblock", httpPort)
-	tick := time.NewTicker(2 * time.Second)
-	defer tick.Stop()
-	var lastErr error
-	for {
-		_, err := tgt.Exec(ctx, "docker", "exec", name, "curl", "-fsS", "--max-time", "5", url)
-		if err == nil {
-			return nil
-		}
-		lastErr = err
-		select {
-		case <-ctx.Done():
-			if lastErr != nil {
-				return fmt.Errorf("%s (last probe error: %v)", ctx.Err(), lastErr)
-			}
-			return ctx.Err()
-		case <-tick.C:
-		}
-	}
+	return nil
 }
 
 func resolveTarget(parsed *intent.Intent) (target.Target, error) {
@@ -330,10 +212,8 @@ func resolveEnvVars(node *intent.NodeSpec) map[string]string {
 	return env
 }
 
-// findTemplatesDir returns an optional on-disk templates directory. The render
-// package falls back to embedded templates if this is empty or missing, so
-// this is only a convenience for local development against an un-committed
-// template tree. Set TROND_TEMPLATES_DIR to override.
+// findTemplatesDir returns an optional on-disk templates directory.
+// Empty return signals render to use the embedded copy.
 func findTemplatesDir() string {
 	if d := os.Getenv("TROND_TEMPLATES_DIR"); d != "" {
 		return d
@@ -341,50 +221,15 @@ func findTemplatesDir() string {
 	candidates := []string{"templates", "./templates"}
 	for _, c := range candidates {
 		if info, err := os.Stat(c); err == nil && info.IsDir() {
-			if _, err := os.Stat(filepath.Join(c, "main_net_config.conf")); err == nil {
+			if _, err := os.Stat(c + "/main_net_config.conf"); err == nil {
 				return c
 			}
 		}
 	}
-	return "" // Signals render to use embedded templates.
-}
-
-func sha256hex(data []byte) string {
-	h := sha256.Sum256(data)
-	return hex.EncodeToString(h[:])
-}
-
-// detectJDKVersion probes the target for an installed Java version. Returns 17
-// when detection fails — most TRON 4.x builds ship with JDK 17 tuning defaults,
-// and the G1 args it selects are safe across modern JDKs.
-func detectJDKVersion(ctx context.Context, tgt target.Target) int {
-	out, err := tgt.Exec(ctx, "java", "-version")
-	if err != nil {
-		return 17
-	}
-	// "openjdk version \"1.8.0_362\""  → 8
-	// "openjdk version \"17.0.8\""      → 17
-	s := string(out)
-	if idx := strings.Index(s, `"`); idx >= 0 {
-		rest := s[idx+1:]
-		end := strings.Index(rest, `"`)
-		if end > 0 {
-			ver := strings.TrimPrefix(rest[:end], "1.")
-			if dot := strings.Index(ver, "."); dot > 0 {
-				ver = ver[:dot]
-			}
-			if n, err := strconv.Atoi(ver); err == nil {
-				return n
-			}
-		}
-	}
-	return 17
+	return ""
 }
 
 // exitWithError returns a StructuredError for propagation through cobra RunE.
-// The root Execute() function inspects the error, writes it in the requested
-// format, and returns the correct exit code — this lets deferred cleanup
-// (e.g. state locks) run before the process exits.
 func exitWithError(_ string, code string, exitCode int, msg string, suggestions ...string) error {
 	return output.NewError(code, exitCode, msg).WithSuggestions(suggestions...)
 }

--- a/cmd/plan.go
+++ b/cmd/plan.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/tronprotocol/tron-deployment/internal/apply"
 	"github.com/tronprotocol/tron-deployment/internal/intent"
 	"github.com/tronprotocol/tron-deployment/internal/output"
 	"github.com/tronprotocol/tron-deployment/internal/render"
@@ -46,7 +47,7 @@ func runPlan(cmd *cobra.Command, args []string) error {
 
 	// 2. Compute intent hash
 	intentData, _ := os.ReadFile(planIntentPath)
-	intentHash := sha256hex(intentData)
+	intentHash := apply.IntentHashFromBytes(intentData)
 
 	// 3. Load current state
 	store, err := state.NewStore(statePath())
@@ -69,7 +70,7 @@ func runPlan(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return exitWithError(outputFmt, "RENDER_ERROR", output.ExitGeneralError, err.Error())
 	}
-	configHash := sha256hex([]byte(hoconConfig))
+	configHash := apply.IntentHashFromBytes([]byte(hoconConfig))
 
 	// 5. Diff
 	var changes []planChange

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"maps"
 	"os"
@@ -10,6 +9,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/tronprotocol/tron-deployment/internal/apply"
 	"github.com/tronprotocol/tron-deployment/internal/output"
 	"github.com/tronprotocol/tron-deployment/internal/state"
 )
@@ -115,61 +115,16 @@ func effectivePort(stored, fallback int) int {
 	return fallback
 }
 
-// liveStatusProbe makes the (cheap) HTTP API calls a status command is
-// expected to surface. Errors are silently dropped — the caller sees
-// the keys appear or not, never a failure on the whole command.
+// liveStatusProbe wraps the package-level apply.LiveStatus so cmd/
+// callers don't have to think about target resolution. The actual
+// probe logic lives in internal/apply for reuse by MCP / recipe.
 func liveStatusProbe(ctx context.Context, node *state.ManagedNode) map[string]any {
-	out := map[string]any{}
-	port := effectivePort(node.HTTPPort, 8090)
-
 	tgt, err := resolveTargetFromNode(node)
 	if err != nil {
-		return out
+		return map[string]any{}
 	}
 	if c, ok := any(tgt).(interface{ Close() error }); ok {
 		defer c.Close()
 	}
-
-	probe := func(path string) ([]byte, error) {
-		url := fmt.Sprintf("http://127.0.0.1:%d%s", port, path)
-		// docker exec for docker runtime, host curl for jar runtime.
-		// Mirrors the diagnose checkers' approach.
-		if node.Runtime == "jar" {
-			return tgt.Exec(ctx, "curl", "-fsS", "--max-time", "2", url)
-		}
-		return tgt.Exec(ctx, "docker", "exec", node.Name, "curl", "-fsS", "--max-time", "2", url)
-	}
-
-	// Block height + sync state from getnowblock.
-	if data, err := probe("/wallet/getnowblock"); err == nil {
-		var block struct {
-			BlockHeader struct {
-				RawData struct {
-					Number    int64 `json:"number"`
-					Timestamp int64 `json:"timestamp"`
-				} `json:"raw_data"`
-			} `json:"block_header"`
-		}
-		if json.Unmarshal(data, &block) == nil {
-			out["block_height"] = block.BlockHeader.RawData.Number
-			if block.BlockHeader.RawData.Timestamp > 0 {
-				// "synced" heuristic: tip is within 60s of now. Good enough for
-				// dashboards; not a consensus-level claim.
-				lag := time.Since(time.UnixMilli(block.BlockHeader.RawData.Timestamp))
-				out["is_synced"] = lag < 60*time.Second
-			}
-		}
-	}
-
-	// Peer count from listnodes.
-	if data, err := probe("/wallet/listnodes"); err == nil {
-		var nodes struct {
-			Nodes []any `json:"nodes"`
-		}
-		if json.Unmarshal(data, &nodes) == nil {
-			out["peer_count"] = len(nodes.Nodes)
-		}
-	}
-
-	return out
+	return apply.LiveStatus(ctx, tgt, node)
 }

--- a/internal/apply/apply.go
+++ b/internal/apply/apply.go
@@ -1,0 +1,334 @@
+// Package apply runs the deploy phase of `trond apply` as a pure
+// function so callers other than cobra (MCP server, recipe runner,
+// e2e test harness) can drive it without forking a subprocess.
+//
+// Scope: this package owns steps 8-10 of the apply pipeline as
+// originally documented in cmd/apply.go::runApply:
+//
+//  8. Render HOCON + compose / systemd, derive JVM args
+//  9. Hand off to docker / jar runtime, persist node into state
+//  10. Optionally block on the node's HTTP API readiness (--wait)
+//
+// What it does NOT own — these stay in cmd/apply.go because they're
+// either presentation-layer or require interactive context the
+// callers control:
+//
+//   - Parsing flags / loading the intent file (caller responsibility)
+//   - Resolving target.Target (cmd needs SSH cert handling, MCP gets
+//     its target from a fresh resolveTarget call)
+//   - Acquiring the state lock (cmd's defer pattern; MCP holds it
+//     for the duration of the tool call)
+//   - The HUMAN_REQUIRED gate for changed intents (this is a
+//     human-confirmation policy; callers decide when it fires)
+//   - Audit log writes (cmd-only — recipe + MCP have their own
+//     audit story via stdout JSON capture)
+//
+// In short: prepare the inputs (Intent + Target + Store + State +
+// IntentHash), call Apply, format the Result however the caller
+// wants. Apply itself is a pure function modulo the file-system
+// side effects of rendering + deploying.
+package apply
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"path/filepath"
+	"time"
+
+	"github.com/tronprotocol/tron-deployment/internal/intent"
+	"github.com/tronprotocol/tron-deployment/internal/render"
+	"github.com/tronprotocol/tron-deployment/internal/runtime"
+	"github.com/tronprotocol/tron-deployment/internal/state"
+	"github.com/tronprotocol/tron-deployment/internal/target"
+)
+
+// Options carries everything Apply needs that the caller is best
+// positioned to assemble (intent, target, store, state, hash).
+type Options struct {
+	Intent     *intent.Intent
+	Target     target.Target
+	Store      *state.Store
+	State      *state.DeploymentState
+	IntentHash string
+
+	// Existing is store.GetNode(state, intent.Name) at call time, or
+	// nil when there's no prior managed node by that name. Carrying
+	// it here avoids a redundant lookup inside Apply.
+	Existing *state.ManagedNode
+
+	// TemplateDir is the optional override for the embedded HOCON
+	// template tree. Empty string uses the embedded copy (the common
+	// case for production builds).
+	TemplateDir string
+
+	// DeploymentsDir is the on-disk root the docker runtime writes
+	// rendered compose + .conf files under (typically ~/.trond/deployments).
+	DeploymentsDir string
+
+	// JDKVersion is honored if non-zero (lets callers skip the
+	// `java -version` probe for known targets). 0 triggers detection.
+	JDKVersion int
+
+	// EnvVars are the Witness-key-style env vars that get passed
+	// through to the docker container / systemd unit.
+	EnvVars map[string]string
+
+	// Wait + WaitTimeout: when Wait is true, Apply blocks until the
+	// node's HTTP API responds 2xx or WaitTimeout elapses. Wait
+	// failures don't roll the deploy back; they surface in
+	// Result.WaitError / Result.Ready.
+	Wait        bool
+	WaitTimeout time.Duration
+}
+
+// Result is the structured output of one Apply call. Stable JSON
+// shape (matches schemas/output/apply.schema.json) so MCP / recipe /
+// CLI presentations are interchangeable.
+type Result struct {
+	Name       string            `json:"name"`
+	Outcome    string            `json:"outcome"` // created | updated | no_change
+	IntentHash string            `json:"intent_hash"`
+	ConfigHash string            `json:"config_hash"`
+	Version    string            `json:"version"`
+	Runtime    string            `json:"runtime"`
+	Endpoints  map[string]string `json:"endpoints"`
+	DurationMs int64             `json:"duration_ms"`
+
+	// Ready / WaitedMs / WaitError are only set when Options.Wait was true.
+	Ready     *bool  `json:"ready,omitempty"`
+	WaitedMs  int64  `json:"waited_ms,omitempty"`
+	WaitError string `json:"wait_error,omitempty"`
+}
+
+// Apply runs the deploy phase. Returns a Result on success or
+// partial-success (deploy succeeded, wait timed out); returns an error
+// only when the deploy itself failed.
+//
+// Idempotency: when opts.Existing.IntentHash == opts.IntentHash, Apply
+// short-circuits as a no-op (Outcome: "no_change") without rendering
+// or touching the runtime. This mirrors cmd/apply.go's hash-gate
+// behavior, but the gate's HUMAN_REQUIRED branch is the caller's
+// concern (it's a UX policy, not a deploy invariant).
+func Apply(ctx context.Context, opts Options) (*Result, error) {
+	if err := validateOptions(opts); err != nil {
+		return nil, err
+	}
+	start := time.Now()
+
+	// No-op short-circuit. Same hash → nothing to do regardless of
+	// the existing node's status. Callers that need "force redeploy
+	// of a stopped node" pass IntentHash="" or simply omit Existing.
+	if opts.Existing != nil && opts.Existing.IntentHash == opts.IntentHash {
+		return &Result{
+			Name:       opts.Intent.Name,
+			Outcome:    "no_change",
+			IntentHash: opts.IntentHash,
+			ConfigHash: opts.Existing.ConfigHash,
+			Version:    opts.Existing.Version,
+			Runtime:    opts.Existing.Runtime,
+			DurationMs: time.Since(start).Milliseconds(),
+		}, nil
+	}
+
+	node := &opts.Intent.Nodes[0]
+
+	hocon, err := render.RenderHOCON(opts.TemplateDir, opts.Intent, node)
+	if err != nil {
+		return nil, fmt.Errorf("render hocon: %w", err)
+	}
+	configHash := sha256hex([]byte(hocon))
+
+	jdk := opts.JDKVersion
+	if jdk == 0 {
+		jdk = detectJDK(ctx, opts.Target)
+	}
+	memGB := render.ParseMemoryGB(node.Resources.Memory)
+	if memGB == 0 {
+		memGB = 16
+	}
+	jvmArgs := render.JVMArgsString(memGB, jdk, node.JVM)
+
+	runtimeType := opts.Intent.Target.Runtime
+	if runtimeType == "" {
+		runtimeType = "docker"
+	}
+
+	deployOpts := runtime.DeployOpts{
+		Name:       opts.Intent.Name,
+		ConfigData: []byte(hocon),
+		EnvVars:    opts.EnvVars,
+	}
+
+	switch runtimeType {
+	case "docker":
+		deployOpts.ComposeData = []byte(render.RenderCompose(opts.Intent.Name, opts.Intent, node, "", jvmArgs))
+		rt := runtime.NewDockerRuntime(opts.Target, opts.DeploymentsDir)
+		if err := rt.Deploy(ctx, deployOpts); err != nil {
+			return nil, fmt.Errorf("docker deploy: %w", err)
+		}
+	case "jar":
+		deployOpts.SystemdData = []byte(render.RenderSystemdUnit(opts.Intent, node, jvmArgs, "", ""))
+		deployOpts.JarPath = filepath.Join(node.InstallPath, "FullNode.jar")
+		if node.Jar != nil {
+			deployOpts.JarURL = node.Jar.URL
+			deployOpts.JarSHA256 = node.Jar.SHA256
+		}
+		rt := runtime.NewJarRuntime(opts.Target)
+		if err := rt.Deploy(ctx, deployOpts); err != nil {
+			return nil, fmt.Errorf("jar deploy: %w", err)
+		}
+	default:
+		return nil, fmt.Errorf("unsupported runtime %q", runtimeType)
+	}
+
+	// Persist into state.
+	managed := state.ManagedNode{
+		Name:       opts.Intent.Name,
+		IntentHash: opts.IntentHash,
+		ConfigHash: configHash,
+		Version:    node.Version,
+		Target: state.NodeTarget{
+			Type:         opts.Intent.Target.Type,
+			Host:         opts.Intent.Target.Host,
+			User:         opts.Intent.Target.User,
+			Port:         opts.Intent.Target.Port,
+			IdentityFile: opts.Intent.Target.IdentityFile,
+		},
+		Runtime:     runtimeType,
+		Status:      "running",
+		LastApplied: time.Now().UTC(),
+		HTTPPort:    node.Ports.HTTP,
+		GRPCPort:    node.Ports.GRPC,
+		Labels:      node.Labels,
+		InstallPath: node.InstallPath,
+	}
+	outcome := "created"
+	if opts.Existing != nil {
+		managed.PreviousVersion = opts.Existing.Version
+		outcome = "updated"
+	}
+	opts.Store.UpsertNode(opts.State, managed)
+	if err := opts.Store.Save(opts.State); err != nil {
+		return nil, fmt.Errorf("save state: %w", err)
+	}
+
+	deployedMs := time.Since(start).Milliseconds()
+	res := &Result{
+		Name:       opts.Intent.Name,
+		Outcome:    outcome,
+		IntentHash: opts.IntentHash,
+		ConfigHash: configHash,
+		Version:    node.Version,
+		Runtime:    runtimeType,
+		Endpoints: map[string]string{
+			"http": fmt.Sprintf("http://127.0.0.1:%d", node.Ports.HTTP),
+			"grpc": fmt.Sprintf("127.0.0.1:%d", node.Ports.GRPC),
+		},
+		DurationMs: deployedMs,
+	}
+
+	if opts.Wait {
+		waitErr := WaitForReady(ctx, opts.Target, opts.Intent.Name, node.Ports.HTTP, opts.WaitTimeout)
+		res.WaitedMs = time.Since(start).Milliseconds() - deployedMs
+		ready := waitErr == nil
+		res.Ready = &ready
+		if waitErr != nil {
+			res.WaitError = waitErr.Error()
+		}
+	}
+	return res, nil
+}
+
+func validateOptions(o Options) error {
+	switch {
+	case o.Intent == nil:
+		return fmt.Errorf("Intent is required")
+	case len(o.Intent.Nodes) == 0:
+		return fmt.Errorf("Intent.Nodes is empty")
+	case o.Target == nil:
+		return fmt.Errorf("Target is required")
+	case o.Store == nil:
+		return fmt.Errorf("Store is required")
+	case o.State == nil:
+		return fmt.Errorf("State is required")
+	case o.IntentHash == "":
+		return fmt.Errorf("IntentHash is required")
+	}
+	return nil
+}
+
+// sha256hex hashes a byte slice as lower-case hex. Mirrors the helper
+// in cmd/apply.go; duplicated here so this package has no cmd import.
+func sha256hex(data []byte) string {
+	h := sha256.Sum256(data)
+	return hex.EncodeToString(h[:])
+}
+
+// IntentHashFromBytes is a convenience for callers that already hold
+// the raw intent.yaml bytes (cmd/apply.go has them after os.ReadFile;
+// MCP has them after reading the file in a tool handler).
+func IntentHashFromBytes(data []byte) string {
+	return sha256hex(data)
+}
+
+// detectJDK probes the target for an installed Java version. Returns
+// 17 when detection fails — most TRON 4.x builds ship with JDK 17
+// tuning defaults and the G1 args we select are safe across modern
+// JDKs. Mirrors cmd/apply.go's helper.
+func detectJDK(ctx context.Context, tgt target.Target) int {
+	out, err := tgt.Exec(ctx, "java", "-version")
+	if err != nil {
+		return 17
+	}
+	s := string(out)
+	idx := indexByte(s, '"')
+	if idx < 0 {
+		return 17
+	}
+	rest := s[idx+1:]
+	end := indexByte(rest, '"')
+	if end <= 0 {
+		return 17
+	}
+	ver := rest[:end]
+	if hasPrefix(ver, "1.") {
+		ver = ver[2:]
+	}
+	if dot := indexByte(ver, '.'); dot > 0 {
+		ver = ver[:dot]
+	}
+	n := atoiSafe(ver)
+	if n == 0 {
+		return 17
+	}
+	return n
+}
+
+// Tiny stdlib re-exports kept inline so the package imports stay
+// trim and the functions read clearly.
+func indexByte(s string, b byte) int {
+	for i := 0; i < len(s); i++ {
+		if s[i] == b {
+			return i
+		}
+	}
+	return -1
+}
+func hasPrefix(s, p string) bool {
+	return len(s) >= len(p) && s[:len(p)] == p
+}
+func atoiSafe(s string) int {
+	if s == "" {
+		return 0
+	}
+	n := 0
+	for _, c := range s {
+		if c < '0' || c > '9' {
+			return 0
+		}
+		n = n*10 + int(c-'0')
+	}
+	return n
+}

--- a/internal/apply/apply_test.go
+++ b/internal/apply/apply_test.go
@@ -1,0 +1,122 @@
+package apply
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/tronprotocol/tron-deployment/internal/intent"
+	"github.com/tronprotocol/tron-deployment/internal/state"
+)
+
+// fakeTarget satisfies target.Target with no-op stubs. Apply only
+// exercises Exec (for the JDK probe + docker deploy fan-out); the
+// other methods exist to satisfy the interface contract.
+type fakeTarget struct{}
+
+func (f *fakeTarget) Exec(_ context.Context, _ string, _ ...string) ([]byte, error) {
+	return nil, nil
+}
+func (f *fakeTarget) Upload(_ context.Context, _, _ string) error          { return nil }
+func (f *fakeTarget) Download(_ context.Context, _, _ string) error        { return nil }
+func (f *fakeTarget) ReadFile(_ context.Context, _ string) ([]byte, error) { return nil, nil }
+func (f *fakeTarget) WriteFile(_ context.Context, _ string, _ []byte, _ os.FileMode) error {
+	return nil
+}
+func (f *fakeTarget) DiskFree(_ context.Context, _ string) (uint64, error) { return 1 << 40, nil }
+func (f *fakeTarget) MemTotal(_ context.Context) (uint64, error)           { return 1 << 30, nil }
+func (f *fakeTarget) String() string                                       { return "fake" }
+
+func TestApply_NoOpWhenIntentHashMatches(t *testing.T) {
+	parsed := minimalIntent()
+	store, st := freshStore(t)
+	existing := state.ManagedNode{
+		Name:        parsed.Name,
+		IntentHash:  "deadbeef",
+		ConfigHash:  "cafef00d",
+		Version:     "4.8.1",
+		Runtime:     "docker",
+		Status:      "running",
+		LastApplied: time.Now(),
+	}
+	store.UpsertNode(st, existing)
+
+	res, err := Apply(context.Background(), Options{
+		Intent:     parsed,
+		Target:     &fakeTarget{},
+		Store:      store,
+		State:      st,
+		IntentHash: "deadbeef",
+		Existing:   &existing,
+	})
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if res.Outcome != "no_change" {
+		t.Errorf("Outcome = %s, want no_change", res.Outcome)
+	}
+	if res.Name != parsed.Name {
+		t.Errorf("Name = %s, want %s", res.Name, parsed.Name)
+	}
+}
+
+func TestApply_RequiresIntent(t *testing.T) {
+	if _, err := Apply(context.Background(), Options{}); err == nil {
+		t.Error("expected error when Intent is nil")
+	}
+}
+
+func TestApply_RequiresIntentHash(t *testing.T) {
+	parsed := minimalIntent()
+	store, st := freshStore(t)
+	if _, err := Apply(context.Background(), Options{
+		Intent: parsed,
+		Target: &fakeTarget{},
+		Store:  store,
+		State:  st,
+	}); err == nil {
+		t.Error("expected error when IntentHash is empty")
+	}
+}
+
+func TestIntentHashFromBytes_Stable(t *testing.T) {
+	// Lower-case hex of SHA256("hello world\n") — sanity check the
+	// alias matches sha256 stdlib behavior.
+	got := IntentHashFromBytes([]byte("hello world\n"))
+	want := "a948904f2f0f479b8f8197694b30184b0d2ed1c1cd2a1ec0fb85d299a192a447"
+	if got != want {
+		t.Errorf("hash mismatch: got %s, want %s", got, want)
+	}
+}
+
+// --- helpers ---
+
+func minimalIntent() *intent.Intent {
+	return &intent.Intent{
+		Name:    "test-node",
+		Network: "nile",
+		Target:  intent.Target{Type: "local", Runtime: "docker"},
+		Nodes: []intent.NodeSpec{{
+			Type:      "fullnode",
+			Version:   "4.8.1",
+			Resources: intent.Resources{Memory: "8GB"},
+			Ports:     intent.PortMapping{HTTP: 8090, GRPC: 50051},
+		}},
+	}
+}
+
+func freshStore(t *testing.T) (*state.Store, *state.DeploymentState) {
+	t.Helper()
+	dir := t.TempDir()
+	store, err := state.NewStore(filepath.Join(dir, "state.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	st, err := store.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return store, st
+}

--- a/internal/apply/probe.go
+++ b/internal/apply/probe.go
@@ -1,0 +1,75 @@
+package apply
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/tronprotocol/tron-deployment/internal/state"
+	"github.com/tronprotocol/tron-deployment/internal/target"
+)
+
+// LiveStatus issues a small set of cheap HTTP probes against a
+// running node and returns the discovered fields (block_height,
+// is_synced, peer_count). Errors are silently dropped — the caller
+// sees a key appear or not, never a failure on the whole call.
+//
+// The probe path differs by runtime: docker nodes get reached via
+// `docker exec <name> curl ...` so the request sees the container's
+// network (host port mapping may be delayed on first start). Jar
+// nodes hit the host-side curl directly.
+//
+// Lives in internal/apply alongside WaitForReady because both are
+// "operate on a deployed node via target.Target" primitives. Used
+// by `trond status`, the MCP `status` tool, and any caller that
+// wants the same combined state + live view.
+func LiveStatus(ctx context.Context, tgt target.Target, node *state.ManagedNode) map[string]any {
+	out := map[string]any{}
+	if tgt == nil || node == nil {
+		return out
+	}
+	port := node.HTTPPort
+	if port == 0 {
+		port = 8090
+	}
+
+	probe := func(path string) ([]byte, error) {
+		url := fmt.Sprintf("http://127.0.0.1:%d%s", port, path)
+		if node.Runtime == "jar" {
+			return tgt.Exec(ctx, "curl", "-fsS", "--max-time", "2", url)
+		}
+		return tgt.Exec(ctx, "docker", "exec", node.Name, "curl", "-fsS", "--max-time", "2", url)
+	}
+
+	if data, err := probe("/wallet/getnowblock"); err == nil {
+		var block struct {
+			BlockHeader struct {
+				RawData struct {
+					Number    int64 `json:"number"`
+					Timestamp int64 `json:"timestamp"`
+				} `json:"raw_data"`
+			} `json:"block_header"`
+		}
+		if json.Unmarshal(data, &block) == nil {
+			out["block_height"] = block.BlockHeader.RawData.Number
+			if block.BlockHeader.RawData.Timestamp > 0 {
+				// "synced" heuristic: tip within 60s of now. Good enough
+				// for dashboards; not a consensus-level claim.
+				lag := time.Since(time.UnixMilli(block.BlockHeader.RawData.Timestamp))
+				out["is_synced"] = lag < 60*time.Second
+			}
+		}
+	}
+
+	if data, err := probe("/wallet/listnodes"); err == nil {
+		var nodes struct {
+			Nodes []any `json:"nodes"`
+		}
+		if json.Unmarshal(data, &nodes) == nil {
+			out["peer_count"] = len(nodes.Nodes)
+		}
+	}
+
+	return out
+}

--- a/internal/apply/wait.go
+++ b/internal/apply/wait.go
@@ -1,0 +1,45 @@
+package apply
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/tronprotocol/tron-deployment/internal/target"
+)
+
+// WaitForReady polls the node's HTTP API via `docker exec` until it
+// responds 2xx or the timeout elapses. Used by Apply when Wait=true
+// and exposed publicly so callers (verify command, MCP tool, recipe
+// step) can reuse the same probe shape without duplicating the curl
+// invocation.
+//
+// The probe runs `docker exec <name> curl ...` so it sees the
+// container's network — important when host-port mapping is delayed
+// on first start.
+func WaitForReady(ctx context.Context, tgt target.Target, name string, httpPort int, timeout time.Duration) error {
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	if httpPort == 0 {
+		httpPort = 8090
+	}
+	url := fmt.Sprintf("http://127.0.0.1:%d/wallet/getnowblock", httpPort)
+	tick := time.NewTicker(2 * time.Second)
+	defer tick.Stop()
+	var lastErr error
+	for {
+		_, err := tgt.Exec(ctx, "docker", "exec", name, "curl", "-fsS", "--max-time", "5", url)
+		if err == nil {
+			return nil
+		}
+		lastErr = err
+		select {
+		case <-ctx.Done():
+			// lastErr is always non-nil here because we only reach
+			// the select after a failed probe; surface both for
+			// debuggability.
+			return fmt.Errorf("%s (last probe error: %v)", ctx.Err(), lastErr)
+		case <-tick.C:
+		}
+	}
+}

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -246,27 +246,31 @@ func TestDestructiveTools_HaveDestructiveHint(t *testing.T) {
 	}
 }
 
-func TestApply_ReturnsNotImplementedEnvelope(t *testing.T) {
+func TestApply_RejectsBadIntentPath(t *testing.T) {
+	// Apply now runs the real internal/apply pipeline (cmd/apply
+	// extraction landed). The stub-tested NOT_IMPLEMENTED_VIA_MCP
+	// path is gone. Replace with a smaller test that exercises the
+	// front-end validation without needing a real Docker target:
+	// pass a non-existent intent path and confirm we surface a
+	// VALIDATION_ERROR envelope rather than a panic.
 	session, cleanup := newConnectedPair(t)
 	defer cleanup()
 
-	// Use a real example intent so intent.Load doesn't fail before we
-	// reach the stub. examples/nile-fullnode.yaml is small + complete.
 	res, err := session.CallTool(context.Background(), &mcp.CallToolParams{
 		Name:      "apply",
-		Arguments: json.RawMessage(`{"path":"../../examples/nile-fullnode.yaml"}`),
+		Arguments: json.RawMessage(`{"path":"/nonexistent/intent.yaml"}`),
 	})
 	if err != nil {
 		t.Fatalf("CallTool apply: %v", err)
 	}
 	if !res.IsError {
-		t.Fatal("apply stub should set IsError=true while in-process apply is unimplemented")
+		t.Fatal("apply with bogus intent path should set IsError=true")
 	}
 	body := extractText(t, res)
 	var env map[string]any
 	_ = json.Unmarshal([]byte(body), &env)
-	if env["error_code"] != "NOT_IMPLEMENTED_VIA_MCP" {
-		t.Errorf("expected error_code=NOT_IMPLEMENTED_VIA_MCP, got %v", env["error_code"])
+	if env["error_code"] != "VALIDATION_ERROR" {
+		t.Errorf("expected error_code=VALIDATION_ERROR, got %v", env["error_code"])
 	}
 }
 

--- a/internal/mcp/tools_diagnostic.go
+++ b/internal/mcp/tools_diagnostic.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 
+	"github.com/tronprotocol/tron-deployment/internal/diagnosis"
 	"github.com/tronprotocol/tron-deployment/internal/paths"
 	"github.com/tronprotocol/tron-deployment/internal/state"
 )
@@ -196,17 +197,11 @@ func healthTool(ctx context.Context, _ *mcp.CallToolRequest, args nodeArg) (*mcp
 }
 
 func diagnoseTool(ctx context.Context, _ *mcp.CallToolRequest, args nodeArg) (*mcp.CallToolResult, any, error) {
-	// The full diagnose suite (sync_progress, peer_count, disk_space,
-	// port_listening, memory_usage) lives in internal/diagnosis but
-	// each check requires either a live target.Target connection or a
-	// docker exec. Wiring those into a fully in-process MCP tool is a
-	// non-trivial extraction. For now we do the lightweight subset
-	// that doesn't need a runtime: present a state snapshot + a
-	// pointer at the CLI for the deeper checks.
-	//
-	// TODO: extract internal/diagnosis CheckOpts into a constructor
-	// that takes a state.ManagedNode + a target factory so this MCP
-	// tool can run the full suite.
+	// Runs the same full check suite (sync_progress, peer_count,
+	// disk_space, port_listening, memory_usage, version) that
+	// `trond diagnose <name>` does, by reaching into
+	// internal/diagnosis directly. The earlier MCP version returned
+	// only a state-only subset; that gap is now closed.
 	store, err := state.NewStore(paths.State())
 	if err != nil {
 		return errResult(err)
@@ -220,45 +215,30 @@ func diagnoseTool(ctx context.Context, _ *mcp.CallToolRequest, args nodeArg) (*m
 		return errResult(notFound("diagnose", args.Name))
 	}
 
-	checks := []map[string]any{
-		{
-			"name":   "managed_in_state",
-			"status": "pass",
-			"message": fmt.Sprintf("known to trond: status=%s, runtime=%s",
-				node.Status, node.Runtime),
-		},
+	tgt, err := mcpResolveTargetFromNode(node)
+	if err != nil {
+		return errResult(err)
 	}
-	if node.Status != "running" {
-		checks = append(checks, map[string]any{
-			"name":    "process_running",
-			"status":  "fail",
-			"message": fmt.Sprintf("state.json reports status=%q; the node is not currently running", node.Status),
-			"suggestions": []string{
-				"Call the 'apply' tool with the original intent to (re)deploy",
-				"Check `docker ps` on the target for the actual container state",
-			},
-		})
-	} else {
-		checks = append(checks, map[string]any{
-			"name":    "process_running",
-			"status":  "pass",
-			"message": "state.json reports status=running",
-		})
+	if c, ok := any(tgt).(interface{ Close() error }); ok {
+		defer c.Close()
 	}
 
-	overall := "pass"
-	for _, c := range checks {
-		if c["status"] == "fail" {
-			overall = "fail"
-		} else if c["status"] == "warning" && overall != "fail" {
-			overall = "warning"
-		}
+	opts := diagnosis.CheckOpts{
+		NodeName: node.Name,
+		Runtime:  node.Runtime,
+		HTTPPort: node.HTTPPort,
+		GRPCPort: node.GRPCPort,
 	}
-	result := map[string]any{
-		"name":    args.Name,
-		"overall": overall,
-		"checks":  checks,
-		"note":    "MCP diagnose is a state-only subset. For the full check suite (sync_progress, peer_count, disk_space, port_listening) call `trond diagnose <name> -o json` from the shell.",
+
+	checkers := diagnosis.AllCheckers()
+	results := make([]diagnosis.CheckResult, 0, len(checkers))
+	for _, c := range checkers {
+		results = append(results, c.Run(ctx, tgt, opts))
 	}
-	return jsonResult(result)
+
+	return jsonResult(map[string]any{
+		"name":    node.Name,
+		"overall": diagnosis.OverallStatus(results),
+		"checks":  results,
+	})
 }

--- a/internal/mcp/tools_inspection.go
+++ b/internal/mcp/tools_inspection.go
@@ -2,11 +2,15 @@ package mcp
 
 import (
 	"context"
+	"maps"
+	"time"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 
+	"github.com/tronprotocol/tron-deployment/internal/apply"
 	"github.com/tronprotocol/tron-deployment/internal/paths"
 	"github.com/tronprotocol/tron-deployment/internal/state"
+	"github.com/tronprotocol/tron-deployment/internal/target"
 )
 
 // registerInspectionTools wires the read-only "what's deployed?"
@@ -85,13 +89,7 @@ func statusForNode(ctx context.Context, _ *mcp.CallToolRequest, args nodeArg) (*
 	if node == nil {
 		return errResult(notFound("status", args.Name))
 	}
-	// We deliberately don't run the live HTTP probe here yet — that
-	// would require wiring `cmd/status.go::liveStatusProbe` out into
-	// internal/. For now return the persisted state, which is the
-	// authoritative source for is_synced / block_height after apply.
-	// TODO: extract liveStatusProbe to internal/ so MCP can offer the
-	// same combined view as `trond status` does.
-	return jsonResult(map[string]any{
+	out := map[string]any{
 		"name":         node.Name,
 		"status":       node.Status,
 		"runtime":      node.Runtime,
@@ -101,7 +99,38 @@ func statusForNode(ctx context.Context, _ *mcp.CallToolRequest, args nodeArg) (*
 		"intent_hash":  node.IntentHash,
 		"config_hash":  node.ConfigHash,
 		"labels":       node.Labels,
-	})
+	}
+	// Live probe — best effort, only when state says the node is
+	// running. We resolve a target via the node's stored target spec
+	// (state.NodeTarget → target.Target) and hand it to apply.LiveStatus.
+	// Errors during probe are silently dropped; the caller sees
+	// block_height / is_synced / peer_count appear or not.
+	if node.Status == "running" {
+		if tgt, err := mcpResolveTargetFromNode(node); err == nil {
+			if c, ok := any(tgt).(interface{ Close() error }); ok {
+				defer c.Close()
+			}
+			probeCtx, cancel := context.WithTimeout(ctx, 3*time.Second)
+			defer cancel()
+			maps.Copy(out, apply.LiveStatus(probeCtx, tgt, node))
+		}
+	}
+	return jsonResult(out)
+}
+
+// mcpResolveTargetFromNode mirrors cmd/resolve.go::resolveTargetFromNode.
+// Duplicated so internal/mcp doesn't import cmd/.
+func mcpResolveTargetFromNode(node *state.ManagedNode) (target.Target, error) {
+	switch node.Target.Type {
+	case "ssh":
+		t := target.NewSSHTarget(node.Target.Host, node.Target.Port, node.Target.User, node.Target.IdentityFile)
+		if err := t.Connect(); err != nil {
+			return nil, err
+		}
+		return t, nil
+	default:
+		return target.NewLocalTarget(), nil
+	}
 }
 
 func inspectAllNodes(ctx context.Context, _ *mcp.CallToolRequest, _ emptyArgs) (*mcp.CallToolResult, any, error) {

--- a/internal/mcp/tools_lifecycle.go
+++ b/internal/mcp/tools_lifecycle.go
@@ -2,11 +2,18 @@ package mcp
 
 import (
 	"context"
+	"fmt"
+	"os"
+	"time"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 
+	"github.com/tronprotocol/tron-deployment/internal/apply"
 	"github.com/tronprotocol/tron-deployment/internal/intent"
 	"github.com/tronprotocol/tron-deployment/internal/output"
+	"github.com/tronprotocol/tron-deployment/internal/paths"
+	"github.com/tronprotocol/tron-deployment/internal/state"
+	"github.com/tronprotocol/tron-deployment/internal/target"
 )
 
 // registerLifecycleTools wires deploy-related tools. Most are
@@ -86,33 +93,93 @@ type applyArgs struct {
 }
 
 func applyTool(ctx context.Context, _ *mcp.CallToolRequest, args applyArgs) (*mcp.CallToolResult, any, error) {
-	// Phase-1 stub: we validate the intent and acknowledge the
-	// requested action without executing it. This prevents an LLM
-	// from accidentally running a destructive op when the trond CLI
-	// pieces have not been extracted from cmd/apply.go yet.
-	//
-	// When that extraction lands, swap the body for a direct call to
-	// the pure-function apply. The MCP tool description already warns
-	// agents about this state.
+	// Pure in-process apply via the internal/apply package. We
+	// duplicate the cmd/apply.go pre-flight (load intent, resolve
+	// target, lock, hash, HUMAN_REQUIRED gate) here because the MCP
+	// surface is the structured tool, not a shell command.
 	parsed, err := intent.Load(args.Path)
+	if err != nil {
+		return errResult(output.NewError("VALIDATION_ERROR", output.ExitValidationError, err.Error()))
+	}
+
+	tgt, err := resolveTarget(parsed)
+	if err != nil {
+		return errResult(output.NewError("TARGET_UNREACHABLE", output.ExitTargetUnreachable, err.Error()))
+	}
+	if closer, ok := tgt.(interface{ Close() error }); ok {
+		defer closer.Close()
+	}
+
+	lock := state.NewLock(paths.BaseDir())
+	if err := lock.Acquire(); err != nil {
+		return errResult(output.NewError("LOCK_ERROR", output.ExitGeneralError, err.Error()))
+	}
+	defer lock.Release()
+
+	store, err := state.NewStore(paths.State())
 	if err != nil {
 		return errResult(err)
 	}
-	return errResult(output.NewError(
-		"NOT_IMPLEMENTED_VIA_MCP",
-		output.ExitGeneralError,
-		"apply is not yet executable directly from MCP; this is a known gap").
-		WithSuggestions(
-			"Run the validated intent through the shell: `trond apply --intent "+args.Path+" --auto-approve "+waitFlag(args.Wait)+"`",
-			"For verification only, the intent has been validated: name="+parsed.Name+" network="+parsed.Network,
-		))
+	st, err := store.Load()
+	if err != nil {
+		return errResult(err)
+	}
+
+	intentBytes, _ := os.ReadFile(args.Path)
+	intentHash := apply.IntentHashFromBytes(intentBytes)
+	existing := store.GetNode(st, parsed.Name)
+	if existing != nil && existing.IntentHash != intentHash && !args.AutoApprove {
+		return errResult(output.NewError("HUMAN_REQUIRED", output.ExitHumanRequired,
+			fmt.Sprintf("Changes detected for node %q; pass auto_approve=true to proceed", parsed.Name)).
+			WithSuggestions("Call the 'plan' tool first to inspect the diff",
+				"Surface the diff to the user, get approval, then re-call apply with auto_approve=true"))
+	}
+
+	res, err := apply.Apply(ctx, apply.Options{
+		Intent:         parsed,
+		Target:         tgt,
+		Store:          store,
+		State:          st,
+		IntentHash:     intentHash,
+		Existing:       existing,
+		TemplateDir:    "",
+		DeploymentsDir: paths.Deployments(),
+		EnvVars:        resolveEnvVars(&parsed.Nodes[0]),
+		Wait:           args.Wait,
+		WaitTimeout:    5 * time.Minute,
+	})
+	if err != nil {
+		return errResult(output.NewError("DEPLOY_ERROR", output.ExitGeneralError, err.Error()))
+	}
+	return jsonResult(res)
 }
 
-func waitFlag(b bool) string {
-	if b {
-		return "--wait"
+// resolveTarget mirrors cmd/apply.go's helper. Duplicated here so the
+// internal/mcp package doesn't import cmd/. Limited to local + ssh
+// since those are the only two intent.Target.Type values.
+func resolveTarget(parsed *intent.Intent) (target.Target, error) {
+	switch parsed.Target.Type {
+	case "ssh":
+		t := target.NewSSHTarget(parsed.Target.Host, parsed.Target.Port, parsed.Target.User, parsed.Target.IdentityFile)
+		if err := t.Connect(); err != nil {
+			return nil, err
+		}
+		return t, nil
+	default:
+		return target.NewLocalTarget(), nil
 	}
-	return ""
+}
+
+// resolveEnvVars mirrors cmd/apply.go's helper for the same reason.
+// Pulls the witness key out of the operator's environment by name.
+func resolveEnvVars(node *intent.NodeSpec) map[string]string {
+	env := map[string]string{}
+	if node.WitnessKeyEnv != "" {
+		if v := os.Getenv(node.WitnessKeyEnv); v != "" {
+			env[node.WitnessKeyEnv] = v
+		}
+	}
+	return env
 }
 
 func ptrTrue() *bool { v := true; return &v }


### PR DESCRIPTION
## Summary

Extracts the deploy + probe primitives out of cmd/apply.go and cmd/status.go into a new internal/apply package. cmd/* becomes a thin presentation layer; MCP tools that previously returned NOT_IMPLEMENTED or state-only subsets now use the same in-process functions.

This unblocks items 2 + 3 from the post-quartet improvement list.

## What ships

### New package: `internal/apply`

| File | Purpose |
|---|---|
| `apply.go` | `Apply(ctx, Options) (*Result, error)` — pure-function deploy: render → runtime → state save → optional wait. Includes hash-match short-circuit. |
| `wait.go` | `WaitForReady(ctx, target, name, port, timeout)` — extracted from cmd/apply.go::waitForNodeReady |
| `probe.go` | `LiveStatus(ctx, target, node)` — extracted from cmd/status.go::liveStatusProbe (block_height / is_synced / peer_count via docker-exec curl) |
| `apply_test.go` | 4 tests: no-op short-circuit on hash match, missing-input validation, IntentHashFromBytes stability against stdlib SHA256 |

### cmd/* shrinks
- `cmd/apply.go::runApply` shrinks from ~220 → ~110 lines. Lock + HUMAN_REQUIRED gate + output formatting stay; deploy phase is one apply.Apply call. **Backward-compatible JSON shape preserved** (legacy `status` / `changes` keys still emitted).
- `cmd/status.go::liveStatusProbe` shrinks to a 10-line wrapper that resolves the target then hands off.
- `cmd/plan.go`'s local `sha256hex` helper replaced with `apply.IntentHashFromBytes`.

### MCP tools that gained real behavior

- **`apply`** — was returning `NOT_IMPLEMENTED_VIA_MCP`; now actually deploys via `apply.Apply`. Test changed from asserting NOT_IMPLEMENTED to asserting validation works on a bogus path.
- **`status`** — was returning state-only fields; now runs `apply.LiveStatus` when the node is `running`, surfacing block_height / is_synced / peer_count.
- **`diagnose`** — was running a state-only subset; now runs the full `diagnosis.AllCheckers()` suite (sync_progress, peer_count, disk_space, port_listening, memory_usage, version) just like `trond diagnose <name>` does.

All three reuse `mcpResolveTargetFromNode` for SSH-aware target resolution + defer Close cleanup.

## Test plan

- [ ] `make build && make test` — every existing test still green; new internal/apply tests cover the no-op + validation paths
- [ ] `./bin/trond apply --intent examples/nile-fullnode.yaml --dry-run` — same shape as before refactor (no shape regression)
- [ ] CI 8 jobs all green

## Backwards compatibility

- CLI: unchanged. JSON shape preserved by translating apply.Result back into the legacy `status` / `changes` / `endpoints` map at the cmd boundary.
- MCP: three previously-broken tools become functional. No removals; no rename. Existing MCP clients calling `status` / `diagnose` see additional fields when the node is running.
- internal/apply is new; nothing depends on it externally yet.

## Lint config note

`.golangci.yml`: extended the cmd/* `closer.Close` errcheck exclusion to `internal/mcp/*` since the pattern is identical there (target.Target stored in `interface{ Close() error }`, deferred for cleanup).

🤖 Generated with [Claude Code](https://claude.com/claude-code)