### PR TITLE
mcp: expose Resources + Prompts in addition to Tools

### DIFF
--- a/internal/mcp/prompts.go
+++ b/internal/mcp/prompts.go
@@ -1,0 +1,202 @@
+package mcp
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// registerPrompts wires the canonical agent-driven workflows as MCP
+// prompt templates. MCP-aware clients (Claude Desktop, Cursor)
+// surface these in a slash-command picker; the user picks one, fills
+// the arguments, and the LLM gets a structured prompt that already
+// understands the trond context.
+//
+// Why: tools alone require the agent to remember the right sequence
+// (validate → plan → apply, diagnose → rollback → verify, etc.).
+// Prompts pre-bake the workflow so a less-capable agent or a fresh
+// session lands on the right path immediately.
+//
+// Each prompt's output is a system+user message pair that:
+//  1. Tells the LLM which trond tools to call and in what order.
+//  2. Declares which arguments map to which tool inputs.
+//  3. Includes the canonical AGENTS.md retry semantics (exit codes,
+//     structured envelope conventions).
+func registerPrompts(s *mcp.Server) {
+	s.AddPrompt(&mcp.Prompt{
+		Name:        "deploy_fullnode",
+		Title:       "Deploy a TRON fullnode",
+		Description: "Walk through the canonical deploy workflow for a single fullnode: validate intent → plan → apply --auto-approve --wait → status. Use this when the user wants to bring up a new fullnode end-to-end.",
+		Arguments: []*mcp.PromptArgument{
+			{Name: "intent_path", Description: "absolute path to the intent.yaml", Required: true},
+		},
+	}, deployFullnodePrompt)
+
+	s.AddPrompt(&mcp.Prompt{
+		Name:        "diagnose_failing_node",
+		Title:       "Triage a failing node",
+		Description: "Apply trond's structured diagnostic suite to a node that's reporting unhealthy: status → diagnose → logs → suggest fix. Walks through the AGENTS.md exit-code retry tree so the agent's response is reproducible.",
+		Arguments: []*mcp.PromptArgument{
+			{Name: "node", Description: "managed node name (matches intent.name)", Required: true},
+		},
+	}, diagnoseFailingNodePrompt)
+
+	s.AddPrompt(&mcp.Prompt{
+		Name:        "setup_private_network",
+		Title:       "Bootstrap a private TRON network",
+		Description: "Stand up a multi-node private network from an intent file. Covers SR_PRIVATE_KEY env, network create, status, and the canonical recovery path when a node fails to come up.",
+		Arguments: []*mcp.PromptArgument{
+			{Name: "intent_path", Description: "absolute path to the multi-node intent.yaml", Required: true},
+		},
+	}, setupPrivateNetworkPrompt)
+
+	s.AddPrompt(&mcp.Prompt{
+		Name:        "recover_failed_upgrade",
+		Title:       "Roll back a failed upgrade",
+		Description: "An upgrade left a node unhealthy. Run diagnose, then trigger rollback to the previous_version recorded in state.json, then verify. Idempotent — safe to invoke even if the rollback already happened.",
+		Arguments: []*mcp.PromptArgument{
+			{Name: "node", Description: "name of the managed node to recover", Required: true},
+		},
+	}, recoverFailedUpgradePrompt)
+}
+
+// promptResult builds a single-message GetPromptResult — every prompt
+// in this package returns a user-role message containing the
+// pre-filled instructions the LLM should follow.
+func promptResult(description, body string) (*mcp.GetPromptResult, error) {
+	return &mcp.GetPromptResult{
+		Description: description,
+		Messages: []*mcp.PromptMessage{{
+			Role: "user",
+			Content: &mcp.TextContent{
+				Text: body,
+			},
+		}},
+	}, nil
+}
+
+func deployFullnodePrompt(_ context.Context, req *mcp.GetPromptRequest) (*mcp.GetPromptResult, error) {
+	intentPath := req.Params.Arguments["intent_path"]
+	if intentPath == "" {
+		return nil, fmt.Errorf("intent_path argument is required")
+	}
+	body := fmt.Sprintf(`Deploy a TRON fullnode end-to-end using trond.
+
+Intent file: %s
+
+Run these tools in order. After each step, parse the JSON response and act on the result_code or error_code before proceeding.
+
+  1. config_validate (path=%[1]q)
+     - On valid=true: continue.
+     - On error_code=VALIDATION_ERROR: surface the error to the user and STOP. Do not attempt to "fix" the YAML.
+
+  2. plan (path=%[1]q)
+     - Show the user the changes[] array and ask for approval.
+     - On approval, continue. On rejection, STOP.
+
+  3. apply (path=%[1]q, auto_approve=true, wait=true)
+     - On result="created" or "updated": continue.
+     - On result="no_change": tell the user nothing changed; STOP (no need to call status).
+     - On error_code=HUMAN_REQUIRED: this means the diff was destructive. Re-show the plan from step 2 and ask for explicit approval before re-calling apply.
+     - On exit_code=1 with error_code=WAIT_TIMEOUT: the node deployed but didn't become ready in 5 minutes. Call diagnose next.
+
+  4. status (name=<intent.name from step 1>)
+     - Read block_height + is_synced. Tell the user the node is up and producing/relaying blocks.
+
+Trond's exit-code contract (AGENTS.md):
+  0 = success            1 = general            2 = validation
+  3 = target unreachable 4 = preflight fail     10 = HUMAN_REQUIRED
+
+Always parse the structured error envelope: {error_code, exit_code, message, suggestions[]}. The suggestions[0] field is the most likely fix; try it before asking the user.`, intentPath)
+	return promptResult("Trond fullnode deploy workflow", body)
+}
+
+func diagnoseFailingNodePrompt(_ context.Context, req *mcp.GetPromptRequest) (*mcp.GetPromptResult, error) {
+	node := req.Params.Arguments["node"]
+	if node == "" {
+		return nil, fmt.Errorf("node argument is required")
+	}
+	body := fmt.Sprintf(`Triage the unhealthy node %[1]q using trond's structured diagnostics.
+
+  1. status (name=%[1]q)
+     - Note status, is_synced, block_height, peer_count.
+     - If error_code=NODE_NOT_FOUND: the node was never deployed (or was removed). Call list to see what IS managed.
+
+  2. diagnose (name=%[1]q)
+     - Returns checks[] with each check's status (pass/warning/fail) and suggestions[].
+     - For every check with status=fail, surface its name and suggestions to the user.
+     - Apply suggestions[0] if it's a tool call (e.g. "Re-run trond apply" → call apply).
+
+  3. health (name=%[1]q)
+     - Lighter HTTP probe of getnowblock. Use to confirm whether the node's HTTP API is responding even if other checks fail.
+
+  4. If diagnose reports sync_progress=fail with is_synced=false:
+     - The node is alive but behind. Tell the user the lag (in blocks).
+     - Don't auto-restart — sync usually catches up.
+
+  5. If diagnose reports peer_count=fail with peer_count=0 and the node is part of a private network:
+     - The shared docker network may be misconfigured. Suggest 'trond network destroy' + 'trond network create'.
+
+Stop after step 4/5 with a structured summary: status, root cause, recommended action. Don't make destructive changes (apply, remove, network destroy) without explicit user confirmation.`, node)
+	return promptResult("Trond unhealthy-node triage workflow", body)
+}
+
+func setupPrivateNetworkPrompt(_ context.Context, req *mcp.GetPromptRequest) (*mcp.GetPromptResult, error) {
+	intentPath := req.Params.Arguments["intent_path"]
+	if intentPath == "" {
+		return nil, fmt.Errorf("intent_path argument is required")
+	}
+	body := fmt.Sprintf(`Bootstrap a multi-node private TRON network from %s.
+
+Pre-flight check (read-only, no side effects):
+  1. config_validate (path=%[1]q) — make sure the intent parses.
+  2. Read trond://state — confirm no nodes named "<intent.name>-node*" already exist.
+
+If the user has not set SR_PRIVATE_KEY for the witness, the apply will fail with a placeholder localwitness value. Ask the user to set SR_PRIVATE_KEY in their shell BEFORE you call apply (the env var is captured at process start). Suggested instruction:
+
+  export SR_PRIVATE_KEY=<64-hex-chars>
+
+Deploy:
+  3. The CLI command for multi-node networks is 'trond network create --intent ...'. The MCP apply tool deploys a single node and is not the right entry point. Ask the user to run:
+
+       SR_PRIVATE_KEY=<key> trond network create --intent %[1]s -o json
+
+     Then poll trond://state until both <name>-node0 and <name>-node1 appear.
+
+Verify:
+  4. status on each node — confirm status=running.
+  5. diagnose on each node — confirm peer_count > 0 (nodes can see each other over the shared docker network).
+
+If peer_count=0 on either node, the shared docker network 'trond-<intent.name>' may have failed to create. Suggest the recover-failed-upgrade prompt or a 'trond network destroy + create' cycle.`, intentPath)
+	return promptResult("Trond private-network bootstrap workflow", body)
+}
+
+func recoverFailedUpgradePrompt(_ context.Context, req *mcp.GetPromptRequest) (*mcp.GetPromptResult, error) {
+	node := req.Params.Arguments["node"]
+	if node == "" {
+		return nil, fmt.Errorf("node argument is required")
+	}
+	body := fmt.Sprintf(`Recover %[1]q from a failed upgrade. This workflow is idempotent — safe to re-run.
+
+  1. diagnose (name=%[1]q)
+     - Capture the structured failure signal for the audit trail. Don't act on it (we're rolling back regardless).
+
+  2. Read trond://state to confirm previous_version is non-empty for %[1]q.
+     - If previous_version is empty, rollback won't work. The CLI command to use instead:
+         trond apply --intent <previous-intent.yaml> --auto-approve
+
+  3. The rollback action is currently CLI-only. Ask the user to run:
+
+       trond rollback %[1]s -o json
+
+     Tell them the expected output is {status: running, version: <prev>, rolled_back_from: <bad>}.
+
+  4. After they confirm rollback succeeded:
+     status (name=%[1]q) — confirm the node is back to status=running with version matching the previous_version recorded before the upgrade.
+
+  5. health (name=%[1]q) — confirm the HTTP API is responding.
+
+Don't proceed past step 4 if status != running — escalate to the user with the diagnose output from step 1.`, node)
+	return promptResult("Trond failed-upgrade recovery workflow", body)
+}

