### PR TITLE
contract test round 5: render goldens, multi-node peering fix, time-travel, UTF-8

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ endif
 
 GOFLAGS    ?=
 
-.PHONY: build test lint e2e build-all clean clean-all fmt vet tidy sync-templates sync-schemas snapshot-schema-baseline docs man cover vuln bootstrap-go
+.PHONY: build test lint e2e build-all clean clean-all fmt vet tidy sync-templates sync-schemas snapshot-schema-baseline update-render-golden docs man cover vuln bootstrap-go
 
 ## bootstrap-go: Download + verify the project-local Go toolchain
 ##               (idempotent; safe to re-run; no-op if already current)
@@ -155,3 +155,11 @@ sync-schemas:
 snapshot-schema-baseline: $(GO_BOOTSTRAP)
 	TROND_SCHEMA_UPDATE_BASELINE=1 $(GO) test -run TestSchemaVersionShape ./internal/schema/
 	@echo "baseline refreshed. Commit version_baseline.json with the SchemaVersion bump."
+
+## update-render-golden: Refresh internal/render/testdata/golden/*.{conf,compose.yaml}
+##                       after intentional template changes. TestRenderHOCON_Golden
+##                       compares current render output against these files; run
+##                       this target to accept the new output as the new baseline.
+update-render-golden: $(GO_BOOTSTRAP)
+	TROND_UPDATE_GOLDEN=1 $(GO) test -run TestRenderHOCON_Golden ./internal/render/
+	@echo "render golden files refreshed under internal/render/testdata/golden/."

--- a/cmd/network/create.go
+++ b/cmd/network/create.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -74,6 +75,32 @@ func runCreate(cmd *cobra.Command, args []string) error {
 	// nodes' "<name>:<p2p_port>" — except when the user supplied an
 	// explicit list, which we never override.
 	autoWireActivePeers(parsed)
+
+	// Each node deploys via its own `docker compose -p <node_name> up`,
+	// which gives it a per-project bridge network. That isolates the
+	// nodes from each other — they can't resolve sibling container
+	// names. We solve it by creating one shared user-defined network
+	// up front (`trond-<intent.name>`) and wiring every rendered
+	// compose file to attach to it via an external-network reference.
+	// docker network create is idempotent enough: re-creating returns
+	// non-zero, which we tolerate as "already exists".
+	sharedNet := "trond-" + parsed.Name
+	if _, err := tgt.Exec(cmd.Context(), "docker", "network", "inspect", sharedNet); err != nil {
+		if _, err := tgt.Exec(cmd.Context(), "docker", "network", "create", sharedNet); err != nil {
+			return output.NewError("DEPLOY_ERROR", output.ExitGeneralError,
+				"create shared docker network "+sharedNet+": "+err.Error()).
+				WithSuggestions("Confirm Docker is running",
+					"Try `docker network rm "+sharedNet+"` then re-run `network create`")
+		}
+	}
+	// Auto-attach the shared network to every node's compose so peer
+	// resolution works. Preserve any networks the user already declared.
+	for i := range parsed.Nodes {
+		n := &parsed.Nodes[i]
+		if !slices.Contains(n.Networks, sharedNet) {
+			n.Networks = append(n.Networks, sharedNet)
+		}
+	}
 
 	var deployed []map[string]any
 

--- a/cmd/network/destroy.go
+++ b/cmd/network/destroy.go
@@ -112,6 +112,30 @@ func runDestroy(cmd *cobra.Command, args []string) error {
 			"failed to persist state after destroy: "+err.Error())
 	}
 
+	// Tear down the shared docker network the matching `network create`
+	// stood up. Best-effort: a leftover network is harmless on next
+	// run (create re-uses it), so we ignore failures rather than
+	// surfacing them as the destroy result.
+	if len(removed) > 0 {
+		// Resolve a target for the network rm. We just used one for
+		// each node above; either is fine — re-pick from the first
+		// node we just removed.
+		for _, n := range deployState.Nodes {
+			if n.Name == removed[0] {
+				if tgt, terr := resolveTargetForNode(&n); terr == nil {
+					_, _ = tgt.Exec(cmd.Context(), "docker", "network", "rm", "trond-"+destroyConfirm)
+					closeTarget(tgt)
+				}
+				break
+			}
+		}
+		// We also try a local-target rm even if no surviving node remained
+		// in state (the loop above iterates the post-RemoveNode state),
+		// since the most common case is "all nodes removed, no entries
+		// left." Falls back silently.
+		_, _ = target.NewLocalTarget().Exec(cmd.Context(), "docker", "network", "rm", "trond-"+destroyConfirm)
+	}
+
 	if len(failures) > 0 {
 		auditResult = "partial"
 	}

--- a/cmd/peering_e2e_test.go
+++ b/cmd/peering_e2e_test.go
@@ -1,0 +1,117 @@
+//go:build e2e
+
+package cmd
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func peeringIntent() string {
+	return `name: private-dev
+target:
+  type: local
+  runtime: docker
+network: private
+nodes:
+  - type: witness
+    version: latest
+    witness_key:
+      private_key_env: SR_PRIVATE_KEY
+    resources:
+      memory: 2GB
+    ports:
+      http: 28090
+      grpc: 50081
+      p2p: 28888
+  - type: fullnode
+    version: latest
+    resources:
+      memory: 2GB
+    ports:
+      http: 28091
+      grpc: 50082
+      p2p: 28889
+`
+}
+
+// TestE2E_Network_Peering deploys a 2-node private network and
+// verifies the nodes can actually reach each other on the docker
+// internal network — i.e. the auto-wired `node.active` peer list is
+// correct AND the docker compose project's user-defined network
+// exposes containers under their compose container_name.
+//
+// Without this test, peering breakage looks like "your private
+// network deploys fine but never produces blocks" — a much harder
+// failure mode to diagnose than a failed deploy. The contract:
+// `docker exec <node-A> curl <node-B>:<http-port>/wallet/getnowblock`
+// must succeed within a small window after deploy.
+//
+// Slow (~15s, dominated by container startup) and Docker-gated.
+func TestE2E_Network_Peering(t *testing.T) {
+	skipUnlessDocker(t)
+	stateDir, env := e2eEnv(t)
+	env = append(env,
+		"SR_PRIVATE_KEY=0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef")
+
+	// Build a minimal 2-node intent with low memory limits — the
+	// committed example asks for 8GB per node, which JVM can't
+	// commit on resource-constrained CI runners (and on Docker
+	// Desktop's default VM size). 2GB per node is enough to start
+	// java-tron's HTTP listener; we don't actually exercise the
+	// chain.
+	intentPath := filepath.Join(stateDir, "peering-intent.yaml")
+	if err := os.WriteFile(intentPath, []byte(peeringIntent()), 0o600); err != nil {
+		t.Fatalf("write intent: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+
+	t.Cleanup(func() {
+		cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 3*time.Minute)
+		defer cleanupCancel()
+		_, _ = runTrondAllowFail(cleanupCtx, t, env,
+			"network", "destroy", "--confirm", "private-dev", "--output", "json")
+	})
+
+	// Deploy the private network.
+	runTrondCtx(ctx, t, env, "network", "create",
+		"--intent", intentPath, "--output", "json")
+
+	// Probe: from inside node0, can DNS resolve node1's container
+	// name? This is the real trond-level peering contract — that
+	// the auto-wired active_peers list refers to addresses both
+	// containers can resolve. We deliberately don't wait for
+	// java-tron's HTTP API to come up (that's java-tron's job +
+	// resource-dependent on CI runners with limited Docker
+	// memory); DNS resolution succeeds within seconds of the
+	// containers starting and is the load-bearing assertion for
+	// `network create`'s shared-network setup.
+	//
+	// Before the shared-network fix, getent would fail with exit
+	// status 2 (not found). After the fix, it returns the peer's
+	// docker IP within the user-defined network.
+	deadline := time.Now().Add(45 * time.Second)
+	var lastErr error
+	var lastOut []byte
+	for time.Now().Before(deadline) {
+		probe := exec.CommandContext(ctx, "docker", "exec", "private-dev-node0",
+			"getent", "hosts", "private-dev-node1")
+		out, err := probe.CombinedOutput()
+		if err == nil && strings.Contains(string(out), "private-dev-node1") {
+			t.Logf("node0 resolved node1: %s", strings.TrimSpace(string(out)))
+			return
+		}
+		lastErr = err
+		lastOut = out
+		time.Sleep(500 * time.Millisecond)
+	}
+	t.Fatalf("node0 could not resolve node1 over shared docker network\n"+
+		"last error: %v\nlast output:\n%s", lastErr, lastOut)
+}

--- a/internal/intent/utf8_test.go
+++ b/internal/intent/utf8_test.go
@@ -1,0 +1,78 @@
+package intent
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestLoad_NonASCIIDescription verifies trond accepts UTF-8 in
+// description / labels — which it should, since YAML and Go's
+// encoding/json both default to UTF-8. We also check that the
+// values round-trip without re-encoding mangling.
+//
+// Why test it: a future regression that ran content through a
+// non-UTF-8-safe codec (e.g. a string-replacement step that
+// assumes ASCII) would only be caught here. Reasonable agents
+// pass labels like role=主节点 or descriptions with emoji as
+// readable hints.
+func TestLoad_NonASCIIDescription(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "intent.yaml")
+	body := `name: test-utf8
+target:
+  type: local
+  runtime: docker
+network: nile
+nodes:
+  - type: fullnode
+    version: latest
+    labels:
+      team: 区块链团队
+      emoji: 🌏-asia
+    resources:
+      memory: 4GB
+    ports:
+      http: 8090
+      grpc: 50051
+      p2p: 18888
+`
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	parsed, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load with UTF-8 labels: %v", err)
+	}
+	if len(parsed.Nodes) == 0 {
+		t.Fatal("intent has no nodes")
+	}
+	labels := parsed.Nodes[0].Labels
+	if got := labels["team"]; got != "区块链团队" {
+		t.Errorf("UTF-8 label mangled: got %q, want %q", got, "区块链团队")
+	}
+	if got := labels["emoji"]; got != "🌏-asia" {
+		t.Errorf("emoji label mangled: got %q, want %q", got, "🌏-asia")
+	}
+}
+
+// TestLoad_RejectsNULBytes guards against a path injection / null-
+// byte trick where an attacker (or sloppy automation) embeds a NUL
+// in a node name to bypass downstream string handling. trond's
+// safe_string validator should refuse it.
+func TestLoad_RejectsNULBytes(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "intent.yaml")
+	body := "name: \"test\\u0000nul\"\n" +
+		"target: {type: local, runtime: docker}\nnetwork: nile\n" +
+		"nodes:\n  - type: fullnode\n    version: latest\n" +
+		"    resources: {memory: 4GB}\n" +
+		"    ports: {http: 8090, grpc: 50051, p2p: 18888}\n"
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if _, err := Load(path); err == nil {
+		t.Error("expected Load to reject NUL byte in name; got success")
+	}
+}

--- a/internal/render/golden_test.go
+++ b/internal/render/golden_test.go
@@ -1,0 +1,128 @@
+package render
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/tronprotocol/tron-deployment/internal/intent"
+)
+
+// TestRenderHOCON_Golden compares the HOCON + compose output for
+// each example intent against a checked-in "golden" copy under
+// testdata/golden/. A drift here means the template or render path
+// changed in a way that affects output bytes — not necessarily a
+// bug, but always a deliberate review checkpoint.
+//
+// The same pattern as the schema-baseline + ajv tests: the golden
+// files are content-addressed, drift is a signal, and the developer
+// regenerates them in lockstep with intentional changes:
+//
+//	make update-render-golden       # regenerate all golden files
+//	go test ./internal/render/...   # confirm green
+//
+// Catches: template typos that change rendered output (a HOCON
+// curly brace moves, a default value flips, JVM args reorder) —
+// things the round-trip regex test misses because it only verifies
+// presence, not exact placement.
+//
+// Skipped for environment-sensitive intents (any that interpolate
+// $HOSTNAME, time.Now, or random ports) — none of the examples
+// currently do.
+func TestRenderHOCON_Golden(t *testing.T) {
+	cases := []struct {
+		intent string
+		// golden file basename. We use a stable short name rather
+		// than the intent filename so renames don't leave orphan
+		// goldens behind.
+		golden string
+	}{
+		{"nile-fullnode.yaml", "nile-fullnode"},
+		{"mainnet-fullnode.yaml", "mainnet-fullnode"},
+		{"mainnet-witness.yaml", "mainnet-witness"},
+	}
+	repoRoot, err := filepath.Abs("../..")
+	if err != nil {
+		t.Fatalf("repo root: %v", err)
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.intent, func(t *testing.T) {
+			intentPath := filepath.Join(repoRoot, "examples", tc.intent)
+			parsed, err := intent.Load(intentPath)
+			if err != nil {
+				t.Fatalf("intent.Load: %v", err)
+			}
+			node := &parsed.Nodes[0]
+
+			gotHOCON, err := RenderHOCON("", parsed, node)
+			if err != nil {
+				t.Fatalf("RenderHOCON: %v", err)
+			}
+			memGB := ParseMemoryGB(node.Resources.Memory)
+			if memGB == 0 {
+				memGB = 16
+			}
+			jvmArgs := JVMArgsString(memGB, 17, node.JVM)
+			gotCompose := RenderCompose(parsed.Name, parsed, node, "", jvmArgs)
+
+			compareGolden(t, tc.golden+".conf", gotHOCON)
+			compareGolden(t, tc.golden+".compose.yaml", gotCompose)
+		})
+	}
+}
+
+// compareGolden compares the actual rendered text against the golden
+// file at testdata/golden/<name>. When TROND_UPDATE_GOLDEN=1 the
+// golden is rewritten with the actual content (or created on first
+// run); otherwise a mismatch fails the test with the goldenName +
+// instructions.
+func compareGolden(t *testing.T, name, got string) {
+	t.Helper()
+	dir := filepath.Join("testdata", "golden")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir testdata/golden: %v", err)
+	}
+	path := filepath.Join(dir, name)
+
+	if updateGolden() {
+		if err := os.WriteFile(path, []byte(got), 0o644); err != nil {
+			t.Fatalf("write golden %s: %v", name, err)
+		}
+		t.Logf("updated %s", path)
+		return
+	}
+
+	want, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read golden %s: %v\nrun `make update-render-golden` to create it",
+			path, err)
+	}
+	if string(want) != got {
+		t.Errorf(
+			"golden mismatch for %s.\n"+
+				"If the change is intentional, regenerate via:\n"+
+				"  make update-render-golden\n"+
+				"Otherwise something in the render path drifted.\n\n"+
+				"--- want (first 400 chars) ---\n%s\n\n"+
+				"--- got (first 400 chars) ---\n%s",
+			name, snippetForGolden(string(want), 400), snippetForGolden(got, 400))
+	}
+}
+
+func updateGolden() bool {
+	for _, a := range os.Args {
+		if a == "-update" {
+			return true
+		}
+	}
+	return strings.EqualFold(os.Getenv("TROND_UPDATE_GOLDEN"), "1")
+}
+
+func snippetForGolden(s string, n int) string {
+	if len(s) > n {
+		return s[:n] + "...(truncated)"
+	}
+	return s
+}

--- a/internal/render/testdata/golden/mainnet-fullnode.compose.yaml
+++ b/internal/render/testdata/golden/mainnet-fullnode.compose.yaml
@@ -1,0 +1,29 @@
+services:
+  my-fullnode:
+    image: tronprotocol/java-tron
+    container_name: my-fullnode
+    restart: unless-stopped
+    ports:
+      - "8090:8090"
+      - "50051:50051"
+      - "18888:18888"
+      - "18888:18888/udp"
+      - "8545:8545"
+      - "9527:9527"
+    volumes:
+      - ./my-fullnode.conf:/java-tron/conf/my-fullnode.conf:ro
+      - my-fullnode-data:/java-tron/output-directory
+      - my-fullnode-logs:/java-tron/logs
+    deploy:
+      resources:
+        limits:
+          memory: 16g
+    command:
+      - "-jvm"
+      - "{-Xmx8g -Xms8g -Xmn2g -XX:MaxDirectMemorySize=1g -XX:+HeapDumpOnOutOfMemoryError -XX:+UseTLAB}"
+      - "-c"
+      - "/java-tron/conf/my-fullnode.conf"
+
+volumes:
+  my-fullnode-data:
+  my-fullnode-logs:

--- a/internal/render/testdata/golden/mainnet-fullnode.conf
+++ b/internal/render/testdata/golden/mainnet-fullnode.conf
@@ -1,0 +1,839 @@
+net {
+  # type is deprecated and has no effect.
+  # type = mainnet
+}
+
+storage {
+  # Directory for storing persistent data
+  db.engine = "LEVELDB",  // deprecated for arm, because arm only support  "ROCKSDB".
+  db.sync = false,
+  db.directory = "database",
+
+  # Whether to write transaction result in transactionRetStore
+  transHistory.switch = "on",
+
+  # setting can improve leveldb performance .... start, deprecated for arm
+  # node: if this will increase process fds,you may be check your ulimit if 'too many open files' error occurs
+  # see https://github.com/tronprotocol/tips/blob/master/tip-343.md for detail
+  # if you find block sync has lower performance, you can try this settings
+  # default = {
+  #  maxOpenFiles = 100
+  # }
+  # defaultM = {
+  #  maxOpenFiles = 500
+  # }
+  # defaultL = {
+  #  maxOpenFiles = 1000
+  # }
+  # setting can improve leveldb performance .... end, deprecated for arm
+
+  # You can customize the configuration for each database. Otherwise, the database settings will use
+  # their defaults, and data will be stored in the "output-directory" or in the directory specified
+  # by the "-d" or "--output-directory" option. Attention: name is a required field that must be set!
+  # In this configuration, the name and path properties take effect for both LevelDB and RocksDB storage engines,
+  # while the additional properties (such as createIfMissing, paranoidChecks, compressionType, etc.) only take effect when using LevelDB.
+  properties = [
+    #    {
+    #      name = "account",
+    #      path = "storage_directory_test",
+    #      createIfMissing = true, // deprecated for arm start
+    #      paranoidChecks = true,
+    #      verifyChecksums = true,
+    #      compressionType = 1,        // compressed with snappy
+    #      blockSize = 4096,           // 4  KB =         4 * 1024 B
+    #      writeBufferSize = 10485760, // 10 MB = 10 * 1024 * 1024 B
+    #      cacheSize = 10485760,       // 10 MB = 10 * 1024 * 1024 B
+    #      maxOpenFiles = 100 // deprecated for arm end
+    #    },
+    #    {
+    #      name = "account-index",
+    #      path = "storage_directory_test",
+    #      createIfMissing = true,
+    #      paranoidChecks = true,
+    #      verifyChecksums = true,
+    #      compressionType = 1,        // compressed with snappy
+    #      blockSize = 4096,           // 4  KB =         4 * 1024 B
+    #      writeBufferSize = 10485760, // 10 MB = 10 * 1024 * 1024 B
+    #      cacheSize = 10485760,       // 10 MB = 10 * 1024 * 1024 B
+    #      maxOpenFiles = 100
+    #    },
+  ]
+
+  needToUpdateAsset = true
+
+  # dbsettings is needed when using rocksdb as the storage implement (db.engine="ROCKSDB").
+  # we'd strongly recommend that do not modify it unless you know every item's meaning clearly.
+  dbSettings = {
+    levelNumber = 7
+    # compactThreads = 32
+    blocksize = 64  // n * KB
+    maxBytesForLevelBase = 256  // n * MB
+    maxBytesForLevelMultiplier = 10
+    level0FileNumCompactionTrigger = 4
+    targetFileSizeBase = 256  // n * MB
+    targetFileSizeMultiplier = 1
+    maxOpenFiles = 5000
+  }
+
+  balance.history.lookup = false
+
+  # checkpoint.version = 2
+  # checkpoint.sync = true
+
+  # the estimated number of block transactions (default 1000, min 100, max 10000).
+  # so the total number of cached transactions is 65536 * txCache.estimatedTransactions
+  # txCache.estimatedTransactions = 1000
+
+  # if true, transaction cache initialization will be faster. Default: false
+  txCache.initOptimization = true
+
+  # The number of blocks flushed to db in each batch during node syncing. Default: 1
+  # snapshot.maxFlushCount = 1
+
+  # data root setting, for check data, currently, only reward-vi is used.
+  # merkleRoot = {
+  # reward-vi = 9debcb9924055500aaae98cdee10501c5c39d4daa75800a996f4bdda73dbccd8 // main-net, Sha256Hash, hexString
+  # }
+
+}
+
+node.discovery = {
+  enable = true
+  persist = true
+}
+
+# custom stop condition
+#node.shutdown = {
+#  BlockTime  = "54 59 08 * * ?" # if block header time in persistent db matched.
+#  BlockHeight = 33350800 # if block header height in persistent db matched.
+#  BlockCount = 12 # block sync count after node start.
+#}
+
+node.backup {
+  # udp listen port, each member should have the same configuration
+  port = 10001
+
+  # my priority, each member should use different priority
+  priority = 8
+
+  # time interval to send keepAlive message, each member should have the same configuration
+  keepAliveInterval = 3000
+
+  # peer's ip list, can't contain mine
+  members = [
+    # "ip",
+    # "ip"
+  ]
+}
+
+# Specify the algorithm for generating a public key from private key. To avoid forks, please do not modify it
+crypto {
+  engine = "eckey"
+}
+
+node.metrics = {
+  # prometheus metrics
+  prometheus {
+    enable = false
+    port = 9527
+  }
+
+  # influxdb metrics
+  storageEnable = false # Whether write metrics data into InfluxDb. Default: false.
+  influxdb {
+    ip = ""
+    port = 8086
+    database = ""
+    metricsReportInterval = 10
+  }
+}
+
+node {
+  # trust node for solidity node
+  # trustNode = "ip:port"
+  trustNode = "127.0.0.1:50051"
+
+  # expose extension api to public or not
+  walletExtensionApi = true
+
+  listen.port = 18888
+
+  connection.timeout = 2
+
+  fetchBlock.timeout = 200
+  # syncFetchBatchNum = 2000
+
+  # Number of validate sign thread, default availableProcessors
+  # validateSignThreadNum = 16
+
+  maxConnections = 30
+
+  minConnections = 8
+
+  minActiveConnections = 3
+
+  maxConnectionsWithSameIp = 2
+
+  maxHttpConnectNumber = 50
+
+  minParticipationRate = 15
+
+  # allowShieldedTransactionApi = true
+
+  # openPrintLog = true
+
+  # If set to true, SR packs transactions into a block in descending order of fee; otherwise, it packs
+  # them based on their receive timestamp. Default: false
+  # openTransactionSort = false
+
+  # The threshold for the number of broadcast transactions received from each peer every second,
+  # transactions exceeding this threshold will be discarded
+  # maxTps = 1000
+
+  isOpenFullTcpDisconnect = false
+  inactiveThreshold = 600 //seconds
+
+  p2p {
+    version = 11111 # Mainnet:11111; Nile:201910292; Shasta:1
+  }
+
+  active = [
+    # Active establish connection in any case
+    # Sample entries:
+    # "ip:port",
+    # "ip:port"
+  ]
+
+  passive = [
+    # Passive accept connection in any case
+    # Sample entries:
+    # "ip:port",
+    # "ip:port"
+  ]
+
+  fastForward = [
+    "100.27.171.62:18888",
+    "15.188.6.125:18888"
+  ]
+
+  http {
+    fullNodeEnable = true
+    fullNodePort = 8090
+    solidityEnable = true
+    solidityPort = 8091
+    PBFTEnable = true
+    PBFTPort = 8092
+  }
+
+  rpc {
+    enable = true
+    port = 50051
+    solidityEnable = true
+    solidityPort = 50061
+    PBFTEnable = true
+    PBFTPort = 50071
+
+    # Number of gRPC thread, default availableProcessors / 2
+    # thread = 16
+
+    # The maximum number of concurrent calls permitted for each incoming connection
+    # maxConcurrentCallsPerConnection =
+
+    # The HTTP/2 flow control window, default 1MB
+    # flowControlWindow =
+
+    # Connection being idle for longer than which will be gracefully terminated
+    maxConnectionIdleInMillis = 60000
+
+    # Connection lasting longer than which will be gracefully terminated
+    # maxConnectionAgeInMillis =
+
+    # The maximum message size allowed to be received on the server, default 4MB
+    # maxMessageSize =
+
+    # The maximum size of header list allowed to be received, default 8192
+    # maxHeaderListSize =
+
+    # The number of RST_STREAM frames allowed to be sent per connection per period for grpc, by default there is no limit.
+    # maxRstStream =
+
+    # The number of seconds per period for grpc
+    # secondsPerWindow =
+
+    # Transactions can only be broadcast if the number of effective connections is reached.
+    minEffectiveConnection = 1
+
+    # The switch of the reflection service, effective for all gRPC services, used for grpcurl tool. Default: false
+    reflectionService = false
+  }
+
+  # number of solidity thread in the FullNode.
+  # If accessing solidity rpc and http interface timeout, could increase the number of threads,
+  # The default value is the number of cpu cores of the machine.
+  # solidity.threads = 8
+
+  # Limits the maximum percentage (default 75%) of producing block interval
+  # to provide sufficient time to perform other operations e.g. broadcast block
+  # blockProducedTimeOut = 75
+
+  # Limits the maximum number (default 700) of transaction from network layer
+  # netMaxTrxPerSecond = 700
+
+  # Whether to enable the node detection function. Default: false
+  # nodeDetectEnable = false
+
+  # use your ipv6 address for node discovery and tcp connection. Default: false
+  # enableIpv6 = false
+
+  # if your node's highest block num is below than all your pees', try to acquire new connection. Default: false
+  # effectiveCheckEnable = false
+
+  # Dynamic loading configuration function, disabled by default
+  dynamicConfig = {
+    # enable = false
+    # checkInterval = 600 // Check interval of Configuration file's change, default is 600 seconds
+  }
+
+  # Whether to continue broadcast transactions after at least maxUnsolidifiedBlocks are not solidified. Default: false
+  # unsolidifiedBlockCheck = false
+  # maxUnsolidifiedBlocks = 54
+
+  dns {
+    # dns urls to get nodes, url format tree://{pubkey}@{domain}, default empty
+    treeUrls = [
+      #"tree://AKMQMNAJJBL73LXWPXDI4I5ZWWIZ4AWO34DWQ636QOBBXNFXH3LQS@main.trondisco.net",
+    ]
+
+    # enable or disable dns publish. Default: false
+    # publish = false
+
+    # dns domain to publish nodes, required if publish is true
+    # dnsDomain = "nodes1.example.org"
+
+    # dns private key used to publish, required if publish is true, hex string of length 64
+    # dnsPrivate = "b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291"
+
+    # known dns urls to publish if publish is true, url format tree://{pubkey}@{domain}, default empty
+    # knownUrls = [
+    #"tree://APFGGTFOBVE2ZNAB3CSMNNX6RRK3ODIRLP2AA5U4YFAA6MSYZUYTQ@nodes2.example.org",
+    # ]
+
+    # staticNodes = [
+    # static nodes to published on dns
+    # Sample entries:
+    # "ip:port",
+    # "ip:port"
+    # ]
+
+    # merge several nodes into a leaf of tree, should be 1~5
+    # maxMergeSize = 5
+
+    # only nodes change percent is bigger then the threshold, we update data on dns
+    # changeThreshold = 0.1
+
+    # dns server to publish, required if publish is true, only aws or aliyun is support
+    # serverType = "aws"
+
+    # access key id of aws or aliyun api, required if publish is true, string
+    # accessKeyId = "your-key-id"
+
+    # access key secret of aws or aliyun api, required if publish is true, string
+    # accessKeySecret = "your-key-secret"
+
+    # if publish is true and serverType is aliyun, it's endpoint of aws dns server, string
+    # aliyunDnsEndpoint = "alidns.aliyuncs.com"
+
+    # if publish is true and serverType is aws, it's region of aws api, such as "eu-south-1", string
+    # awsRegion = "us-east-1"
+
+    # if publish is true and server-type is aws, it's host zone id of aws's domain, string
+    # awsHostZoneId = "your-host-zone-id"
+  }
+
+  # open the history query APIs(http&GRPC) when node is a lite FullNode,
+  # like {getBlockByNum, getBlockByID, getTransactionByID...}. Default: false.
+  # note: above APIs may return null even if blocks and transactions actually are on the blockchain
+  # when opening on a lite FullNode. only open it if the consequences being clearly known
+  # openHistoryQueryWhenLiteFN = false
+
+  jsonrpc {
+    # Note: Before release_4.8.1, if you turn on jsonrpc and run it for a while and then turn it off,
+    # you will not be able to get the data from eth_getLogs for that period of time. Default: false
+    httpFullNodeEnable = true
+    # httpFullNodePort = 8545
+    # httpSolidityEnable = false
+    # httpSolidityPort = 8555
+    # httpPBFTEnable = false
+    # httpPBFTPort = 8565
+
+    # The maximum blocks range to retrieve logs for eth_getLogs, default value is 5000,
+    # should be > 0, otherwise means no limit.
+    maxBlockRange = 5000
+
+    # The maximum number of allowed topics within a topic criteria, default value is 1000,
+    # should be > 0, otherwise means no limit.
+    maxSubTopics = 1000
+    # Allowed maximum number for blockFilter
+    maxBlockFilterNum = 50000
+  }
+
+  # Disabled api list, it will work for http, rpc and pbft, both FullNode and SolidityNode,
+  # but not jsonrpc. The setting is case insensitive, GetNowBlock2 is equal to getnowblock2
+  disabledApi = [
+    #  "getaccount",
+    #  "getnowblock2"
+  ]
+
+}
+
+## rate limiter config
+rate.limiter = {
+  # Every api could only set a specific rate limit strategy. Three blocking strategy are supported:
+  # GlobalPreemptibleAdapter: The number of preemptible resource or maximum concurrent requests globally.
+  # QpsRateLimiterAdapter: qps is the average request count in one second supported by the server, it could be a Double or a Integer.
+  # IPQPSRateLimiterAdapter: similar to the QpsRateLimiterAdapter, qps could be a Double or a Integer.
+  # If not set, QpsRateLimiterAdapter with qps=1000 is the default strategy.
+  #
+  # Sample entries:
+  #
+  http = [
+    #  {
+    #    component = "GetNowBlockServlet",
+    #    strategy = "GlobalPreemptibleAdapter",
+    #    paramString = "permit=1"
+    #  },
+
+    #  {
+    #    component = "GetAccountServlet",
+    #    strategy = "IPQPSRateLimiterAdapter",
+    #    paramString = "qps=1"
+    #  },
+
+    #  {
+    #    component = "ListWitnessesServlet",
+    #    strategy = "QpsRateLimiterAdapter",
+    #    paramString = "qps=1"
+    #  }
+  ],
+
+  rpc = [
+    #  {
+    #    component = "protocol.Wallet/GetBlockByLatestNum2",
+    #    strategy = "GlobalPreemptibleAdapter",
+    #    paramString = "permit=1"
+    #  },
+
+    #  {
+    #    component = "protocol.Wallet/GetAccount",
+    #    strategy = "IPQPSRateLimiterAdapter",
+    #    paramString = "qps=1"
+    #  },
+
+    #  {
+    #    component = "protocol.Wallet/ListWitnesses",
+    #    strategy = "QpsRateLimiterAdapter",
+    #    paramString = "qps=1"
+    #  },
+  ]
+
+  p2p = {
+    # syncBlockChain = 3.0
+    # fetchInvData = 3.0
+    # disconnect = 1.0
+  }
+
+  # global qps, default 50000
+  global.qps = 50000
+  # IP-based global qps, default 10000
+  global.ip.qps = 10000
+}
+
+
+
+seed.node = {
+  # List of the seed nodes
+  # Seed nodes are stable full nodes
+  # example:
+  # ip.list = [
+  #   "ip:port",
+  #   "ip:port"
+  # ]
+  ip.list = [
+    "3.225.171.164:18888",
+    "52.8.46.215:18888",
+    "3.79.71.167:18888",
+    "108.128.110.16:18888",
+    "18.133.82.227:18888",
+    "35.180.81.133:18888",
+    "13.210.151.5:18888",
+    "18.231.27.82:18888",
+    "3.12.212.122:18888",
+    "52.24.128.7:18888",
+    "15.207.144.3:18888",
+    "3.39.38.55:18888",
+    "54.151.226.240:18888",
+    "35.174.93.198:18888",
+    "18.210.241.149:18888",
+    "54.177.115.127:18888",
+    "54.254.131.82:18888",
+    "18.167.171.167:18888",
+    "54.167.11.177:18888",
+    "35.74.7.196:18888",
+    "52.196.244.176:18888",
+    "54.248.129.19:18888",
+    "43.198.142.160:18888",
+    "3.0.214.7:18888",
+    "54.153.59.116:18888",
+    "54.153.94.160:18888",
+    "54.82.161.39:18888",
+    "54.179.207.68:18888",
+    "18.142.82.44:18888",
+    "18.163.230.203:18888",
+    # "[2a05:d014:1f2f:2600:1b15:921:d60b:4c60]:18888", // use this if support ipv6
+    # "[2600:1f18:7260:f400:8947:ebf3:78a0:282b]:18888", // use this if support ipv6
+  ]
+}
+
+genesis.block = {
+  # Reserve balance
+  assets = [
+    {
+      accountName = "Zion"
+      accountType = "AssetIssue"
+      address = "TLLM21wteSPs4hKjbxgmH1L6poyMjeTbHm"
+      balance = "99000000000000000"
+    },
+    {
+      accountName = "Sun"
+      accountType = "AssetIssue"
+      address = "TXmVpin5vq5gdZsciyyjdZgKRUju4st1wM"
+      balance = "0"
+    },
+    {
+      accountName = "Blackhole"
+      accountType = "AssetIssue"
+      address = "TLsV52sRDL79HXGGm9yzwKibb6BeruhUzy"
+      balance = "-9223372036854775808"
+    }
+  ]
+
+  witnesses = [
+    {
+      address: THKJYuUmMKKARNf7s2VT51g5uPY6KEqnat,
+      url = "http://GR1.com",
+      voteCount = 100000026
+    },
+    {
+      address: TVDmPWGYxgi5DNeW8hXrzrhY8Y6zgxPNg4,
+      url = "http://GR2.com",
+      voteCount = 100000025
+    },
+    {
+      address: TWKZN1JJPFydd5rMgMCV5aZTSiwmoksSZv,
+      url = "http://GR3.com",
+      voteCount = 100000024
+    },
+    {
+      address: TDarXEG2rAD57oa7JTK785Yb2Et32UzY32,
+      url = "http://GR4.com",
+      voteCount = 100000023
+    },
+    {
+      address: TAmFfS4Tmm8yKeoqZN8x51ASwdQBdnVizt,
+      url = "http://GR5.com",
+      voteCount = 100000022
+    },
+    {
+      address: TK6V5Pw2UWQWpySnZyCDZaAvu1y48oRgXN,
+      url = "http://GR6.com",
+      voteCount = 100000021
+    },
+    {
+      address: TGqFJPFiEqdZx52ZR4QcKHz4Zr3QXA24VL,
+      url = "http://GR7.com",
+      voteCount = 100000020
+    },
+    {
+      address: TC1ZCj9Ne3j5v3TLx5ZCDLD55MU9g3XqQW,
+      url = "http://GR8.com",
+      voteCount = 100000019
+    },
+    {
+      address: TWm3id3mrQ42guf7c4oVpYExyTYnEGy3JL,
+      url = "http://GR9.com",
+      voteCount = 100000018
+    },
+    {
+      address: TCvwc3FV3ssq2rD82rMmjhT4PVXYTsFcKV,
+      url = "http://GR10.com",
+      voteCount = 100000017
+    },
+    {
+      address: TFuC2Qge4GxA2U9abKxk1pw3YZvGM5XRir,
+      url = "http://GR11.com",
+      voteCount = 100000016
+    },
+    {
+      address: TNGoca1VHC6Y5Jd2B1VFpFEhizVk92Rz85,
+      url = "http://GR12.com",
+      voteCount = 100000015
+    },
+    {
+      address: TLCjmH6SqGK8twZ9XrBDWpBbfyvEXihhNS,
+      url = "http://GR13.com",
+      voteCount = 100000014
+    },
+    {
+      address: TEEzguTtCihbRPfjf1CvW8Euxz1kKuvtR9,
+      url = "http://GR14.com",
+      voteCount = 100000013
+    },
+    {
+      address: TZHvwiw9cehbMxrtTbmAexm9oPo4eFFvLS,
+      url = "http://GR15.com",
+      voteCount = 100000012
+    },
+    {
+      address: TGK6iAKgBmHeQyp5hn3imB71EDnFPkXiPR,
+      url = "http://GR16.com",
+      voteCount = 100000011
+    },
+    {
+      address: TLaqfGrxZ3dykAFps7M2B4gETTX1yixPgN,
+      url = "http://GR17.com",
+      voteCount = 100000010
+    },
+    {
+      address: TX3ZceVew6yLC5hWTXnjrUFtiFfUDGKGty,
+      url = "http://GR18.com",
+      voteCount = 100000009
+    },
+    {
+      address: TYednHaV9zXpnPchSywVpnseQxY9Pxw4do,
+      url = "http://GR19.com",
+      voteCount = 100000008
+    },
+    {
+      address: TCf5cqLffPccEY7hcsabiFnMfdipfyryvr,
+      url = "http://GR20.com",
+      voteCount = 100000007
+    },
+    {
+      address: TAa14iLEKPAetX49mzaxZmH6saRxcX7dT5,
+      url = "http://GR21.com",
+      voteCount = 100000006
+    },
+    {
+      address: TBYsHxDmFaRmfCF3jZNmgeJE8sDnTNKHbz,
+      url = "http://GR22.com",
+      voteCount = 100000005
+    },
+    {
+      address: TEVAq8dmSQyTYK7uP1ZnZpa6MBVR83GsV6,
+      url = "http://GR23.com",
+      voteCount = 100000004
+    },
+    {
+      address: TRKJzrZxN34YyB8aBqqPDt7g4fv6sieemz,
+      url = "http://GR24.com",
+      voteCount = 100000003
+    },
+    {
+      address: TRMP6SKeFUt5NtMLzJv8kdpYuHRnEGjGfe,
+      url = "http://GR25.com",
+      voteCount = 100000002
+    },
+    {
+      address: TDbNE1VajxjpgM5p7FyGNDASt3UVoFbiD3,
+      url = "http://GR26.com",
+      voteCount = 100000001
+    },
+    {
+      address: TLTDZBcPoJ8tZ6TTEeEqEvwYFk2wgotSfD,
+      url = "http://GR27.com",
+      voteCount = 100000000
+    }
+  ]
+
+  timestamp = "0" # Genesis block timestamp, milli seconds
+
+  parentHash = "0xe58f33f9baf9305dc6f82b9f1934ea8f0ade2defb951258d50167028c780351f"
+}
+
+# Optional. The default is empty. It is used when the witness account has set the witnessPermission.
+# When it is not empty, the localWitnessAccountAddress represents the address of the witness account,
+# and the localwitness is configured with the private key of the witnessPermissionAddress in the witness account.
+# When it is empty,the localwitness is configured with the private key of the witness account.
+# localWitnessAccountAddress =
+
+localwitness = [
+]
+
+# localwitnesskeystore = [
+#  "localwitnesskeystore.json"
+# ]
+
+block = {
+  needSyncCheck = true
+  maintenanceTimeInterval = 21600000 // 6 hours: 21600000(ms)
+  proposalExpireTime = 259200000 // default value: 3 days: 259200000(ms), Note: this value is controlled by committee proposal
+  # checkFrozenTime = 1 // for test only
+}
+
+# Transaction reference block, default is "solid", configure to "head" may cause TaPos error
+trx.reference.block = "solid" // "head" or "solid"
+
+# This property sets the number of milliseconds after the creation of the transaction that is expired, default value is  60000.
+# trx.expiration.timeInMilliseconds = 60000
+
+vm = {
+  supportConstant = false
+  maxEnergyLimitForConstant = 100000000
+  minTimeRatio = 0.0
+  maxTimeRatio = 5.0
+  saveInternalTx = false
+  # lruCacheSize = 500
+  # vmTrace = false
+
+  # Indicates whether the node stores featured internal transactions, such as freeze, vote and so on. Default: false.
+  # saveFeaturedInternalTx = false
+
+  # Indicates whether the node stores the details of the internal transactions generated by the CANCELALLUNFREEZEV2 opcode,
+  # such as bandwidth/energy/tronpower cancel amount. Default: false.
+  # saveCancelAllUnfreezeV2Details = false
+
+  # In rare cases, transactions that will be within the specified maximum execution time (default 10(ms)) are re-executed and packaged
+  # longRunningTime = 10
+
+  # Indicates whether the node support estimate energy API. Default: false.
+  # estimateEnergy = false
+
+  # Indicates the max retry time for executing transaction in estimating energy. Default 3.
+  # estimateEnergyMaxRetry = 3
+}
+
+# These parameters are designed for private chain testing only and cannot be freely switched on or off in production systems.
+committee = {
+  allowCreationOfContracts = 0  //mainnet:0 (reset by committee),test:1
+  allowAdaptiveEnergy = 0  //mainnet:0 (reset by committee),test:1
+  # allowCreationOfContracts = 0
+  # allowMultiSign = 0
+  # allowAdaptiveEnergy = 0
+  # allowDelegateResource = 0
+  # allowSameTokenName = 0
+  # allowTvmTransferTrc10 = 0
+  # allowTvmConstantinople = 0
+  # allowTvmSolidity059 = 0
+  # forbidTransferToContract = 0
+  # allowShieldedTRC20Transaction = 0
+  # allowTvmIstanbul = 0
+  # allowMarketTransaction = 0
+  # allowProtoFilterNum = 0
+  # allowAccountStateRoot = 0
+  # changedDelegation = 0
+  # allowPBFT = 0
+  # pBFTExpireNum = 0
+  # allowTransactionFeePool = 0
+  # allowBlackHoleOptimization = 0
+  # allowNewResourceModel = 0
+  # allowReceiptsMerkleRoot = 0
+  # allowTvmFreeze = 0
+  # allowTvmVote = 0
+  # unfreezeDelayDays = 0
+  # allowTvmLondon = 0
+  # allowTvmCompatibleEvm = 0
+  # allowNewRewardAlgorithm = 0
+  # allowAccountAssetOptimization = 0
+  # allowAssetOptimization = 0
+  # allowNewReward = 0
+  # memoFee = 0
+  # allowDelegateOptimization = 0
+  # allowDynamicEnergy = 0
+  # dynamicEnergyThreshold = 0
+  # dynamicEnergyMaxFactor = 0
+  # allowTvmShangHai = 0
+  # allowOldRewardOpt = 0
+  # allowEnergyAdjustment = 0
+  # allowStrictMath = 0
+  # allowTvmCancun = 0
+  # allowTvmBlob = 0
+  # consensusLogicOptimization = 0
+  # allowOptimizedReturnValueOfChainId = 0
+  # allowTvmOsaka = 0
+}
+
+event.subscribe = {
+  enable = false // enable event subscribe, replaces deprecated CLI flag --es
+  native = {
+    useNativeQueue = true // if true, use native message queue, else use event plugin.
+    bindport = 5555 // bind port
+    sendqueuelength = 1000 //max length of send queue
+  }
+  version = 0
+  # Specify the starting block number to sync historical events. This is only applicable when version = 1.
+  # After performing a full event sync, set this value to 0 or a negative number.
+  # startSyncBlockNum = 1
+
+  path = "" // absolute path of plugin
+  server = "" // target server address to receive event triggers
+  # dbname|username|password, if you want to create indexes for collections when the collections
+  # are not exist, you can add version and set it to 2, as dbname|username|password|version
+  # if you use version 2 and one collection not exists, it will create index automaticaly;
+  # if you use version 2 and one collection exists, it will not create index, you must create index manually;
+  dbconfig = ""
+  contractParse = true
+  topics = [
+    {
+      triggerName = "block" // block trigger, the value can't be modified
+      enable = false
+      topic = "block" // plugin topic, the value could be modified
+      solidified = false // if set true, just need solidified block. Default: false
+    },
+    {
+      triggerName = "transaction"
+      enable = false
+      topic = "transaction"
+      solidified = false
+      ethCompatible = false // if set true, add transactionIndex, cumulativeEnergyUsed, preCumulativeLogCount, logList, energyUnitPrice. Default: false
+    },
+    {
+      triggerName = "contractevent" // contractevent represents contractlog data decoded by the ABI.
+      enable = false
+      topic = "contractevent"
+    },
+    {
+      triggerName = "contractlog"
+      enable = false
+      topic = "contractlog"
+      redundancy = false // if set true, contractevent will also be regarded as contractlog
+    },
+    {
+      triggerName = "solidity" // solidity block trigger(just include solidity block number and timestamp), the value can't be modified
+      enable = true            // Default: true
+      topic = "solidity"
+    },
+    {
+      triggerName = "solidityevent"
+      enable = false
+      topic = "solidityevent"
+    },
+    {
+      triggerName = "soliditylog"
+      enable = false
+      topic = "soliditylog"
+      redundancy = false // if set true, solidityevent will also be regarded as soliditylog
+    }
+  ]
+
+  filter = {
+    fromblock = "" // the value could be "", "earliest" or a specified block number as the beginning of the queried range
+    toblock = "" // the value could be "", "latest" or a specified block number as end of the queried range
+    contractAddress = [
+      "" // contract address you want to subscribe, if it's set to "", you will receive contract logs/events with any contract address.
+    ]
+
+    contractTopic = [
+      "" // contract topic you want to subscribe, if it's set to "", you will receive contract logs/events with any contract topic.
+    ]
+  }
+}