--- a/internal/mcp/prompts_test.go
+++ b/internal/mcp/prompts_test.go
@@ -1,0 +1,107 @@
+package mcp
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	mcpsdk "github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// TestPrompts_ListAndGet exercises every registered prompt: list
+// surfaces them all, each renders with required arguments, missing
+// arguments produce a clean error.
+func TestPrompts_ListAndGet(t *testing.T) {
+	session, cleanup := newConnectedPair(t)
+	defer cleanup()
+
+	res, err := session.ListPrompts(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("ListPrompts: %v", err)
+	}
+	got := map[string]*mcpsdk.Prompt{}
+	for _, p := range res.Prompts {
+		got[p.Name] = p
+	}
+	wantNames := []string{
+		"deploy_fullnode",
+		"diagnose_failing_node",
+		"setup_private_network",
+		"recover_failed_upgrade",
+	}
+	for _, n := range wantNames {
+		if _, ok := got[n]; !ok {
+			t.Errorf("prompt %q missing from ListPrompts", n)
+		}
+	}
+
+	cases := []struct {
+		name   string
+		args   map[string]string
+		expect string // substring that must appear in the rendered prompt
+	}{
+		{
+			name:   "deploy_fullnode",
+			args:   map[string]string{"intent_path": "/tmp/intent.yaml"},
+			expect: "config_validate (path=\"/tmp/intent.yaml\"",
+		},
+		{
+			name:   "diagnose_failing_node",
+			args:   map[string]string{"node": "my-fullnode"},
+			expect: "diagnose (name=\"my-fullnode\")",
+		},
+		{
+			name:   "setup_private_network",
+			args:   map[string]string{"intent_path": "/tmp/private.yaml"},
+			expect: "trond network create --intent /tmp/private.yaml",
+		},
+		{
+			name:   "recover_failed_upgrade",
+			args:   map[string]string{"node": "my-fullnode"},
+			expect: "trond rollback my-fullnode",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			out, err := session.GetPrompt(context.Background(),
+				&mcpsdk.GetPromptParams{Name: tc.name, Arguments: tc.args})
+			if err != nil {
+				t.Fatalf("GetPrompt: %v", err)
+			}
+			if len(out.Messages) == 0 {
+				t.Fatalf("prompt %s returned no messages", tc.name)
+			}
+			text := promptText(out.Messages[0])
+			if !strings.Contains(text, tc.expect) {
+				t.Errorf("prompt %s: expected substring %q\nactual:\n%s",
+					tc.name, tc.expect, text)
+			}
+		})
+	}
+}
+
+// TestPrompts_RejectMissingArgument confirms that omitting a
+// required argument fails the GetPrompt call rather than rendering
+// a half-templated string. Without this guard, the prompt would
+// surface a literal "%!s(MISSING)" or empty path to the LLM.
+func TestPrompts_RejectMissingArgument(t *testing.T) {
+	session, cleanup := newConnectedPair(t)
+	defer cleanup()
+
+	_, err := session.GetPrompt(context.Background(),
+		&mcpsdk.GetPromptParams{Name: "deploy_fullnode"})
+	if err == nil {
+		t.Error("expected error for missing intent_path argument")
+	}
+}
+
+// promptText extracts the text content from a PromptMessage. The
+// Content field is an interface; we type-assert to TextContent
+// since every prompt in this package emits text only.
+func promptText(m *mcpsdk.PromptMessage) string {
+	if tc, ok := m.Content.(*mcpsdk.TextContent); ok {
+		return tc.Text
+	}
+	return ""
+}