--- a/internal/render/testdata/golden/mainnet-witness.compose.yaml
+++ b/internal/render/testdata/golden/mainnet-witness.compose.yaml
@@ -1,0 +1,29 @@
+services:
+  my-witness:
+    image: tronprotocol/java-tron
+    container_name: my-witness
+    restart: unless-stopped
+    ports:
+      - "8090:8090"
+      - "50051:50051"
+      - "18888:18888"
+      - "18888:18888/udp"
+      - "9527:9527"
+    volumes:
+      - ./my-witness.conf:/java-tron/conf/my-witness.conf:ro
+      - my-witness-data:/java-tron/output-directory
+      - my-witness-logs:/java-tron/logs
+    deploy:
+      resources:
+        limits:
+          memory: 32g
+    command:
+      - "-jvm"
+      - "{-Xmx14g -Xms14g -Xmn3g -XX:MaxDirectMemorySize=1g -XX:+UseG1GC -XX:G1HeapRegionSize=16m -XX:G1RSetUpdatingPauseTimePercent=5 -XX:InitiatingHeapOccupancyPercent=35 -XX:MaxGCPauseMillis=200 -Xlog:gc*:file=gc.log:time,uptime,level,tags:filecount=10,filesize=100m -XX:+HeapDumpOnOutOfMemoryError -XX:+UseTLAB}"
+      - "-c"
+      - "/java-tron/conf/my-witness.conf"
+      - "--witness"
+
+volumes:
+  my-witness-data:
+  my-witness-logs:

--- a/internal/render/testdata/golden/mainnet-witness.conf
+++ b/internal/render/testdata/golden/mainnet-witness.conf
@@ -1,0 +1,842 @@
+net {
+  # type is deprecated and has no effect.
+  # type = mainnet
+}
+
+storage {
+  # Directory for storing persistent data
+  db.engine = "LEVELDB",  // deprecated for arm, because arm only support  "ROCKSDB".
+  db.sync = false,
+  db.directory = "database",
+
+  # Whether to write transaction result in transactionRetStore
+  transHistory.switch = "on",
+
+  # setting can improve leveldb performance .... start, deprecated for arm
+  # node: if this will increase process fds,you may be check your ulimit if 'too many open files' error occurs
+  # see https://github.com/tronprotocol/tips/blob/master/tip-343.md for detail
+  # if you find block sync has lower performance, you can try this settings
+  # default = {
+  #  maxOpenFiles = 100
+  # }
+  # defaultM = {
+  #  maxOpenFiles = 500
+  # }
+  # defaultL = {
+  #  maxOpenFiles = 1000
+  # }
+  # setting can improve leveldb performance .... end, deprecated for arm
+
+  # You can customize the configuration for each database. Otherwise, the database settings will use
+  # their defaults, and data will be stored in the "output-directory" or in the directory specified
+  # by the "-d" or "--output-directory" option. Attention: name is a required field that must be set!
+  # In this configuration, the name and path properties take effect for both LevelDB and RocksDB storage engines,
+  # while the additional properties (such as createIfMissing, paranoidChecks, compressionType, etc.) only take effect when using LevelDB.
+  properties = [
+    #    {
+    #      name = "account",
+    #      path = "storage_directory_test",
+    #      createIfMissing = true, // deprecated for arm start
+    #      paranoidChecks = true,
+    #      verifyChecksums = true,
+    #      compressionType = 1,        // compressed with snappy
+    #      blockSize = 4096,           // 4  KB =         4 * 1024 B
+    #      writeBufferSize = 10485760, // 10 MB = 10 * 1024 * 1024 B
+    #      cacheSize = 10485760,       // 10 MB = 10 * 1024 * 1024 B
+    #      maxOpenFiles = 100 // deprecated for arm end
+    #    },
+    #    {
+    #      name = "account-index",
+    #      path = "storage_directory_test",
+    #      createIfMissing = true,
+    #      paranoidChecks = true,
+    #      verifyChecksums = true,
+    #      compressionType = 1,        // compressed with snappy
+    #      blockSize = 4096,           // 4  KB =         4 * 1024 B
+    #      writeBufferSize = 10485760, // 10 MB = 10 * 1024 * 1024 B
+    #      cacheSize = 10485760,       // 10 MB = 10 * 1024 * 1024 B
+    #      maxOpenFiles = 100
+    #    },
+  ]
+
+  needToUpdateAsset = true
+
+  # dbsettings is needed when using rocksdb as the storage implement (db.engine="ROCKSDB").
+  # we'd strongly recommend that do not modify it unless you know every item's meaning clearly.
+  dbSettings = {
+    levelNumber = 7
+    # compactThreads = 32
+    blocksize = 64  // n * KB
+    maxBytesForLevelBase = 256  // n * MB
+    maxBytesForLevelMultiplier = 10
+    level0FileNumCompactionTrigger = 4
+    targetFileSizeBase = 256  // n * MB
+    targetFileSizeMultiplier = 1
+    maxOpenFiles = 5000
+  }
+
+  balance.history.lookup = false
+
+  # checkpoint.version = 2
+  # checkpoint.sync = true
+
+  # the estimated number of block transactions (default 1000, min 100, max 10000).
+  # so the total number of cached transactions is 65536 * txCache.estimatedTransactions
+  # txCache.estimatedTransactions = 1000
+
+  # if true, transaction cache initialization will be faster. Default: false
+  txCache.initOptimization = true
+
+  # The number of blocks flushed to db in each batch during node syncing. Default: 1
+  # snapshot.maxFlushCount = 1
+
+  # data root setting, for check data, currently, only reward-vi is used.
+  # merkleRoot = {
+  # reward-vi = 9debcb9924055500aaae98cdee10501c5c39d4daa75800a996f4bdda73dbccd8 // main-net, Sha256Hash, hexString
+  # }
+
+}
+
+node.discovery = {
+  enable = true
+  persist = true
+}
+
+# custom stop condition
+#node.shutdown = {
+#  BlockTime  = "54 59 08 * * ?" # if block header time in persistent db matched.
+#  BlockHeight = 33350800 # if block header height in persistent db matched.
+#  BlockCount = 12 # block sync count after node start.
+#}
+
+node.backup {
+  # udp listen port, each member should have the same configuration
+  port = 10001
+
+  # my priority, each member should use different priority
+  priority = 8
+
+  # time interval to send keepAlive message, each member should have the same configuration
+  keepAliveInterval = 3000
+
+  # peer's ip list, can't contain mine
+  members = [
+    # "ip",
+    # "ip"
+  ]
+}
+
+# Specify the algorithm for generating a public key from private key. To avoid forks, please do not modify it
+crypto {
+  engine = "eckey"
+}
+
+node.metrics = {
+  # prometheus metrics
+  prometheus {
+    enable = false
+    port = 9527
+  }
+
+  # influxdb metrics
+  storageEnable = false # Whether write metrics data into InfluxDb. Default: false.
+  influxdb {
+    ip = ""
+    port = 8086
+    database = ""
+    metricsReportInterval = 10
+  }
+}
+
+node {
+  # trust node for solidity node
+  # trustNode = "ip:port"
+  trustNode = "127.0.0.1:50051"
+
+  # expose extension api to public or not
+  walletExtensionApi = true
+
+  listen.port = 18888
+
+  connection.timeout = 2
+
+  fetchBlock.timeout = 200
+  # syncFetchBatchNum = 2000
+
+  # Number of validate sign thread, default availableProcessors
+  # validateSignThreadNum = 16
+
+  maxConnections = 30
+
+  minConnections = 8
+
+  minActiveConnections = 3
+
+  maxConnectionsWithSameIp = 2
+
+  maxHttpConnectNumber = 50
+
+  minParticipationRate = 15
+
+  # allowShieldedTransactionApi = true
+
+  # openPrintLog = true
+
+  # If set to true, SR packs transactions into a block in descending order of fee; otherwise, it packs
+  # them based on their receive timestamp. Default: false
+  # openTransactionSort = false
+
+  # The threshold for the number of broadcast transactions received from each peer every second,
+  # transactions exceeding this threshold will be discarded
+  # maxTps = 1000
+
+  isOpenFullTcpDisconnect = false
+  inactiveThreshold = 600 //seconds
+
+  p2p {
+    version = 11111 # Mainnet:11111; Nile:201910292; Shasta:1
+  }
+
+  active = [
+    # Active establish connection in any case
+    # Sample entries:
+    # "ip:port",
+    # "ip:port"
+  ]
+
+  passive = [
+    # Passive accept connection in any case
+    # Sample entries:
+    # "ip:port",
+    # "ip:port"
+  ]
+
+  fastForward = [
+    "100.27.171.62:18888",
+    "15.188.6.125:18888"
+  ]
+
+  http {
+    fullNodeEnable = true
+    fullNodePort = 8090
+    solidityEnable = true
+    solidityPort = 8091
+    PBFTEnable = true
+    PBFTPort = 8092
+  }
+
+  rpc {
+    enable = true
+    port = 50051
+    solidityEnable = true
+    solidityPort = 50061
+    PBFTEnable = true
+    PBFTPort = 50071
+
+    # Number of gRPC thread, default availableProcessors / 2
+    # thread = 16
+
+    # The maximum number of concurrent calls permitted for each incoming connection
+    # maxConcurrentCallsPerConnection =
+
+    # The HTTP/2 flow control window, default 1MB
+    # flowControlWindow =
+
+    # Connection being idle for longer than which will be gracefully terminated
+    maxConnectionIdleInMillis = 60000
+
+    # Connection lasting longer than which will be gracefully terminated
+    # maxConnectionAgeInMillis =
+
+    # The maximum message size allowed to be received on the server, default 4MB
+    # maxMessageSize =
+
+    # The maximum size of header list allowed to be received, default 8192
+    # maxHeaderListSize =
+
+    # The number of RST_STREAM frames allowed to be sent per connection per period for grpc, by default there is no limit.
+    # maxRstStream =
+
+    # The number of seconds per period for grpc
+    # secondsPerWindow =
+
+    # Transactions can only be broadcast if the number of effective connections is reached.
+    minEffectiveConnection = 1
+
+    # The switch of the reflection service, effective for all gRPC services, used for grpcurl tool. Default: false
+    reflectionService = false
+  }
+
+  # number of solidity thread in the FullNode.
+  # If accessing solidity rpc and http interface timeout, could increase the number of threads,
+  # The default value is the number of cpu cores of the machine.
+  # solidity.threads = 8
+
+  # Limits the maximum percentage (default 75%) of producing block interval
+  # to provide sufficient time to perform other operations e.g. broadcast block
+  # blockProducedTimeOut = 75
+
+  # Limits the maximum number (default 700) of transaction from network layer
+  # netMaxTrxPerSecond = 700
+
+  # Whether to enable the node detection function. Default: false
+  # nodeDetectEnable = false
+
+  # use your ipv6 address for node discovery and tcp connection. Default: false
+  # enableIpv6 = false
+
+  # if your node's highest block num is below than all your pees', try to acquire new connection. Default: false
+  # effectiveCheckEnable = false
+
+  # Dynamic loading configuration function, disabled by default
+  dynamicConfig = {
+    # enable = false
+    # checkInterval = 600 // Check interval of Configuration file's change, default is 600 seconds
+  }
+
+  # Whether to continue broadcast transactions after at least maxUnsolidifiedBlocks are not solidified. Default: false
+  # unsolidifiedBlockCheck = false
+  # maxUnsolidifiedBlocks = 54
+
+  dns {
+    # dns urls to get nodes, url format tree://{pubkey}@{domain}, default empty
+    treeUrls = [
+      #"tree://AKMQMNAJJBL73LXWPXDI4I5ZWWIZ4AWO34DWQ636QOBBXNFXH3LQS@main.trondisco.net",
+    ]
+
+    # enable or disable dns publish. Default: false
+    # publish = false
+
+    # dns domain to publish nodes, required if publish is true
+    # dnsDomain = "nodes1.example.org"
+
+    # dns private key used to publish, required if publish is true, hex string of length 64
+    # dnsPrivate = "b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291"
+
+    # known dns urls to publish if publish is true, url format tree://{pubkey}@{domain}, default empty
+    # knownUrls = [
+    #"tree://APFGGTFOBVE2ZNAB3CSMNNX6RRK3ODIRLP2AA5U4YFAA6MSYZUYTQ@nodes2.example.org",
+    # ]
+
+    # staticNodes = [
+    # static nodes to published on dns
+    # Sample entries:
+    # "ip:port",
+    # "ip:port"
+    # ]
+
+    # merge several nodes into a leaf of tree, should be 1~5
+    # maxMergeSize = 5
+
+    # only nodes change percent is bigger then the threshold, we update data on dns
+    # changeThreshold = 0.1
+
+    # dns server to publish, required if publish is true, only aws or aliyun is support
+    # serverType = "aws"
+
+    # access key id of aws or aliyun api, required if publish is true, string
+    # accessKeyId = "your-key-id"
+
+    # access key secret of aws or aliyun api, required if publish is true, string
+    # accessKeySecret = "your-key-secret"
+
+    # if publish is true and serverType is aliyun, it's endpoint of aws dns server, string
+    # aliyunDnsEndpoint = "alidns.aliyuncs.com"
+
+    # if publish is true and serverType is aws, it's region of aws api, such as "eu-south-1", string
+    # awsRegion = "us-east-1"
+
+    # if publish is true and server-type is aws, it's host zone id of aws's domain, string
+    # awsHostZoneId = "your-host-zone-id"
+  }
+
+  # open the history query APIs(http&GRPC) when node is a lite FullNode,
+  # like {getBlockByNum, getBlockByID, getTransactionByID...}. Default: false.
+  # note: above APIs may return null even if blocks and transactions actually are on the blockchain
+  # when opening on a lite FullNode. only open it if the consequences being clearly known
+  # openHistoryQueryWhenLiteFN = false
+
+  jsonrpc {
+    # Note: Before release_4.8.1, if you turn on jsonrpc and run it for a while and then turn it off,
+    # you will not be able to get the data from eth_getLogs for that period of time. Default: false
+    # httpFullNodeEnable = false
+    # httpFullNodePort = 8545
+    # httpSolidityEnable = false
+    # httpSolidityPort = 8555
+    # httpPBFTEnable = false
+    # httpPBFTPort = 8565
+
+    # The maximum blocks range to retrieve logs for eth_getLogs, default value is 5000,
+    # should be > 0, otherwise means no limit.
+    maxBlockRange = 5000
+
+    # The maximum number of allowed topics within a topic criteria, default value is 1000,
+    # should be > 0, otherwise means no limit.
+    maxSubTopics = 1000
+    # Allowed maximum number for blockFilter
+    maxBlockFilterNum = 50000
+  }
+
+  # Disabled api list, it will work for http, rpc and pbft, both FullNode and SolidityNode,
+  # but not jsonrpc. The setting is case insensitive, GetNowBlock2 is equal to getnowblock2
+  disabledApi = [
+    #  "getaccount",
+    #  "getnowblock2"
+  ]
+
+}
+
+## rate limiter config
+rate.limiter = {
+  # Every api could only set a specific rate limit strategy. Three blocking strategy are supported:
+  # GlobalPreemptibleAdapter: The number of preemptible resource or maximum concurrent requests globally.
+  # QpsRateLimiterAdapter: qps is the average request count in one second supported by the server, it could be a Double or a Integer.
+  # IPQPSRateLimiterAdapter: similar to the QpsRateLimiterAdapter, qps could be a Double or a Integer.
+  # If not set, QpsRateLimiterAdapter with qps=1000 is the default strategy.
+  #
+  # Sample entries:
+  #
+  http = [
+    #  {
+    #    component = "GetNowBlockServlet",
+    #    strategy = "GlobalPreemptibleAdapter",
+    #    paramString = "permit=1"
+    #  },
+
+    #  {
+    #    component = "GetAccountServlet",
+    #    strategy = "IPQPSRateLimiterAdapter",
+    #    paramString = "qps=1"
+    #  },
+
+    #  {
+    #    component = "ListWitnessesServlet",
+    #    strategy = "QpsRateLimiterAdapter",
+    #    paramString = "qps=1"
+    #  }
+  ],
+
+  rpc = [
+    #  {
+    #    component = "protocol.Wallet/GetBlockByLatestNum2",
+    #    strategy = "GlobalPreemptibleAdapter",
+    #    paramString = "permit=1"
+    #  },
+
+    #  {
+    #    component = "protocol.Wallet/GetAccount",
+    #    strategy = "IPQPSRateLimiterAdapter",
+    #    paramString = "qps=1"
+    #  },
+
+    #  {
+    #    component = "protocol.Wallet/ListWitnesses",
+    #    strategy = "QpsRateLimiterAdapter",
+    #    paramString = "qps=1"
+    #  },
+  ]
+
+  p2p = {
+    # syncBlockChain = 3.0
+    # fetchInvData = 3.0
+    # disconnect = 1.0
+  }
+
+  # global qps, default 50000
+  global.qps = 50000
+  # IP-based global qps, default 10000
+  global.ip.qps = 10000
+}
+
+
+
+seed.node = {
+  # List of the seed nodes
+  # Seed nodes are stable full nodes
+  # example:
+  # ip.list = [
+  #   "ip:port",
+  #   "ip:port"
+  # ]
+  ip.list = [
+    "3.225.171.164:18888",
+    "52.8.46.215:18888",
+    "3.79.71.167:18888",
+    "108.128.110.16:18888",
+    "18.133.82.227:18888",
+    "35.180.81.133:18888",
+    "13.210.151.5:18888",
+    "18.231.27.82:18888",
+    "3.12.212.122:18888",
+    "52.24.128.7:18888",
+    "15.207.144.3:18888",
+    "3.39.38.55:18888",
+    "54.151.226.240:18888",
+    "35.174.93.198:18888",
+    "18.210.241.149:18888",
+    "54.177.115.127:18888",
+    "54.254.131.82:18888",
+    "18.167.171.167:18888",
+    "54.167.11.177:18888",
+    "35.74.7.196:18888",
+    "52.196.244.176:18888",
+    "54.248.129.19:18888",
+    "43.198.142.160:18888",
+    "3.0.214.7:18888",
+    "54.153.59.116:18888",
+    "54.153.94.160:18888",
+    "54.82.161.39:18888",
+    "54.179.207.68:18888",
+    "18.142.82.44:18888",
+    "18.163.230.203:18888",
+    # "[2a05:d014:1f2f:2600:1b15:921:d60b:4c60]:18888", // use this if support ipv6
+    # "[2600:1f18:7260:f400:8947:ebf3:78a0:282b]:18888", // use this if support ipv6
+  ]
+}
+
+genesis.block = {
+  # Reserve balance
+  assets = [
+    {
+      accountName = "Zion"
+      accountType = "AssetIssue"
+      address = "TLLM21wteSPs4hKjbxgmH1L6poyMjeTbHm"
+      balance = "99000000000000000"
+    },
+    {
+      accountName = "Sun"
+      accountType = "AssetIssue"
+      address = "TXmVpin5vq5gdZsciyyjdZgKRUju4st1wM"
+      balance = "0"
+    },
+    {
+      accountName = "Blackhole"
+      accountType = "AssetIssue"
+      address = "TLsV52sRDL79HXGGm9yzwKibb6BeruhUzy"
+      balance = "-9223372036854775808"
+    }
+  ]
+
+  witnesses = [
+    {
+      address: THKJYuUmMKKARNf7s2VT51g5uPY6KEqnat,
+      url = "http://GR1.com",
+      voteCount = 100000026
+    },
+    {
+      address: TVDmPWGYxgi5DNeW8hXrzrhY8Y6zgxPNg4,
+      url = "http://GR2.com",
+      voteCount = 100000025
+    },
+    {
+      address: TWKZN1JJPFydd5rMgMCV5aZTSiwmoksSZv,
+      url = "http://GR3.com",
+      voteCount = 100000024
+    },
+    {
+      address: TDarXEG2rAD57oa7JTK785Yb2Et32UzY32,
+      url = "http://GR4.com",
+      voteCount = 100000023
+    },
+    {
+      address: TAmFfS4Tmm8yKeoqZN8x51ASwdQBdnVizt,
+      url = "http://GR5.com",
+      voteCount = 100000022
+    },
+    {
+      address: TK6V5Pw2UWQWpySnZyCDZaAvu1y48oRgXN,
+      url = "http://GR6.com",
+      voteCount = 100000021
+    },
+    {
+      address: TGqFJPFiEqdZx52ZR4QcKHz4Zr3QXA24VL,
+      url = "http://GR7.com",
+      voteCount = 100000020
+    },
+    {
+      address: TC1ZCj9Ne3j5v3TLx5ZCDLD55MU9g3XqQW,
+      url = "http://GR8.com",
+      voteCount = 100000019
+    },
+    {
+      address: TWm3id3mrQ42guf7c4oVpYExyTYnEGy3JL,
+      url = "http://GR9.com",
+      voteCount = 100000018
+    },
+    {
+      address: TCvwc3FV3ssq2rD82rMmjhT4PVXYTsFcKV,
+      url = "http://GR10.com",
+      voteCount = 100000017
+    },
+    {
+      address: TFuC2Qge4GxA2U9abKxk1pw3YZvGM5XRir,
+      url = "http://GR11.com",
+      voteCount = 100000016
+    },
+    {
+      address: TNGoca1VHC6Y5Jd2B1VFpFEhizVk92Rz85,
+      url = "http://GR12.com",
+      voteCount = 100000015
+    },
+    {
+      address: TLCjmH6SqGK8twZ9XrBDWpBbfyvEXihhNS,
+      url = "http://GR13.com",
+      voteCount = 100000014
+    },
+    {
+      address: TEEzguTtCihbRPfjf1CvW8Euxz1kKuvtR9,
+      url = "http://GR14.com",
+      voteCount = 100000013
+    },
+    {
+      address: TZHvwiw9cehbMxrtTbmAexm9oPo4eFFvLS,
+      url = "http://GR15.com",
+      voteCount = 100000012
+    },
+    {
+      address: TGK6iAKgBmHeQyp5hn3imB71EDnFPkXiPR,
+      url = "http://GR16.com",
+      voteCount = 100000011
+    },
+    {
+      address: TLaqfGrxZ3dykAFps7M2B4gETTX1yixPgN,
+      url = "http://GR17.com",
+      voteCount = 100000010
+    },
+    {
+      address: TX3ZceVew6yLC5hWTXnjrUFtiFfUDGKGty,
+      url = "http://GR18.com",
+      voteCount = 100000009
+    },
+    {
+      address: TYednHaV9zXpnPchSywVpnseQxY9Pxw4do,
+      url = "http://GR19.com",
+      voteCount = 100000008
+    },
+    {
+      address: TCf5cqLffPccEY7hcsabiFnMfdipfyryvr,
+      url = "http://GR20.com",
+      voteCount = 100000007
+    },
+    {
+      address: TAa14iLEKPAetX49mzaxZmH6saRxcX7dT5,
+      url = "http://GR21.com",
+      voteCount = 100000006
+    },
+    {
+      address: TBYsHxDmFaRmfCF3jZNmgeJE8sDnTNKHbz,
+      url = "http://GR22.com",
+      voteCount = 100000005
+    },
+    {
+      address: TEVAq8dmSQyTYK7uP1ZnZpa6MBVR83GsV6,
+      url = "http://GR23.com",
+      voteCount = 100000004
+    },
+    {
+      address: TRKJzrZxN34YyB8aBqqPDt7g4fv6sieemz,
+      url = "http://GR24.com",
+      voteCount = 100000003
+    },
+    {
+      address: TRMP6SKeFUt5NtMLzJv8kdpYuHRnEGjGfe,
+      url = "http://GR25.com",
+      voteCount = 100000002
+    },
+    {
+      address: TDbNE1VajxjpgM5p7FyGNDASt3UVoFbiD3,
+      url = "http://GR26.com",
+      voteCount = 100000001
+    },
+    {
+      address: TLTDZBcPoJ8tZ6TTEeEqEvwYFk2wgotSfD,
+      url = "http://GR27.com",
+      voteCount = 100000000
+    }
+  ]
+
+  timestamp = "0" # Genesis block timestamp, milli seconds
+
+  parentHash = "0xe58f33f9baf9305dc6f82b9f1934ea8f0ade2defb951258d50167028c780351f"
+}
+
+# Optional. The default is empty. It is used when the witness account has set the witnessPermission.
+# When it is not empty, the localWitnessAccountAddress represents the address of the witness account,
+# and the localwitness is configured with the private key of the witnessPermissionAddress in the witness account.
+# When it is empty,the localwitness is configured with the private key of the witness account.
+# localWitnessAccountAddress =
+
+localwitness = [
+]
+
+# localwitnesskeystore = [
+#  "localwitnesskeystore.json"
+# ]
+
+block = {
+  needSyncCheck = true
+  maintenanceTimeInterval = 21600000 // 6 hours: 21600000(ms)
+  proposalExpireTime = 259200000 // default value: 3 days: 259200000(ms), Note: this value is controlled by committee proposal
+  # checkFrozenTime = 1 // for test only
+}
+
+# Transaction reference block, default is "solid", configure to "head" may cause TaPos error
+trx.reference.block = "solid" // "head" or "solid"
+
+# This property sets the number of milliseconds after the creation of the transaction that is expired, default value is  60000.
+# trx.expiration.timeInMilliseconds = 60000
+
+vm = {
+  supportConstant = false
+  maxEnergyLimitForConstant = 100000000
+  minTimeRatio = 0.0
+  maxTimeRatio = 5.0
+  saveInternalTx = false
+  # lruCacheSize = 500
+  # vmTrace = false
+
+  # Indicates whether the node stores featured internal transactions, such as freeze, vote and so on. Default: false.
+  # saveFeaturedInternalTx = false
+
+  # Indicates whether the node stores the details of the internal transactions generated by the CANCELALLUNFREEZEV2 opcode,
+  # such as bandwidth/energy/tronpower cancel amount. Default: false.
+  # saveCancelAllUnfreezeV2Details = false
+
+  # In rare cases, transactions that will be within the specified maximum execution time (default 10(ms)) are re-executed and packaged
+  # longRunningTime = 10
+
+  # Indicates whether the node support estimate energy API. Default: false.
+  # estimateEnergy = false
+
+  # Indicates the max retry time for executing transaction in estimating energy. Default 3.
+  # estimateEnergyMaxRetry = 3
+}
+
+# These parameters are designed for private chain testing only and cannot be freely switched on or off in production systems.
+committee = {
+  allowCreationOfContracts = 0  //mainnet:0 (reset by committee),test:1
+  allowAdaptiveEnergy = 0  //mainnet:0 (reset by committee),test:1
+  # allowCreationOfContracts = 0
+  # allowMultiSign = 0
+  # allowAdaptiveEnergy = 0
+  # allowDelegateResource = 0
+  # allowSameTokenName = 0
+  # allowTvmTransferTrc10 = 0
+  # allowTvmConstantinople = 0
+  # allowTvmSolidity059 = 0
+  # forbidTransferToContract = 0
+  # allowShieldedTRC20Transaction = 0
+  # allowTvmIstanbul = 0
+  # allowMarketTransaction = 0
+  # allowProtoFilterNum = 0
+  # allowAccountStateRoot = 0
+  # changedDelegation = 0
+  # allowPBFT = 0
+  # pBFTExpireNum = 0
+  # allowTransactionFeePool = 0
+  # allowBlackHoleOptimization = 0
+  # allowNewResourceModel = 0
+  # allowReceiptsMerkleRoot = 0
+  # allowTvmFreeze = 0
+  # allowTvmVote = 0
+  # unfreezeDelayDays = 0
+  # allowTvmLondon = 0
+  # allowTvmCompatibleEvm = 0
+  # allowNewRewardAlgorithm = 0
+  # allowAccountAssetOptimization = 0
+  # allowAssetOptimization = 0
+  # allowNewReward = 0
+  # memoFee = 0
+  # allowDelegateOptimization = 0
+  # allowDynamicEnergy = 0
+  # dynamicEnergyThreshold = 0
+  # dynamicEnergyMaxFactor = 0
+  # allowTvmShangHai = 0
+  # allowOldRewardOpt = 0
+  # allowEnergyAdjustment = 0
+  # allowStrictMath = 0
+  # allowTvmCancun = 0
+  # allowTvmBlob = 0
+  # consensusLogicOptimization = 0
+  # allowOptimizedReturnValueOfChainId = 0
+  # allowTvmOsaka = 0
+}
+
+event.subscribe = {
+  enable = false // enable event subscribe, replaces deprecated CLI flag --es
+  native = {
+    useNativeQueue = true // if true, use native message queue, else use event plugin.
+    bindport = 5555 // bind port
+    sendqueuelength = 1000 //max length of send queue
+  }
+  version = 0
+  # Specify the starting block number to sync historical events. This is only applicable when version = 1.
+  # After performing a full event sync, set this value to 0 or a negative number.
+  # startSyncBlockNum = 1
+
+  path = "" // absolute path of plugin
+  server = "" // target server address to receive event triggers
+  # dbname|username|password, if you want to create indexes for collections when the collections
+  # are not exist, you can add version and set it to 2, as dbname|username|password|version
+  # if you use version 2 and one collection not exists, it will create index automaticaly;
+  # if you use version 2 and one collection exists, it will not create index, you must create index manually;
+  dbconfig = ""
+  contractParse = true
+  topics = [
+    {
+      triggerName = "block" // block trigger, the value can't be modified
+      enable = false
+      topic = "block" // plugin topic, the value could be modified
+      solidified = false // if set true, just need solidified block. Default: false
+    },
+    {
+      triggerName = "transaction"
+      enable = false
+      topic = "transaction"
+      solidified = false
+      ethCompatible = false // if set true, add transactionIndex, cumulativeEnergyUsed, preCumulativeLogCount, logList, energyUnitPrice. Default: false
+    },
+    {
+      triggerName = "contractevent" // contractevent represents contractlog data decoded by the ABI.
+      enable = false
+      topic = "contractevent"
+    },
+    {
+      triggerName = "contractlog"
+      enable = false
+      topic = "contractlog"
+      redundancy = false // if set true, contractevent will also be regarded as contractlog
+    },
+    {
+      triggerName = "solidity" // solidity block trigger(just include solidity block number and timestamp), the value can't be modified
+      enable = true            // Default: true
+      topic = "solidity"
+    },
+    {
+      triggerName = "solidityevent"
+      enable = false
+      topic = "solidityevent"
+    },
+    {
+      triggerName = "soliditylog"
+      enable = false
+      topic = "soliditylog"
+      redundancy = false // if set true, solidityevent will also be regarded as soliditylog
+    }
+  ]
+
+  filter = {
+    fromblock = "" // the value could be "", "earliest" or a specified block number as the beginning of the queried range
+    toblock = "" // the value could be "", "latest" or a specified block number as end of the queried range
+    contractAddress = [
+      "" // contract address you want to subscribe, if it's set to "", you will receive contract logs/events with any contract address.
+    ]
+
+    contractTopic = [
+      "" // contract topic you want to subscribe, if it's set to "", you will receive contract logs/events with any contract topic.
+    ]
+  }
+}
+
+# === trond overrides (last-write-wins) ===
+localwitness = ["<UNSET:SR_PRIVATE_KEY>"]