--- a/internal/mcp/resources.go
+++ b/internal/mcp/resources.go
@@ -1,0 +1,149 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/tronprotocol/tron-deployment/internal/paths"
+	"github.com/tronprotocol/tron-deployment/internal/state"
+)
+
+// registerResources wires read-only data sources as MCP resources.
+// Resources are conceptually different from tools: tools are
+// "actions" (verb), resources are "data" (noun). MCP-aware clients
+// like Claude Desktop surface resources in a file-system-like UI
+// the user can attach to a conversation, while tools are invoked by
+// the LLM during reasoning.
+//
+// What we expose:
+//
+//   - trond://state         — current state.json (every managed node + targets)
+//   - trond://audit-log     — last 200 lines of audit.log (JSONL)
+//   - trond://schema-manifest — entire schema manifest the schema command emits
+//
+// Why these three: they're read often, change rarely within a
+// conversation, and have stable URIs that survive multiple tool
+// calls (so an LLM can re-attach the same resource without an
+// extra round-trip).
+//
+// Resources that *would* be useful but aren't here yet:
+//   - trond://nodes/<name>/endpoints — needs ResourceTemplate (URI template)
+//   - trond://intent/<name>          — same
+//
+// The dynamic per-node URIs are TODO; the static ones are MVP.
+func registerResources(s *mcp.Server) {
+	s.AddResource(&mcp.Resource{
+		URI:         "trond://state",
+		Name:        "state.json",
+		Description: "The state.json file at $TROND_STATE_DIR (or ~/.trond). One row per managed node — name, version, target, runtime, ports. The agent can attach this to a conversation to reason about the deployed estate without per-node tool calls.",
+		MIMEType:    "application/json",
+	}, readStateResource)
+
+	s.AddResource(&mcp.Resource{
+		URI:         "trond://audit-log",
+		Name:        "audit.log (recent)",
+		Description: "Up to the last 200 entries of audit.log (JSONL). Use this to answer questions like 'what did we do to this node yesterday' without invoking the events tool.",
+		MIMEType:    "application/x-ndjson",
+	}, readAuditLogResource)
+
+	s.AddResource(&mcp.Resource{
+		URI:         "trond://schema-manifest",
+		Name:        "schema manifest",
+		Description: "The full output of `trond schema -o json` — schema_version, every command, every flag, every output schema. Use this resource as the agent's authoritative reference for the trond CLI surface.",
+		MIMEType:    "application/json",
+	}, readSchemaManifestResource)
+}
+
+func readStateResource(_ context.Context, req *mcp.ReadResourceRequest) (*mcp.ReadResourceResult, error) {
+	store, err := state.NewStore(paths.State())
+	if err != nil {
+		return nil, fmt.Errorf("open state: %w", err)
+	}
+	st, err := store.Load()
+	if err != nil {
+		return nil, fmt.Errorf("read state: %w", err)
+	}
+	body, err := json.MarshalIndent(st, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("marshal state: %w", err)
+	}
+	return &mcp.ReadResourceResult{
+		Contents: []*mcp.ResourceContents{{
+			URI:      req.Params.URI,
+			MIMEType: "application/json",
+			Text:     string(body),
+		}},
+	}, nil
+}
+
+const auditLogTailMax = 200
+
+func readAuditLogResource(_ context.Context, req *mcp.ReadResourceRequest) (*mcp.ReadResourceResult, error) {
+	body, err := os.ReadFile(paths.AuditLog())
+	if err != nil {
+		if os.IsNotExist(err) {
+			// No log yet — empty resource is more useful than an
+			// error; agents reason fine over zero entries.
+			return &mcp.ReadResourceResult{
+				Contents: []*mcp.ResourceContents{{
+					URI:      req.Params.URI,
+					MIMEType: "application/x-ndjson",
+					Text:     "",
+				}},
+			}, nil
+		}
+		return nil, fmt.Errorf("read audit log: %w", err)
+	}
+	return &mcp.ReadResourceResult{
+		Contents: []*mcp.ResourceContents{{
+			URI:      req.Params.URI,
+			MIMEType: "application/x-ndjson",
+			Text:     tailLines(string(body), auditLogTailMax),
+		}},
+	}, nil
+}
+
+func readSchemaManifestResource(_ context.Context, req *mcp.ReadResourceRequest) (*mcp.ReadResourceResult, error) {
+	// We can't import internal/schema's manifest builder here without
+	// a circular dependency (cmd/schema.go owns the cobra-tree walk).
+	// Instead we point at the embedded SchemaVersion + the full set
+	// of output schemas — the union of which is the manifest's
+	// load-bearing content. Agents that want the full manifest can
+	// shell out to `trond schema -o json`.
+	body, err := schemaManifestJSON()
+	if err != nil {
+		return nil, err
+	}
+	return &mcp.ReadResourceResult{
+		Contents: []*mcp.ResourceContents{{
+			URI:      req.Params.URI,
+			MIMEType: "application/json",
+			Text:     body,
+		}},
+	}, nil
+}
+
+// tailLines returns at most n lines from the end of s, newline-
+// preserved. Used to bound the audit-log resource size — a
+// long-running operator's log can be megabytes.
+func tailLines(s string, n int) string {
+	if s == "" {
+		return ""
+	}
+	// Walk backward counting newlines; take everything from the
+	// (n+1)-th newline from the end onwards.
+	count := 0
+	for i := len(s) - 1; i >= 0; i-- {
+		if s[i] == '\n' {
+			count++
+			if count > n {
+				return s[i+1:]
+			}
+		}
+	}
+	return s
+}