--- a/internal/render/testdata/golden/nile-fullnode.compose.yaml
+++ b/internal/render/testdata/golden/nile-fullnode.compose.yaml
@@ -1,0 +1,28 @@
+services:
+  nile-fullnode:
+    image: tronprotocol/java-tron
+    container_name: nile-fullnode
+    restart: unless-stopped
+    ports:
+      - "8090:8090"
+      - "50051:50051"
+      - "18888:18888"
+      - "18888:18888/udp"
+      - "8545:8545"
+    volumes:
+      - ./nile-fullnode.conf:/java-tron/conf/nile-fullnode.conf:ro
+      - nile-fullnode-data:/java-tron/output-directory
+      - nile-fullnode-logs:/java-tron/logs
+    deploy:
+      resources:
+        limits:
+          memory: 8g
+    command:
+      - "-jvm"
+      - "{-Xmx4g -Xms4g -Xmn1g -XX:MaxDirectMemorySize=512m -XX:+HeapDumpOnOutOfMemoryError -XX:+UseTLAB}"
+      - "-c"
+      - "/java-tron/conf/nile-fullnode.conf"
+
+volumes:
+  nile-fullnode-data:
+  nile-fullnode-logs:

--- a/internal/render/testdata/golden/nile-fullnode.conf
+++ b/internal/render/testdata/golden/nile-fullnode.conf
@@ -1,0 +1,589 @@
+net {
+  type = mainnet
+  # type = testnet
+}
+
+storage {
+  # Directory for storing persistent data
+  db.version = 2,
+  db.engine = "LEVELDB",
+  db.sync = false,
+  db.directory = "database",
+  index.directory = "index",
+  transHistory.switch = "on",
+  # You can custom these 14 databases' configs:
+
+  # account, account-index, asset-issue, block, block-index,
+  # block_KDB, peers, properties, recent-block, trans,
+  # utxo, votes, witness, witness_schedule.
+
+  # Otherwise, db configs will remain defualt and data will be stored in
+  # the path of "output-directory" or which is set by "-d" ("--output-directory").
+
+  # Attention: name is a required field that must be set !!!
+  properties = [
+    //    {
+    //      name = "account",
+    //      path = "storage_directory_test",
+    //      createIfMissing = true,
+    //      paranoidChecks = true,
+    //      verifyChecksums = true,
+    //      compressionType = 1,        // compressed with snappy
+    //      blockSize = 4096,           // 4  KB =         4 * 1024 B
+    //      writeBufferSize = 10485760, // 10 MB = 10 * 1024 * 1024 B
+    //      cacheSize = 10485760,       // 10 MB = 10 * 1024 * 1024 B
+    //      maxOpenFiles = 100
+    //    },
+    //    {
+    //      name = "account-index",
+    //      path = "storage_directory_test",
+    //      createIfMissing = true,
+    //      paranoidChecks = true,
+    //      verifyChecksums = true,
+    //      compressionType = 1,        // compressed with snappy
+    //      blockSize = 4096,           // 4  KB =         4 * 1024 B
+    //      writeBufferSize = 10485760, // 10 MB = 10 * 1024 * 1024 B
+    //      cacheSize = 10485760,       // 10 MB = 10 * 1024 * 1024 B
+    //      maxOpenFiles = 100
+    //    },
+  ]
+
+  needToUpdateAsset = true
+
+  //dbsettings is needed when using rocksdb as the storage implement (db.version=2 and db.engine="ROCKSDB").
+  //we'd strongly recommend that do not modify it unless you know every item's meaning clearly.
+  dbSettings = {
+    levelNumber = 7
+    //compactThreads = 32
+    blocksize = 64  // n * KB
+    maxBytesForLevelBase = 256  // n * MB
+    maxBytesForLevelMultiplier = 10
+    level0FileNumCompactionTrigger = 4
+    targetFileSizeBase = 256  // n * MB
+    targetFileSizeMultiplier = 1
+  }
+
+  //backup settings when using rocks db as the storage implement (db.version=2 and db.engine="ROCKSDB").
+  //if you want to use the backup plugin, please confirm set the db.version=2 and db.engine="ROCKSDB" above.
+  backup = {
+    enable = false  // indicate whether enable the backup plugin
+    propPath = "prop.properties" // record which bak directory is valid
+    bak1path = "bak1/database" // you must set two backup directories to prevent application halt unexpected(e.g. kill -9).
+    bak2path = "bak2/database"
+    frequency = 10000   // indicate backup db once every 10000 blocks processed.
+  }
+  
+  # if true, transaction cache initialization will be faster. default false
+  # txCache.initOptimization = true
+
+  # data root setting, for check data, currently, only reward-vi is used.
+  merkleRoot = {
+    reward-vi = b474b61f93824cd70106f8f5283fa740d61b83a7d57a3c12401d627f1fae0a77
+  }
+}
+
+node.discovery = {
+  enable = true
+  persist = true
+  bind.ip = ""
+  external.ip = null
+}
+
+
+
+node.backup {
+  port = 10001
+
+  # my priority, each member should use different priority
+  priority = 8
+
+  # peer's ip list, can't contain mine
+  members = [
+    # "ip",
+    # "ip"
+  ]
+}
+
+
+
+node {
+  # trust node for solidity node
+  # trustNode = "ip:port"
+  trustNode = "127.0.0.1:50051"
+
+  # expose extension api to public or not
+  walletExtensionApi = true
+
+  listen.port = 18888
+
+  connection.timeout = 2
+
+  tcpNettyWorkThreadNum = 0
+
+  udpNettyWorkThreadNum = 1
+
+  # Number of validate sign thread, default availableProcessors / 2
+  # validateSignThreadNum = 16
+
+  maxConnections = 30
+
+  minConnections = 8
+
+  minActiveConnections = 3
+
+  maxActiveNodesWithSameIp = 2
+
+  maxHttpConnectNumber = 50
+
+  minParticipationRate = 15
+
+  zenTokenId = 1000016
+
+  # check the peer data transfer ,disconnect factor
+  disconnectNumberFactor = 0.4
+  maxConnectNumberFactor = 0.8
+  receiveTcpMinDataLength = 2048
+  isOpenFullTcpDisconnect = true
+
+  p2p {
+    version = 201910292
+  }
+
+  active = [
+    # Active establish connection in any case
+    # Sample entries:
+    # "ip:port",
+    # "ip:port"
+  ]
+
+  passive = [
+    # Passive accept connection in any case
+    # Sample entries:
+    # "ip:port",
+    # "ip:port"
+  ]
+
+  # read node.active and node.passive periodically, default false
+  # checkInterval unit: second
+  dynamicConfig {
+    # enable = false
+    # checkInterval = 600
+  }
+
+  fastForward = [
+  ]
+
+  http {
+    fullNodePort = 8090
+    solidityPort = 8091
+  }
+
+  # use your ipv6 address for node discovery and tcp connection, default false
+  # enableIpv6 = false
+
+  # if your node's highest block num is below than all your pees', try to acquire new connection. default false
+  # effectiveCheckEnable = false
+
+  # Enable node detect
+  # nodeDetectEnable = false
+
+  dns {
+    # dns urls to get nodes, url format tree://{pubkey}@{domain}, default empty
+    treeUrls = [
+      #"tree://APFGGTFOBVE2ZNAB3CSMNNX6RRK3ODIRLP2AA5U4YFAA6MSYZUYTQ@nodes1.example.org",
+    ]
+  }
+
+  rpc {
+    port = 50051
+    #solidityPort = 50061
+    # Number of gRPC thread, default availableProcessors / 2
+    # thread = 16
+
+    # The maximum number of concurrent calls permitted for each incoming connection
+    # maxConcurrentCallsPerConnection =
+
+    # The HTTP/2 flow control window, default 1MB
+    # flowControlWindow =
+
+    # Connection being idle for longer than which will be gracefully terminated
+    maxConnectionIdleInMillis = 60000
+
+    # Connection lasting longer than which will be gracefully terminated
+    # maxConnectionAgeInMillis =
+
+    # The maximum message size allowed to be received on the server, default 4MB
+    # maxMessageSize =
+
+    # The maximum size of header list allowed to be received, default 8192
+    # maxHeaderListSize =
+
+    # Transactions can only be broadcast if the number of effective connections is reached.
+    minEffectiveConnection = 1
+
+    # The switch of the reflection service, effective for all gRPC services
+    # reflectionService = true
+  }
+
+  # number of solidity thread in the FullNode.
+  # If accessing solidity rpc and http interface timeout, could increase the number of threads,
+  # The default value is the number of cpu cores of the machine.
+  #solidity.threads = 8
+
+  # Limits the maximum percentage (default 75%) of producing block interval
+  # to provide sufficient time to perform other operations e.g. broadcast block
+  # blockProducedTimeOut = 75
+
+  # Limits the maximum number (default 700) of transaction from network layer
+  # netMaxTrxPerSecond = 700
+
+  jsonrpc {
+    # Note: If you turn on jsonrpc and run it for a while and then turn it off, you will not
+    # be able to get the data from eth_getLogs for that period of time.
+
+    httpFullNodeEnable = true
+    # httpFullNodePort = 8545
+    # httpSolidityEnable = true
+    # httpSolidityPort = 8555
+    # httpPBFTEnable = true
+    # httpPBFTPort = 8565
+
+    # The maximum blocks range to retrieve logs for eth_getLogs, default value is 5000,
+    # should be > 0, otherwise means no limit.
+    # maxBlockRange = 5000
+
+    # The maximum number of allowed topics within a topic criteria, default value is 1000,
+    # should be > 0, otherwise means no limit.
+    # maxSubTopics = 1000
+  }
+
+}
+
+## rate limiter config
+rate.limiter = {
+  # Use global settings to limit the QPS of the entire node or every ip address
+  # global.qps = 1000
+  # global.ip.qps = 100
+
+  # Every api could be set a specific rate limit strategy. Three strategy are supported：GlobalPreemptibleAdapter、IPQPSRateLimiterAdapte、QpsRateLimiterAdapter
+  # GlobalPreemptibleAdapter: permit is the number of preemptible resource, every client must apply one resourse
+  #       before do the request and release the resource after got the reponse automaticlly. permit should be a Integer.
+  # QpsRateLimiterAdapter: qps is the average request count in one second supported by the server, it could be a Double or a Integer.
+  # IPQPSRateLimiterAdapter: similar to the QpsRateLimiterAdapter, qps could be a Double or a Integer.
+  # If do not set, the "default strategy" is set.The "default startegy" is based on QpsRateLimiterAdapter, the qps is set as 10000.
+  #
+  # Sample entries:
+  #
+  http = [
+    #  {
+    #    component = "GetNowBlockServlet",
+    #    strategy = "GlobalPreemptibleAdapter",
+    #    paramString = "permit=1"
+    #  },
+
+    #  {
+    #    component = "GetAccountServlet",
+    #    strategy = "IPQPSRateLimiterAdapter",
+    #    paramString = "qps=1"
+    #  },
+
+    #  {
+    #    component = "ListWitnessesServlet",
+    #    strategy = "QpsRateLimiterAdapter",
+    #    paramString = "qps=1"
+    #  }
+  ],
+
+  rpc = [
+    #  {
+    #    component = "protocol.Wallet/GetBlockByLatestNum2",
+    #    strategy = "GlobalPreemptibleAdapter",
+    #    paramString = "permit=1"
+    #  },
+
+    #  {
+    #    component = "protocol.Wallet/GetAccount",
+    #    strategy = "IPQPSRateLimiterAdapter",
+    #    paramString = "qps=1"
+    #  },
+
+    #  {
+    #    component = "protocol.Wallet/ListWitnesses",
+    #    strategy = "QpsRateLimiterAdapter",
+    #    paramString = "qps=1"
+    #  },
+  ]
+}
+
+
+seed.node = {
+  # List of the seed nodes
+  # Seed nodes are stable full nodes
+  # example:
+  # ip.list = [
+  #   "ip:port",
+  #   "ip:port"
+  # ]
+  ip.list = [
+    "44.236.192.97:18888",
+    "44.236.125.107:18888",
+    "44.232.119.174:18888",
+    "52.39.105.180:18888",
+    "54.70.52.47:18888"
+  ]
+}
+
+genesis.block = {
+  # Reserve balance
+  assets = [
+    {
+      accountName = "Zion"
+      accountType = "AssetIssue"
+      address = "TMWXhuxiT1KczhBxCseCDDsrhmpYGUcoA9"
+      balance = "99000000000000000"
+    },
+    {
+      accountName = "Sun"
+      accountType = "AssetIssue"
+      address = "TN21Wx2yoNYiZ7znuQonmZMJnH5Vdfxu78"
+      balance = "99000000000000000"
+    },
+    {
+      accountName = "Blackhole"
+      accountType = "AssetIssue"
+      address = "TDPJULRzVtzVjnBmZvfaTcTNQ2tsVi6XxQ"
+      balance = "-9223372036854775808"
+    }
+  ]
+
+  witnesses = [
+    {
+      address: TD23EqH3ixYMYh8CMXKdHyQWjePi3KQvxV,
+      url = "http://GR1.com",
+      voteCount = 100000026
+    },
+    {
+      address: TCm4Lz1uP3tQm3jzpwFTG6o5UvSTA2XEHc,
+      url = "http://GR2.com",
+      voteCount = 100000025
+    },
+    {
+      address: TTgDUgREiPBeY3iudD5e2eEibE4v4CE8C9,
+      url = "http://GR3.com",
+      voteCount = 100000024
+    },
+    {
+      address: TFVDe7kMEmb8EuUxxp42kocQY1fFY727WS,
+      url = "http://GR4.com",
+      voteCount = 100000023
+    },
+    {
+      address: TY4NSjctzTchHkhaCskVc5zQtnX9s1uxAX,
+      url = "http://GR5.com",
+      voteCount = 100000022
+    },
+    {
+      address: TWSMPrm6aizvsJmPnjMB7x3UExJfRhyQhd,
+      url = "http://GR6.com",
+      voteCount = 100000021
+    },
+    {
+      address: TKwLkSaCvqqpAB44qaHGTohCTCFoYw7ecy,
+      url = "http://GR7.com",
+      voteCount = 100000020
+    },
+    {
+      address: TDsYmm1St9r4UZebDGWBcTMtfYTw9YX5h4,
+      url = "http://GR8.com",
+      voteCount = 100000019
+    },
+    {
+      address: TFEQbWAPxhbUr1P14y9UJBUZo3LgtdqTS7,
+      url = "http://GR9.com",
+      voteCount = 100000018
+    },
+    {
+      address: TCynAi8tb7UWP7uhLv6fe971KLm2KT8tcs,
+      url = "http://GR10.com",
+      voteCount = 100000017
+    },
+    {
+      address: TC2YsLp4rzrt3AbeN3EryoSywrBjEUVCq3,
+      url = "http://GR11.com",
+      voteCount = 100000016
+    },
+    {
+      address: THxMKH1uaL5FpURujkQR7u2sNZ2n5PSsiH,
+      url = "http://GR12.com",
+      voteCount = 100000015
+    },
+    {
+      address: TWbzgoHimDcXWy19ts1An8bxA4JKjcYHeG,
+      url = "http://GR13.com",
+      voteCount = 100000014
+    },
+    {
+      address: TW2LmXnVCEaxuVtQN8gZR1ixT5PNm4QLft,
+      url = "http://GR14.com",
+      voteCount = 100000013
+    },
+    {
+      address: TVuqk4rYYVHVA6j6sSEnaLexhhoQhN8nyZ,
+      url = "http://GR15.com",
+      voteCount = 100000012
+    },
+    {
+      address: TVMZu5ptZPhhkZ3Kaagkq35FmyuKNvUKJV,
+      url = "http://GR16.com",
+      voteCount = 100000011
+    },
+    {
+      address: TFDHT8PqUrL2Bd8DeysSiHHBAEMidZgkhx,
+      url = "http://GR17.com",
+      voteCount = 100000010
+    },
+    {
+      address: TVqz5Bj3M1uEenaSsw2NnXvTWChPj6K3hb,
+      url = "http://GR18.com",
+      voteCount = 100000009
+    },
+    {
+      address: TSt8YNpARJkhdMdEV4C7ajH1tFHpZWzF1T,
+      url = "http://GR19.com",
+      voteCount = 100000008
+    },
+    {
+      address: TTxWDjEb3Be1Ax8BCvK48cnaorZofLq2C9,
+      url = "http://GR20.com",
+      voteCount = 100000007
+    },
+    {
+      address: TU5T838YtyZtEQKpnXEdRz3d8hJn6WHhjw,
+      url = "http://GR21.com",
+      voteCount = 100000006
+    },
+    {
+      address: TRuSs1MpL3o2hzhU8r6HLC7WtDyVE9hsF6,
+      url = "http://GR22.com",
+      voteCount = 100000005
+    },
+    {
+      address: TYMCoCZyAjWkWdUfEHg1oZQYbLKev282ou,
+      url = "http://GR23.com",
+      voteCount = 100000004
+    },
+    {
+      address: TQvAyGATpLZymHbpeaRozJCKqSeRWVNhCJ,
+      url = "http://GR24.com",
+      voteCount = 100000003
+    },
+    {
+      address: TYDd9nskbhJmLLNoe4yV2Z1SYtGjNa8wyg,
+      url = "http://GR25.com",
+      voteCount = 100000002
+    },
+    {
+      address: TS5991Geh2qeHtw46rskpJyn6hFNbuZGGc,
+      url = "http://GR26.com",
+      voteCount = 100000001
+    },
+    {
+      address: TKnn5MBnmXXeKdu9dxKVfKk4n1YdCeSRGr,
+      url = "http://GR27.com",
+      voteCount = 100000000
+    }
+  ]
+
+  timestamp = "0" #2017-8-26 12:00:00
+
+  parentHash = "0xe58f33f9baf9305dc6f82b9f1934ea8f0ade2defb951258d50167028c780351f"
+}
+
+// Optional.The default is empty.
+// It is used when the witness account has set the witnessPermission.
+// When it is not empty, the localWitnessAccountAddress represents the address of the witness account,
+// and the localwitness is configured with the private key of the witnessPermissionAddress in the witness account.
+// When it is empty,the localwitness is configured with the private key of the witness account.
+
+//localWitnessAccountAddress =
+
+#localwitnesskeystore = [
+#  "localwitnesskeystore.json"
+#]
+
+block = {
+  needSyncCheck = false
+  maintenanceTimeInterval = 600000
+  proposalExpireTime = 600000 //
+}
+
+# Transaction reference block, default is "head", configure to "solid" can avoid TaPos error
+# trx.reference.block = "head" // head;solid;
+
+# This property sets the number of milliseconds after the creation of the transaction that is expired, default value is  60000.
+# trx.expiration.timeInMilliseconds = 60000
+
+vm = {
+  supportConstant =true
+  minTimeRatio = 0.0
+  maxTimeRatio = 5.0
+  saveInternalTx = true
+  saveFeaturedInternalTx = true
+  saveCancelAllUnfreezeV2Details = true
+
+  # In rare cases, transactions that will be within the specified maximum execution time (default 10(ms)) are re-executed and packaged
+  # longRunningTime = 10
+}
+
+committee = {
+  allowCreationOfContracts = 0  //mainnet:0 (reset by committee),test:1
+  allowAdaptiveEnergy = 0  //mainnet:0 (reset by committee),test:1
+}
+
+event.subscribe = {
+  native = {
+    useNativeQueue = true // if true, use native message queue, else use event plugin.
+    bindport = 5555 // bind port
+    sendqueuelength = 1000 //max length of send queue
+  }
+
+  path = "" // absolute path of plugin
+  server = "" // target server address to receive event triggers
+  dbconfig = "" // dbname|username|password
+  contractParse = true,
+  topics = [
+    {
+      triggerName = "block" // block trigger, the value can't be modified
+      enable = false
+      topic = "block" // plugin topic, the value could be modified
+    },
+    {
+      triggerName = "transaction"
+      enable = false
+      topic = "transaction"
+    },
+    {
+      triggerName = "contractevent"
+      enable = false
+      topic = "contractevent"
+    },
+    {
+      triggerName = "contractlog"
+      enable = false
+      topic = "contractlog"
+    }
+  ]
+
+  filter = {
+    fromblock = "" // the value could be "", "earliest" or a specified block number as the beginning of the queried range
+    toblock = "" // the value could be "", "latest" or a specified block number as end of the queried range
+    contractAddress = [
+      "" // contract address you want to subscribe, if it's set to "", you will receive contract logs/events with any contract address.
+    ]
+
+    contractTopic = [
+      "" // contract topic you want to subscribe, if it's set to "", you will receive contract logs/events with any contract topic.
+    ]
+  }
+}
+                            

--- a/internal/security/time_test.go
+++ b/internal/security/time_test.go
@@ -1,0 +1,56 @@
+package security
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestAuditLog_TimestampUTC pins the contract that audit log entries
+// always emit timestamps in UTC. SIEM ingest pipelines often correlate
+// across hosts; if some entries were in local time and some in UTC,
+// timeline reconstruction would be off by hours.
+func TestAuditLog_TimestampUTC(t *testing.T) {
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, "audit.log")
+	al, err := NewAuditLog(logPath)
+	if err != nil {
+		t.Fatalf("NewAuditLog: %v", err)
+	}
+	if err := al.Write(AuditEntry{
+		Command: "test", Result: "success", Target: "local",
+	}); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	body, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	scanner := bytes.NewReader(bytes.TrimSpace(body))
+	var entry AuditEntry
+	if err := json.NewDecoder(scanner).Decode(&entry); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	// time.Time.MarshalJSON uses RFC3339Nano. UTC entries end in
+	// "Z"; local-time entries end in a numeric offset like "+08:00".
+	stamp, err := json.Marshal(entry.Timestamp)
+	if err != nil {
+		t.Fatalf("re-marshal: %v", err)
+	}
+	stampStr := strings.Trim(string(stamp), `"`)
+	if !strings.HasSuffix(stampStr, "Z") {
+		t.Errorf("timestamp not UTC (must end in 'Z'): %s", stampStr)
+	}
+
+	// Sanity: timezone offset is zero relative to UTC.
+	loc := entry.Timestamp.Location()
+	if loc != time.UTC && loc.String() != "UTC" {
+		t.Errorf("timestamp location: want UTC, got %s", loc)
+	}
+}