--- a/internal/mcp/resources_test.go
+++ b/internal/mcp/resources_test.go
@@ -1,0 +1,129 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	mcpsdk "github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/tronprotocol/tron-deployment/internal/paths"
+)
+
+// TestResources_ListAndRead exercises every resource the server
+// exposes: list shows them all, each reads cleanly, content matches
+// the documented MIME type.
+func TestResources_ListAndRead(t *testing.T) {
+	session, cleanup := newConnectedPair(t)
+	defer cleanup()
+
+	res, err := session.ListResources(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("ListResources: %v", err)
+	}
+	got := map[string]*mcpsdk.Resource{}
+	for _, r := range res.Resources {
+		got[r.URI] = r
+	}
+	want := []string{
+		"trond://state",
+		"trond://audit-log",
+		"trond://schema-manifest",
+	}
+	for _, uri := range want {
+		if _, ok := got[uri]; !ok {
+			t.Errorf("resource %q missing from ListResources", uri)
+		}
+	}
+
+	for _, uri := range want {
+		t.Run(uri, func(t *testing.T) {
+			out, err := session.ReadResource(context.Background(),
+				&mcpsdk.ReadResourceParams{URI: uri})
+			if err != nil {
+				t.Fatalf("ReadResource(%s): %v", uri, err)
+			}
+			if len(out.Contents) == 0 {
+				t.Fatalf("ReadResource(%s) returned no contents", uri)
+			}
+			body := out.Contents[0]
+			// state + schema-manifest should produce JSON; audit-log
+			// is JSONL (which is also a valid empty string for a
+			// fresh state dir).
+			switch uri {
+			case "trond://state", "trond://schema-manifest":
+				var v any
+				if err := json.Unmarshal([]byte(body.Text), &v); err != nil {
+					t.Errorf("%s body not JSON: %v\n%s", uri, err, body.Text)
+				}
+			case "trond://audit-log":
+				// Empty is fine — fresh state. Otherwise must parse line-by-line.
+				for _, line := range strings.Split(body.Text, "\n") {
+					line = strings.TrimSpace(line)
+					if line == "" {
+						continue
+					}
+					var v any
+					if err := json.Unmarshal([]byte(line), &v); err != nil {
+						t.Errorf("%s: line is not JSON: %v\nline: %s",
+							uri, err, line)
+					}
+				}
+			}
+		})
+	}
+}
+
+// TestResources_AuditLogTail asserts the audit-log resource caps at
+// the documented 200 lines, even when the on-disk audit.log has more.
+// Without this guard, an operator with months of audit history would
+// blow out the agent's context window.
+func TestResources_AuditLogTail(t *testing.T) {
+	session, cleanup := newConnectedPair(t)
+	defer cleanup()
+
+	// Plant > 200 lines of synthetic JSONL into audit.log.
+	logPath := paths.AuditLog()
+	if err := os.MkdirAll(filepath.Dir(logPath), 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	var sb strings.Builder
+	const total = 350
+	for i := range total {
+		sb.WriteString(`{"timestamp":"2026-05-03T00:00:00Z","command":"x","result":"success","target":"local","line":`)
+		sb.WriteString(itoaSimple(i))
+		sb.WriteString("}\n")
+	}
+	if err := os.WriteFile(logPath, []byte(sb.String()), 0o600); err != nil {
+		t.Fatalf("write audit log: %v", err)
+	}
+
+	out, err := session.ReadResource(context.Background(),
+		&mcpsdk.ReadResourceParams{URI: "trond://audit-log"})
+	if err != nil {
+		t.Fatalf("ReadResource: %v", err)
+	}
+	got := strings.Count(out.Contents[0].Text, "\n")
+	if got > auditLogTailMax {
+		t.Errorf("audit-log resource returned %d lines, max is %d",
+			got, auditLogTailMax)
+	}
+	if got == 0 {
+		t.Errorf("audit-log resource returned 0 lines despite %d on disk", total)
+	}
+}
+
+func itoaSimple(i int) string {
+	if i == 0 {
+		return "0"
+	}
+	var b []byte
+	for i > 0 {
+		b = append([]byte{byte('0' + i%10)}, b...)
+		i /= 10
+	}
+	return string(b)
+}

--- a/internal/mcp/schema_manifest.go
+++ b/internal/mcp/schema_manifest.go
@@ -1,0 +1,44 @@
+package mcp
+
+import (
+	"encoding/json"
+
+	"github.com/tronprotocol/tron-deployment/internal/schema"
+)
+
+// schemaManifestJSON returns a compact manifest exposed via the
+// `trond://schema-manifest` resource. We intentionally avoid pulling
+// the full cobra-tree walker (lives in cmd/schema.go) so this stays
+// importable from internal/mcp without a cycle. Callers that want
+// the full command/flag manifest should shell out to
+// `trond schema -o json`.
+//
+// Shape:
+//
+//	{
+//	  "schema_version": "1.1.0",
+//	  "schemas": {
+//	    "apply":  { ...full schema object... },
+//	    "doctor": { ... },
+//	    ...
+//	  }
+//	}
+func schemaManifestJSON() (string, error) {
+	out := struct {
+		SchemaVersion string                    `json:"schema_version"`
+		Schemas       map[string]map[string]any `json:"schemas"`
+	}{
+		SchemaVersion: schema.SchemaVersion,
+		Schemas:       map[string]map[string]any{},
+	}
+	for _, name := range schema.Names() {
+		if doc, ok := schema.Get(name); ok {
+			out.Schemas[name] = doc
+		}
+	}
+	body, err := json.MarshalIndent(out, "", "  ")
+	if err != nil {
+		return "", err
+	}
+	return string(body), nil
+}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -66,6 +66,16 @@ func Run(ctx context.Context, in io.Reader, out io.Writer, trondVersion string) 
 	registerSnapshotTools(server)
 	registerKnowledgeTools(server)
 
+	// Beyond tools, MCP exposes resources (read-only data the agent
+	// can attach to a conversation) and prompts (pre-baked workflow
+	// templates the user invokes via slash-commands). Resources let
+	// the agent see state.json + audit.log + the schema manifest
+	// without per-call tool invocations; prompts encode AGENTS.md's
+	// canonical workflows so a fresh agent session lands on the
+	// right tool sequence the first time.
+	registerResources(server)
+	registerPrompts(server)
+
 	// MCP's stdio transport is a thin wrapper around io.Reader/Writer
 	// pairs; tests pass net.Pipe() ends, real use passes os.Stdin/Stdout.
 	return server.Run(ctx, &mcp.StdioTransport{})
@@ -89,6 +99,19 @@ the canonical chains documented in AGENTS.md (the TRON deployment
 repo's agent guide). Always validate intent files with config_validate
 before plan/apply. Pass auto_approve=true to apply only when the user
 has explicitly approved the diff shown by plan.
+
+Beyond tools, this server exposes:
+
+  Resources (read-only data — attach to context, don't tool-call):
+    trond://state            — current state.json (every managed node)
+    trond://audit-log        — last 200 audit log entries (JSONL)
+    trond://schema-manifest  — all output schemas + SchemaVersion
+
+  Prompts (slash-command workflows the user picks):
+    deploy_fullnode         — validate → plan → apply --wait → status
+    diagnose_failing_node   — status → diagnose → logs → suggest
+    setup_private_network   — multi-node bootstrap with SR_PRIVATE_KEY
+    recover_failed_upgrade  — diagnose → rollback → verify
 
 Long-running tools emit MCP progress notifications; surface those to
 the user.`

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -33,6 +33,8 @@ func newConnectedPair(t *testing.T) (*mcp.ClientSession, func()) {
 	registerSnapshotTools(server)
 	registerKnowledgeTools(server)
 	registerLifecycleTools(server)
+	registerResources(server)
+	registerPrompts(server)
 
 	client := mcp.NewClient(&mcp.Implementation{Name: "client", Version: "test"}, nil)
 


### PR DESCRIPTION
## Summary

Trond's MCP server has shipped 17 tools but never the other half of the MCP surface — resources (read-only data) and prompts (slash-command workflows). This PR adds both, making the MCP integration usable the way Claude Desktop / Cursor / Cline actually present MCP servers in their UI.

## Resources (read-only data the agent attaches to context)

| URI | MIME | What |
|---|---|---|
| \`trond://state\` | application/json | Current state.json — every managed node, target, runtime, ports |
| \`trond://audit-log\` | application/x-ndjson | Last 200 audit.log entries, bounded so months of logs don't blow context |
| \`trond://schema-manifest\` | application/json | SchemaVersion + every output schema |

Agents drop one of these into a conversation once and reason about the estate without per-call list / inspect / events tool invocations.

## Prompts (slash-command workflows)

| Name | Arguments | Workflow |
|---|---|---|
| \`deploy_fullnode\` | \`intent_path\` | validate → plan → apply --wait → status |
| \`diagnose_failing_node\` | \`node\` | status → diagnose → health → suggest fix (no destructive changes) |
| \`setup_private_network\` | \`intent_path\` | Multi-node bootstrap; defers to CLI \`trond network create\` for the shared-network setup |
| \`recover_failed_upgrade\` | \`node\` | diagnose → rollback → verify, idempotent |

Each prompt encodes AGENTS.md's exit-code retry tree so a fresh agent session lands on the right tool sequence the first time. Missing required arguments fail \`GetPrompt\` with a clean error instead of rendering half-templated strings.

## Tests

- \`internal/mcp/resources_test.go\` — list + read for all three resources, JSON parses, audit-log respects the 200-line cap with 350+ entries on disk.
- \`internal/mcp/prompts_test.go\` — list + get for all four prompts, missing-argument failure path.

All in-process (in-memory transport); ~10ms total.

## Test plan

- [x] \`go test -race ./...\`
- [x] \`make lint\`
- [x] Resources / prompts wire into the same server.Run path the existing \`trond mcp\` subcommand uses