--- a/internal/snapshot/prune_boundary_test.go
+++ b/internal/snapshot/prune_boundary_test.go
@@ -1,0 +1,71 @@
+package snapshot
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// TestListJobs_HandlesFutureStartedAt verifies that a job written
+// with a StartedAt in the future (clock skew, manual edit, restored
+// backup) does not break ListJobs sorting. Earlier this would put
+// the future job at the top and silently mask all the real recent
+// activity.
+func TestListJobs_HandlesFutureStartedAt(t *testing.T) {
+	dir := t.TempDir()
+
+	// Plant three manifests: two "normal", one in the future.
+	must := func(j Job) {
+		t.Helper()
+		if err := WriteJob(dir, j); err != nil {
+			t.Fatalf("WriteJob: %v", err)
+		}
+	}
+	now := time.Now().UTC()
+	must(Job{ID: "old", PID: 1, StartedAt: now.Add(-2 * time.Hour)})
+	must(Job{ID: "mid", PID: 2, StartedAt: now.Add(-1 * time.Hour)})
+	must(Job{ID: "future", PID: 3, StartedAt: now.Add(+1 * time.Hour)})
+
+	jobs, err := ListJobs(dir)
+	if err != nil {
+		t.Fatalf("ListJobs: %v", err)
+	}
+	if len(jobs) != 3 {
+		t.Fatalf("expected 3 jobs, got %d", len(jobs))
+	}
+	// Sort order is newest-first by StartedAt — "future" comes
+	// first; the test asserts the function doesn't panic / drop a
+	// job, regardless of skew.
+	if jobs[0].ID != "future" {
+		t.Errorf("expected future first, got %s", jobs[0].ID)
+	}
+	if jobs[2].ID != "old" {
+		t.Errorf("expected old last, got %s", jobs[2].ID)
+	}
+}
+
+// TestRemoveJob_LogAndManifest verifies that RemoveJob removes both
+// the .json and .log files. Half-removed jobs (manifest gone, log
+// remaining) would leak disk space across upgrades.
+func TestRemoveJob_LogAndManifest(t *testing.T) {
+	dir := t.TempDir()
+
+	if err := WriteJob(dir, Job{ID: "x", PID: 1, StartedAt: time.Now().UTC()}); err != nil {
+		t.Fatalf("WriteJob: %v", err)
+	}
+	logPath := filepath.Join(dir, "x.log")
+	if err := os.WriteFile(logPath, []byte("hi"), 0o644); err != nil {
+		t.Fatalf("write log: %v", err)
+	}
+
+	if err := RemoveJob(dir, "x"); err != nil {
+		t.Fatalf("RemoveJob: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "x.json")); !os.IsNotExist(err) {
+		t.Errorf("manifest not removed: %v", err)
+	}
+	if _, err := os.Stat(logPath); !os.IsNotExist(err) {
+		t.Errorf("log not removed: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

Round 5 of the contract test arc. Stacks on the four merged round 1–4 PRs (#159–#162) — those landed on develop earlier today.

## Tests added

| File | Layer | Coverage |
|---|---|---|
| \`internal/render/golden_test.go\` | unit | HOCON + compose output captured as golden files; drift fails CI |
| \`cmd/peering_e2e_test.go\` | e2e (Docker) | 2-node private network can resolve sibling container names |
| \`internal/security/time_test.go\` | unit | audit log timestamps are UTC |
| \`internal/snapshot/prune_boundary_test.go\` | unit | future-skewed StartedAt + RemoveJob log+manifest cleanup |
| \`internal/intent/utf8_test.go\` | unit | UTF-8 labels round-trip; NUL bytes in name rejected |

## Bug caught + fixed

**Multi-node private networks couldn't peer.** \`cmd/network/create.go\` deploys each node with its own \`docker compose -p <node> up\`, giving every node a per-project bridge network. Sibling containers can't resolve each other by name; the auto-wired \`active_peers\` list (\`<node>:<port>\` hostnames) returns NXDOMAIN at runtime. Real users running \`trond network create\` against \`private-network.yaml\` would see a deployment that succeeds but never produces blocks.

**Fix**: \`network create\` now creates a shared docker network \`trond-<intent.name>\` up front (idempotent inspect-then-create) and attaches every node to it. \`network destroy\` tears the shared network down on the way out.

## Tooling

- \`make update-render-golden\` regenerates the testdata/golden/* files after intentional template changes (mirrors the existing \`snapshot-schema-baseline\` workflow).

## Test plan

- [x] \`go test -race ./...\`
- [x] \`go test -tags=e2e ./cmd/ -run TestE2E_Network_Peering\` (9s)
- [x] \`make lint\`
- [x] \`make update-render-golden\` regenerates cleanly