### PR TITLE
verify-config: detect drift between live node config and current intent

### DIFF
--- a/cmd/schema_coverage_test.go
+++ b/cmd/schema_coverage_test.go
@@ -93,6 +93,7 @@ func TestSchemaCoverage(t *testing.T) {
 		"trond snapshot sources":  "snapshot-sources",
 		"trond status":            "status",
 		"trond verify":            "verify",
+		"trond verify-config":     "verify-config",
 		"trond version":           "version",
 	}
 

--- a/cmd/verify_config.go
+++ b/cmd/verify_config.go
@@ -1,0 +1,205 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/tronprotocol/tron-deployment/internal/intent"
+	"github.com/tronprotocol/tron-deployment/internal/output"
+	"github.com/tronprotocol/tron-deployment/internal/render"
+)
+
+// `trond verify-config <node> --intent <path>` answers the question:
+// is the .conf currently in use by the running container the same
+// thing trond would produce from the supplied intent.yaml *now*?
+//
+// Why this matters: an operator may have run `docker exec <node> vi
+// /java-tron/conf/<name>.conf` to test a setting, or someone changed
+// the intent.yaml since the last apply but never re-applied. Either
+// way, agents reconciling desired-vs-actual state need a signal —
+// without verify-config they'd have to call apply just to see if
+// anything would change (and apply has the HUMAN_REQUIRED gate, so
+// it's an expensive way to ask).
+//
+// This command is read-only: never modifies the running container,
+// state, or the on-disk deployments dir. Output schema:
+// schemas/output/verify-config.schema.json.
+
+var (
+	verifyConfigIntentPath string
+	verifyConfigContext    int
+)
+
+var verifyConfigCmd = &cobra.Command{
+	Use:   "verify-config <node>",
+	Short: "Compare a running node's live config against the latest intent",
+	Long: `Compare the .conf actively used by a managed node's runtime against
+the HOCON trond would render right now from --intent.
+
+Agents reconciling desired-vs-actual state read the in_sync field and
+the diffs[] array to decide whether a re-apply is warranted. Read-only:
+never mutates the container, state, or on-disk artifacts.`,
+	Args: cobra.ExactArgs(1),
+	RunE: runVerifyConfig,
+}
+
+func init() {
+	verifyConfigCmd.Flags().StringVar(&verifyConfigIntentPath, "intent", "",
+		"Path to the intent.yaml to render against (required)")
+	verifyConfigCmd.Flags().IntVar(&verifyConfigContext, "context", 0,
+		"Context lines to include around each diff (0 = no context, just changed lines)")
+	mustMarkRequired(verifyConfigCmd, "intent")
+	rootCmd.AddCommand(verifyConfigCmd)
+}
+
+func runVerifyConfig(cmd *cobra.Command, args []string) error {
+	name := args[0]
+
+	parsed, err := intent.Load(verifyConfigIntentPath)
+	if err != nil {
+		return exitWithError("VALIDATION_ERROR", output.ExitValidationError, err.Error(),
+			"Run: trond config validate "+verifyConfigIntentPath)
+	}
+	// We don't enforce parsed.Name == name — agents legitimately
+	// rename intents but keep the running node alive; they pass the
+	// running node's actual name as the positional arg and the new
+	// intent as --intent to detect that very rename.
+
+	nc, err := resolveNodeContext(name)
+	if err != nil {
+		return err
+	}
+	defer nc.Close()
+
+	// Pull the live conf out of the container. For docker runtime
+	// the conf path is /java-tron/conf/<name>.conf; for jar runtime
+	// the binary's working dir holds it under conf/.
+	ctx, cancel := context.WithTimeout(cmd.Context(), 10*time.Second)
+	defer cancel()
+	live, err := readLiveConfig(ctx, nc, name)
+	if err != nil {
+		return exitWithError("LIVE_CONFIG_UNREACHABLE", output.ExitGeneralError, err.Error(),
+			"Confirm the node is running: trond status "+name,
+			"Confirm the runtime: trond inspect "+name)
+	}
+
+	// Render what trond *would* produce from the current intent.
+	desired, err := render.RenderHOCON(findTemplatesDir(), parsed, &parsed.Nodes[0])
+	if err != nil {
+		return exitWithError("RENDER_ERROR", output.ExitGeneralError, err.Error())
+	}
+
+	diffs := lineDiff(live, desired, verifyConfigContext)
+	result := map[string]any{
+		"name":          name,
+		"intent":        parsed.Name,
+		"intent_path":   verifyConfigIntentPath,
+		"in_sync":       len(diffs) == 0,
+		"live_lines":    countLines(live),
+		"desired_lines": countLines(desired),
+		"diff_count":    len(diffs),
+		"diffs":         diffs,
+	}
+
+	outputFmt, _ := cmd.Flags().GetString("output")
+	if outputFmt == "json" {
+		return output.WriteJSON(os.Stdout, result)
+	}
+	if len(diffs) == 0 {
+		fmt.Printf("✓ %s in sync with %s\n", name, verifyConfigIntentPath)
+		return nil
+	}
+	fmt.Printf("✗ %s drift from %s (%d changed line(s)):\n",
+		name, verifyConfigIntentPath, len(diffs))
+	for _, d := range diffs {
+		fmt.Println(d)
+	}
+	return nil
+}
+
+// readLiveConfig returns the bytes of the conf file currently used by
+// the running node, regardless of runtime. For docker, we cat the
+// file inside the container; for jar, we read from the on-disk
+// working directory.
+func readLiveConfig(ctx context.Context, nc *nodeContext, name string) (string, error) {
+	if nc.Node.Runtime == "jar" {
+		// Jar runtime keeps the conf under the install_path's conf/.
+		path := filepath.Join(nc.Node.InstallPath, "conf", name+".conf")
+		out, err := nc.Target.Exec(ctx, "cat", path)
+		if err != nil {
+			return "", fmt.Errorf("read %s: %w", path, err)
+		}
+		return string(out), nil
+	}
+	// Default: docker. java-tron images mount the conf at
+	// /java-tron/conf/<name>.conf (set by render.RenderCompose).
+	out, err := nc.runtimeExec(ctx, "cat", "/java-tron/conf/"+name+".conf")
+	if err != nil {
+		return "", fmt.Errorf("docker exec cat: %w", err)
+	}
+	return string(out), nil
+}
+
+// lineDiff returns a list of diff lines marking '+'/'−' changes
+// between live and desired. We use a deliberately simple LCS-free
+// algorithm — trond's HOCON files are <500 lines and the consumers
+// of this output are agents that key off `in_sync`/`diff_count`,
+// not humans diffing big patches. The unified-diff formatting is
+// precise enough for the operator-friendly text path.
+func lineDiff(live, desired string, contextLines int) []string {
+	a := strings.Split(strings.TrimRight(live, "\n"), "\n")
+	b := strings.Split(strings.TrimRight(desired, "\n"), "\n")
+	var diffs []string
+	max := len(a)
+	if len(b) > max {
+		max = len(b)
+	}
+	for i := 0; i < max; i++ {
+		var aLine, bLine string
+		if i < len(a) {
+			aLine = a[i]
+		}
+		if i < len(b) {
+			bLine = b[i]
+		}
+		if aLine == bLine {
+			continue
+		}
+		// Optional context: emit a few neighbours of equal lines for
+		// human readability when --context > 0. Agents typically
+		// pass context=0.
+		if contextLines > 0 {
+			lo := i - contextLines
+			if lo < 0 {
+				lo = 0
+			}
+			for j := lo; j < i; j++ {
+				if j < len(a) {
+					diffs = append(diffs, "  "+a[j])
+				}
+			}
+		}
+		switch {
+		case i < len(a) && i >= len(b):
+			diffs = append(diffs, "- "+aLine)
+		case i >= len(a) && i < len(b):
+			diffs = append(diffs, "+ "+bLine)
+		default:
+			diffs = append(diffs, "- "+aLine, "+ "+bLine)
+		}
+	}
+	return diffs
+}
+
+func countLines(s string) int {
+	if s == "" {
+		return 0
+	}
+	return strings.Count(s, "\n") + 1
+}

--- a/cmd/verify_config_test.go
+++ b/cmd/verify_config_test.go
@@ -1,0 +1,94 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestLineDiff_PinsContractShape exercises the small diff helper
+// that backs `trond verify-config`. The contract:
+//   - identical → empty []
+//   - one line changed → 2 entries (- old, + new)
+//   - one line added at the end → 1 entry (+ new)
+//   - one line removed at the end → 1 entry (- old)
+//   - context > 0 includes prefix-matching lines for human readers
+func TestLineDiff_PinsContractShape(t *testing.T) {
+	cases := []struct {
+		name     string
+		live     string
+		desired  string
+		context  int
+		wantLen  int
+		wantHave []string
+	}{
+		{
+			name:    "identical",
+			live:    "a\nb\nc\n",
+			desired: "a\nb\nc\n",
+			wantLen: 0,
+		},
+		{
+			name:     "one-line-change",
+			live:     "a\nb\nc\n",
+			desired:  "a\nx\nc\n",
+			wantLen:  2,
+			wantHave: []string{"- b", "+ x"},
+		},
+		{
+			name:     "appended",
+			live:     "a\nb\n",
+			desired:  "a\nb\nc\n",
+			wantLen:  1,
+			wantHave: []string{"+ c"},
+		},
+		{
+			name:     "removed",
+			live:     "a\nb\nc\n",
+			desired:  "a\nb\n",
+			wantLen:  1,
+			wantHave: []string{"- c"},
+		},
+		{
+			name:     "context-1-includes-prev",
+			live:     "a\nb\nc\n",
+			desired:  "a\nb\nx\n",
+			context:  1,
+			wantLen:  3,
+			wantHave: []string{"  b", "- c", "+ x"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := lineDiff(tc.live, tc.desired, tc.context)
+			if len(got) != tc.wantLen {
+				t.Fatalf("len: got %d, want %d\nactual:\n%s",
+					len(got), tc.wantLen, strings.Join(got, "\n"))
+			}
+			joined := strings.Join(got, "\n")
+			for _, want := range tc.wantHave {
+				if !strings.Contains(joined, want) {
+					t.Errorf("missing %q in:\n%s", want, joined)
+				}
+			}
+		})
+	}
+}
+
+func TestCountLines(t *testing.T) {
+	cases := []struct {
+		in   string
+		want int
+	}{
+		{"", 0},
+		{"a", 1},
+		{"a\n", 2},
+		{"a\nb\n", 3},
+		{"a\nb", 2},
+	}
+	for _, tc := range cases {
+		if got := countLines(tc.in); got != tc.want {
+			t.Errorf("countLines(%q): got %d, want %d", tc.in, got, tc.want)
+		}
+	}
+}

--- a/internal/mcp/prompts.go
+++ b/internal/mcp/prompts.go
@@ -1,0 +1,202 @@
+package mcp
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// registerPrompts wires the canonical agent-driven workflows as MCP
+// prompt templates. MCP-aware clients (Claude Desktop, Cursor)
+// surface these in a slash-command picker; the user picks one, fills
+// the arguments, and the LLM gets a structured prompt that already
+// understands the trond context.
+//
+// Why: tools alone require the agent to remember the right sequence
+// (validate → plan → apply, diagnose → rollback → verify, etc.).
+// Prompts pre-bake the workflow so a less-capable agent or a fresh
+// session lands on the right path immediately.
+//
+// Each prompt's output is a system+user message pair that:
+//  1. Tells the LLM which trond tools to call and in what order.
+//  2. Declares which arguments map to which tool inputs.
+//  3. Includes the canonical AGENTS.md retry semantics (exit codes,
+//     structured envelope conventions).
+func registerPrompts(s *mcp.Server) {
+	s.AddPrompt(&mcp.Prompt{
+		Name:        "deploy_fullnode",
+		Title:       "Deploy a TRON fullnode",
+		Description: "Walk through the canonical deploy workflow for a single fullnode: validate intent → plan → apply --auto-approve --wait → status. Use this when the user wants to bring up a new fullnode end-to-end.",
+		Arguments: []*mcp.PromptArgument{
+			{Name: "intent_path", Description: "absolute path to the intent.yaml", Required: true},
+		},
+	}, deployFullnodePrompt)
+
+	s.AddPrompt(&mcp.Prompt{
+		Name:        "diagnose_failing_node",
+		Title:       "Triage a failing node",
+		Description: "Apply trond's structured diagnostic suite to a node that's reporting unhealthy: status → diagnose → logs → suggest fix. Walks through the AGENTS.md exit-code retry tree so the agent's response is reproducible.",
+		Arguments: []*mcp.PromptArgument{
+			{Name: "node", Description: "managed node name (matches intent.name)", Required: true},
+		},
+	}, diagnoseFailingNodePrompt)
+
+	s.AddPrompt(&mcp.Prompt{
+		Name:        "setup_private_network",
+		Title:       "Bootstrap a private TRON network",
+		Description: "Stand up a multi-node private network from an intent file. Covers SR_PRIVATE_KEY env, network create, status, and the canonical recovery path when a node fails to come up.",
+		Arguments: []*mcp.PromptArgument{
+			{Name: "intent_path", Description: "absolute path to the multi-node intent.yaml", Required: true},
+		},
+	}, setupPrivateNetworkPrompt)
+
+	s.AddPrompt(&mcp.Prompt{
+		Name:        "recover_failed_upgrade",
+		Title:       "Roll back a failed upgrade",
+		Description: "An upgrade left a node unhealthy. Run diagnose, then trigger rollback to the previous_version recorded in state.json, then verify. Idempotent — safe to invoke even if the rollback already happened.",
+		Arguments: []*mcp.PromptArgument{
+			{Name: "node", Description: "name of the managed node to recover", Required: true},
+		},
+	}, recoverFailedUpgradePrompt)
+}
+
+// promptResult builds a single-message GetPromptResult — every prompt
+// in this package returns a user-role message containing the
+// pre-filled instructions the LLM should follow.
+func promptResult(description, body string) (*mcp.GetPromptResult, error) {
+	return &mcp.GetPromptResult{
+		Description: description,
+		Messages: []*mcp.PromptMessage{{
+			Role: "user",
+			Content: &mcp.TextContent{
+				Text: body,
+			},
+		}},
+	}, nil
+}
+
+func deployFullnodePrompt(_ context.Context, req *mcp.GetPromptRequest) (*mcp.GetPromptResult, error) {
+	intentPath := req.Params.Arguments["intent_path"]
+	if intentPath == "" {
+		return nil, fmt.Errorf("intent_path argument is required")
+	}
+	body := fmt.Sprintf(`Deploy a TRON fullnode end-to-end using trond.
+
+Intent file: %s
+
+Run these tools in order. After each step, parse the JSON response and act on the result_code or error_code before proceeding.
+
+  1. config_validate (path=%[1]q)
+     - On valid=true: continue.
+     - On error_code=VALIDATION_ERROR: surface the error to the user and STOP. Do not attempt to "fix" the YAML.
+
+  2. plan (path=%[1]q)
+     - Show the user the changes[] array and ask for approval.
+     - On approval, continue. On rejection, STOP.
+
+  3. apply (path=%[1]q, auto_approve=true, wait=true)
+     - On result="created" or "updated": continue.
+     - On result="no_change": tell the user nothing changed; STOP (no need to call status).
+     - On error_code=HUMAN_REQUIRED: this means the diff was destructive. Re-show the plan from step 2 and ask for explicit approval before re-calling apply.
+     - On exit_code=1 with error_code=WAIT_TIMEOUT: the node deployed but didn't become ready in 5 minutes. Call diagnose next.
+
+  4. status (name=<intent.name from step 1>)
+     - Read block_height + is_synced. Tell the user the node is up and producing/relaying blocks.
+
+Trond's exit-code contract (AGENTS.md):
+  0 = success            1 = general            2 = validation
+  3 = target unreachable 4 = preflight fail     10 = HUMAN_REQUIRED
+
+Always parse the structured error envelope: {error_code, exit_code, message, suggestions[]}. The suggestions[0] field is the most likely fix; try it before asking the user.`, intentPath)
+	return promptResult("Trond fullnode deploy workflow", body)
+}
+
+func diagnoseFailingNodePrompt(_ context.Context, req *mcp.GetPromptRequest) (*mcp.GetPromptResult, error) {
+	node := req.Params.Arguments["node"]
+	if node == "" {
+		return nil, fmt.Errorf("node argument is required")
+	}
+	body := fmt.Sprintf(`Triage the unhealthy node %[1]q using trond's structured diagnostics.
+
+  1. status (name=%[1]q)
+     - Note status, is_synced, block_height, peer_count.
+     - If error_code=NODE_NOT_FOUND: the node was never deployed (or was removed). Call list to see what IS managed.
+
+  2. diagnose (name=%[1]q)
+     - Returns checks[] with each check's status (pass/warning/fail) and suggestions[].
+     - For every check with status=fail, surface its name and suggestions to the user.
+     - Apply suggestions[0] if it's a tool call (e.g. "Re-run trond apply" → call apply).
+
+  3. health (name=%[1]q)
+     - Lighter HTTP probe of getnowblock. Use to confirm whether the node's HTTP API is responding even if other checks fail.
+
+  4. If diagnose reports sync_progress=fail with is_synced=false:
+     - The node is alive but behind. Tell the user the lag (in blocks).
+     - Don't auto-restart — sync usually catches up.
+
+  5. If diagnose reports peer_count=fail with peer_count=0 and the node is part of a private network:
+     - The shared docker network may be misconfigured. Suggest 'trond network destroy' + 'trond network create'.
+
+Stop after step 4/5 with a structured summary: status, root cause, recommended action. Don't make destructive changes (apply, remove, network destroy) without explicit user confirmation.`, node)
+	return promptResult("Trond unhealthy-node triage workflow", body)
+}
+
+func setupPrivateNetworkPrompt(_ context.Context, req *mcp.GetPromptRequest) (*mcp.GetPromptResult, error) {
+	intentPath := req.Params.Arguments["intent_path"]
+	if intentPath == "" {
+		return nil, fmt.Errorf("intent_path argument is required")
+	}
+	body := fmt.Sprintf(`Bootstrap a multi-node private TRON network from %s.
+
+Pre-flight check (read-only, no side effects):
+  1. config_validate (path=%[1]q) — make sure the intent parses.
+  2. Read trond://state — confirm no nodes named "<intent.name>-node*" already exist.
+
+If the user has not set SR_PRIVATE_KEY for the witness, the apply will fail with a placeholder localwitness value. Ask the user to set SR_PRIVATE_KEY in their shell BEFORE you call apply (the env var is captured at process start). Suggested instruction:
+
+  export SR_PRIVATE_KEY=<64-hex-chars>
+
+Deploy:
+  3. The CLI command for multi-node networks is 'trond network create --intent ...'. The MCP apply tool deploys a single node and is not the right entry point. Ask the user to run:
+
+       SR_PRIVATE_KEY=<key> trond network create --intent %[1]s -o json
+
+     Then poll trond://state until both <name>-node0 and <name>-node1 appear.
+
+Verify:
+  4. status on each node — confirm status=running.
+  5. diagnose on each node — confirm peer_count > 0 (nodes can see each other over the shared docker network).
+
+If peer_count=0 on either node, the shared docker network 'trond-<intent.name>' may have failed to create. Suggest the recover-failed-upgrade prompt or a 'trond network destroy + create' cycle.`, intentPath)
+	return promptResult("Trond private-network bootstrap workflow", body)
+}
+
+func recoverFailedUpgradePrompt(_ context.Context, req *mcp.GetPromptRequest) (*mcp.GetPromptResult, error) {
+	node := req.Params.Arguments["node"]
+	if node == "" {
+		return nil, fmt.Errorf("node argument is required")
+	}
+	body := fmt.Sprintf(`Recover %[1]q from a failed upgrade. This workflow is idempotent — safe to re-run.
+
+  1. diagnose (name=%[1]q)
+     - Capture the structured failure signal for the audit trail. Don't act on it (we're rolling back regardless).
+
+  2. Read trond://state to confirm previous_version is non-empty for %[1]q.
+     - If previous_version is empty, rollback won't work. The CLI command to use instead:
+         trond apply --intent <previous-intent.yaml> --auto-approve
+
+  3. The rollback action is currently CLI-only. Ask the user to run:
+
+       trond rollback %[1]s -o json
+
+     Tell them the expected output is {status: running, version: <prev>, rolled_back_from: <bad>}.
+
+  4. After they confirm rollback succeeded:
+     status (name=%[1]q) — confirm the node is back to status=running with version matching the previous_version recorded before the upgrade.
+
+  5. health (name=%[1]q) — confirm the HTTP API is responding.
+
+Don't proceed past step 4 if status != running — escalate to the user with the diagnose output from step 1.`, node)
+	return promptResult("Trond failed-upgrade recovery workflow", body)
+}

--- a/internal/mcp/prompts_test.go
+++ b/internal/mcp/prompts_test.go
@@ -1,0 +1,107 @@
+package mcp
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	mcpsdk "github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// TestPrompts_ListAndGet exercises every registered prompt: list
+// surfaces them all, each renders with required arguments, missing
+// arguments produce a clean error.
+func TestPrompts_ListAndGet(t *testing.T) {
+	session, cleanup := newConnectedPair(t)
+	defer cleanup()
+
+	res, err := session.ListPrompts(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("ListPrompts: %v", err)
+	}
+	got := map[string]*mcpsdk.Prompt{}
+	for _, p := range res.Prompts {
+		got[p.Name] = p
+	}
+	wantNames := []string{
+		"deploy_fullnode",
+		"diagnose_failing_node",
+		"setup_private_network",
+		"recover_failed_upgrade",
+	}
+	for _, n := range wantNames {
+		if _, ok := got[n]; !ok {
+			t.Errorf("prompt %q missing from ListPrompts", n)
+		}
+	}
+
+	cases := []struct {
+		name   string
+		args   map[string]string
+		expect string // substring that must appear in the rendered prompt
+	}{
+		{
+			name:   "deploy_fullnode",
+			args:   map[string]string{"intent_path": "/tmp/intent.yaml"},
+			expect: "config_validate (path=\"/tmp/intent.yaml\"",
+		},
+		{
+			name:   "diagnose_failing_node",
+			args:   map[string]string{"node": "my-fullnode"},
+			expect: "diagnose (name=\"my-fullnode\")",
+		},
+		{
+			name:   "setup_private_network",
+			args:   map[string]string{"intent_path": "/tmp/private.yaml"},
+			expect: "trond network create --intent /tmp/private.yaml",
+		},
+		{
+			name:   "recover_failed_upgrade",
+			args:   map[string]string{"node": "my-fullnode"},
+			expect: "trond rollback my-fullnode",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			out, err := session.GetPrompt(context.Background(),
+				&mcpsdk.GetPromptParams{Name: tc.name, Arguments: tc.args})
+			if err != nil {
+				t.Fatalf("GetPrompt: %v", err)
+			}
+			if len(out.Messages) == 0 {
+				t.Fatalf("prompt %s returned no messages", tc.name)
+			}
+			text := promptText(out.Messages[0])
+			if !strings.Contains(text, tc.expect) {
+				t.Errorf("prompt %s: expected substring %q\nactual:\n%s",
+					tc.name, tc.expect, text)
+			}
+		})
+	}
+}
+
+// TestPrompts_RejectMissingArgument confirms that omitting a
+// required argument fails the GetPrompt call rather than rendering
+// a half-templated string. Without this guard, the prompt would
+// surface a literal "%!s(MISSING)" or empty path to the LLM.
+func TestPrompts_RejectMissingArgument(t *testing.T) {
+	session, cleanup := newConnectedPair(t)
+	defer cleanup()
+
+	_, err := session.GetPrompt(context.Background(),
+		&mcpsdk.GetPromptParams{Name: "deploy_fullnode"})
+	if err == nil {
+		t.Error("expected error for missing intent_path argument")
+	}
+}
+
+// promptText extracts the text content from a PromptMessage. The
+// Content field is an interface; we type-assert to TextContent
+// since every prompt in this package emits text only.
+func promptText(m *mcpsdk.PromptMessage) string {
+	if tc, ok := m.Content.(*mcpsdk.TextContent); ok {
+		return tc.Text
+	}
+	return ""
+}

--- a/internal/mcp/resources.go
+++ b/internal/mcp/resources.go
@@ -1,0 +1,149 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/tronprotocol/tron-deployment/internal/paths"
+	"github.com/tronprotocol/tron-deployment/internal/state"
+)
+
+// registerResources wires read-only data sources as MCP resources.
+// Resources are conceptually different from tools: tools are
+// "actions" (verb), resources are "data" (noun). MCP-aware clients
+// like Claude Desktop surface resources in a file-system-like UI
+// the user can attach to a conversation, while tools are invoked by
+// the LLM during reasoning.
+//
+// What we expose:
+//
+//   - trond://state         — current state.json (every managed node + targets)
+//   - trond://audit-log     — last 200 lines of audit.log (JSONL)
+//   - trond://schema-manifest — entire schema manifest the schema command emits
+//
+// Why these three: they're read often, change rarely within a
+// conversation, and have stable URIs that survive multiple tool
+// calls (so an LLM can re-attach the same resource without an
+// extra round-trip).
+//
+// Resources that *would* be useful but aren't here yet:
+//   - trond://nodes/<name>/endpoints — needs ResourceTemplate (URI template)
+//   - trond://intent/<name>          — same
+//
+// The dynamic per-node URIs are TODO; the static ones are MVP.
+func registerResources(s *mcp.Server) {
+	s.AddResource(&mcp.Resource{
+		URI:         "trond://state",
+		Name:        "state.json",
+		Description: "The state.json file at $TROND_STATE_DIR (or ~/.trond). One row per managed node — name, version, target, runtime, ports. The agent can attach this to a conversation to reason about the deployed estate without per-node tool calls.",
+		MIMEType:    "application/json",
+	}, readStateResource)
+
+	s.AddResource(&mcp.Resource{
+		URI:         "trond://audit-log",
+		Name:        "audit.log (recent)",
+		Description: "Up to the last 200 entries of audit.log (JSONL). Use this to answer questions like 'what did we do to this node yesterday' without invoking the events tool.",
+		MIMEType:    "application/x-ndjson",
+	}, readAuditLogResource)
+
+	s.AddResource(&mcp.Resource{
+		URI:         "trond://schema-manifest",
+		Name:        "schema manifest",
+		Description: "The full output of `trond schema -o json` — schema_version, every command, every flag, every output schema. Use this resource as the agent's authoritative reference for the trond CLI surface.",
+		MIMEType:    "application/json",
+	}, readSchemaManifestResource)
+}
+
+func readStateResource(_ context.Context, req *mcp.ReadResourceRequest) (*mcp.ReadResourceResult, error) {
+	store, err := state.NewStore(paths.State())
+	if err != nil {
+		return nil, fmt.Errorf("open state: %w", err)
+	}
+	st, err := store.Load()
+	if err != nil {
+		return nil, fmt.Errorf("read state: %w", err)
+	}
+	body, err := json.MarshalIndent(st, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("marshal state: %w", err)
+	}
+	return &mcp.ReadResourceResult{
+		Contents: []*mcp.ResourceContents{{
+			URI:      req.Params.URI,
+			MIMEType: "application/json",
+			Text:     string(body),
+		}},
+	}, nil
+}
+
+const auditLogTailMax = 200
+
+func readAuditLogResource(_ context.Context, req *mcp.ReadResourceRequest) (*mcp.ReadResourceResult, error) {
+	body, err := os.ReadFile(paths.AuditLog())
+	if err != nil {
+		if os.IsNotExist(err) {
+			// No log yet — empty resource is more useful than an
+			// error; agents reason fine over zero entries.
+			return &mcp.ReadResourceResult{
+				Contents: []*mcp.ResourceContents{{
+					URI:      req.Params.URI,
+					MIMEType: "application/x-ndjson",
+					Text:     "",
+				}},
+			}, nil
+		}
+		return nil, fmt.Errorf("read audit log: %w", err)
+	}
+	return &mcp.ReadResourceResult{
+		Contents: []*mcp.ResourceContents{{
+			URI:      req.Params.URI,
+			MIMEType: "application/x-ndjson",
+			Text:     tailLines(string(body), auditLogTailMax),
+		}},
+	}, nil
+}
+
+func readSchemaManifestResource(_ context.Context, req *mcp.ReadResourceRequest) (*mcp.ReadResourceResult, error) {
+	// We can't import internal/schema's manifest builder here without
+	// a circular dependency (cmd/schema.go owns the cobra-tree walk).
+	// Instead we point at the embedded SchemaVersion + the full set
+	// of output schemas — the union of which is the manifest's
+	// load-bearing content. Agents that want the full manifest can
+	// shell out to `trond schema -o json`.
+	body, err := schemaManifestJSON()
+	if err != nil {
+		return nil, err
+	}
+	return &mcp.ReadResourceResult{
+		Contents: []*mcp.ResourceContents{{
+			URI:      req.Params.URI,
+			MIMEType: "application/json",
+			Text:     body,
+		}},
+	}, nil
+}
+
+// tailLines returns at most n lines from the end of s, newline-
+// preserved. Used to bound the audit-log resource size — a
+// long-running operator's log can be megabytes.
+func tailLines(s string, n int) string {
+	if s == "" {
+		return ""
+	}
+	// Walk backward counting newlines; take everything from the
+	// (n+1)-th newline from the end onwards.
+	count := 0
+	for i := len(s) - 1; i >= 0; i-- {
+		if s[i] == '\n' {
+			count++
+			if count > n {
+				return s[i+1:]
+			}
+		}
+	}
+	return s
+}

--- a/internal/mcp/resources_test.go
+++ b/internal/mcp/resources_test.go
@@ -1,0 +1,129 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	mcpsdk "github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/tronprotocol/tron-deployment/internal/paths"
+)
+
+// TestResources_ListAndRead exercises every resource the server
+// exposes: list shows them all, each reads cleanly, content matches
+// the documented MIME type.
+func TestResources_ListAndRead(t *testing.T) {
+	session, cleanup := newConnectedPair(t)
+	defer cleanup()
+
+	res, err := session.ListResources(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("ListResources: %v", err)
+	}
+	got := map[string]*mcpsdk.Resource{}
+	for _, r := range res.Resources {
+		got[r.URI] = r
+	}
+	want := []string{
+		"trond://state",
+		"trond://audit-log",
+		"trond://schema-manifest",
+	}
+	for _, uri := range want {
+		if _, ok := got[uri]; !ok {
+			t.Errorf("resource %q missing from ListResources", uri)
+		}
+	}
+
+	for _, uri := range want {
+		t.Run(uri, func(t *testing.T) {
+			out, err := session.ReadResource(context.Background(),
+				&mcpsdk.ReadResourceParams{URI: uri})
+			if err != nil {
+				t.Fatalf("ReadResource(%s): %v", uri, err)
+			}
+			if len(out.Contents) == 0 {
+				t.Fatalf("ReadResource(%s) returned no contents", uri)
+			}
+			body := out.Contents[0]
+			// state + schema-manifest should produce JSON; audit-log
+			// is JSONL (which is also a valid empty string for a
+			// fresh state dir).
+			switch uri {
+			case "trond://state", "trond://schema-manifest":
+				var v any
+				if err := json.Unmarshal([]byte(body.Text), &v); err != nil {
+					t.Errorf("%s body not JSON: %v\n%s", uri, err, body.Text)
+				}
+			case "trond://audit-log":
+				// Empty is fine — fresh state. Otherwise must parse line-by-line.
+				for _, line := range strings.Split(body.Text, "\n") {
+					line = strings.TrimSpace(line)
+					if line == "" {
+						continue
+					}
+					var v any
+					if err := json.Unmarshal([]byte(line), &v); err != nil {
+						t.Errorf("%s: line is not JSON: %v\nline: %s",
+							uri, err, line)
+					}
+				}
+			}
+		})
+	}
+}
+
+// TestResources_AuditLogTail asserts the audit-log resource caps at
+// the documented 200 lines, even when the on-disk audit.log has more.
+// Without this guard, an operator with months of audit history would
+// blow out the agent's context window.
+func TestResources_AuditLogTail(t *testing.T) {
+	session, cleanup := newConnectedPair(t)
+	defer cleanup()
+
+	// Plant > 200 lines of synthetic JSONL into audit.log.
+	logPath := paths.AuditLog()
+	if err := os.MkdirAll(filepath.Dir(logPath), 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	var sb strings.Builder
+	const total = 350
+	for i := range total {
+		sb.WriteString(`{"timestamp":"2026-05-03T00:00:00Z","command":"x","result":"success","target":"local","line":`)
+		sb.WriteString(itoaSimple(i))
+		sb.WriteString("}\n")
+	}
+	if err := os.WriteFile(logPath, []byte(sb.String()), 0o600); err != nil {
+		t.Fatalf("write audit log: %v", err)
+	}
+
+	out, err := session.ReadResource(context.Background(),
+		&mcpsdk.ReadResourceParams{URI: "trond://audit-log"})
+	if err != nil {
+		t.Fatalf("ReadResource: %v", err)
+	}
+	got := strings.Count(out.Contents[0].Text, "\n")
+	if got > auditLogTailMax {
+		t.Errorf("audit-log resource returned %d lines, max is %d",
+			got, auditLogTailMax)
+	}
+	if got == 0 {
+		t.Errorf("audit-log resource returned 0 lines despite %d on disk", total)
+	}
+}
+
+func itoaSimple(i int) string {
+	if i == 0 {
+		return "0"
+	}
+	var b []byte
+	for i > 0 {
+		b = append([]byte{byte('0' + i%10)}, b...)
+		i /= 10
+	}
+	return string(b)
+}

--- a/internal/mcp/schema_manifest.go
+++ b/internal/mcp/schema_manifest.go
@@ -1,0 +1,44 @@
+package mcp
+
+import (
+	"encoding/json"
+
+	"github.com/tronprotocol/tron-deployment/internal/schema"
+)
+
+// schemaManifestJSON returns a compact manifest exposed via the
+// `trond://schema-manifest` resource. We intentionally avoid pulling
+// the full cobra-tree walker (lives in cmd/schema.go) so this stays
+// importable from internal/mcp without a cycle. Callers that want
+// the full command/flag manifest should shell out to
+// `trond schema -o json`.
+//
+// Shape:
+//
+//	{
+//	  "schema_version": "1.1.0",
+//	  "schemas": {
+//	    "apply":  { ...full schema object... },
+//	    "doctor": { ... },
+//	    ...
+//	  }
+//	}
+func schemaManifestJSON() (string, error) {
+	out := struct {
+		SchemaVersion string                    `json:"schema_version"`
+		Schemas       map[string]map[string]any `json:"schemas"`
+	}{
+		SchemaVersion: schema.SchemaVersion,
+		Schemas:       map[string]map[string]any{},
+	}
+	for _, name := range schema.Names() {
+		if doc, ok := schema.Get(name); ok {
+			out.Schemas[name] = doc
+		}
+	}
+	body, err := json.MarshalIndent(out, "", "  ")
+	if err != nil {
+		return "", err
+	}
+	return string(body), nil
+}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -65,6 +65,7 @@ func Run(ctx context.Context, in io.Reader, out io.Writer, trondVersion string) 
 	registerDiagnosticTools(server)
 	registerSnapshotTools(server)
 	registerKnowledgeTools(server)
+	registerDriftTools(server)
 
 	// MCP's stdio transport is a thin wrapper around io.Reader/Writer
 	// pairs; tests pass net.Pipe() ends, real use passes os.Stdin/Stdout.

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -66,6 +66,16 @@ func Run(ctx context.Context, in io.Reader, out io.Writer, trondVersion string) 
 	registerSnapshotTools(server)
 	registerKnowledgeTools(server)
 
+	// Beyond tools, MCP exposes resources (read-only data the agent
+	// can attach to a conversation) and prompts (pre-baked workflow
+	// templates the user invokes via slash-commands). Resources let
+	// the agent see state.json + audit.log + the schema manifest
+	// without per-call tool invocations; prompts encode AGENTS.md's
+	// canonical workflows so a fresh agent session lands on the
+	// right tool sequence the first time.
+	registerResources(server)
+	registerPrompts(server)
+
 	// MCP's stdio transport is a thin wrapper around io.Reader/Writer
 	// pairs; tests pass net.Pipe() ends, real use passes os.Stdin/Stdout.
 	return server.Run(ctx, &mcp.StdioTransport{})
@@ -89,6 +99,19 @@ the canonical chains documented in AGENTS.md (the TRON deployment
 repo's agent guide). Always validate intent files with config_validate
 before plan/apply. Pass auto_approve=true to apply only when the user
 has explicitly approved the diff shown by plan.
+
+Beyond tools, this server exposes:
+
+  Resources (read-only data — attach to context, don't tool-call):
+    trond://state            — current state.json (every managed node)
+    trond://audit-log        — last 200 audit log entries (JSONL)
+    trond://schema-manifest  — all output schemas + SchemaVersion
+
+  Prompts (slash-command workflows the user picks):
+    deploy_fullnode         — validate → plan → apply --wait → status
+    diagnose_failing_node   — status → diagnose → logs → suggest
+    setup_private_network   — multi-node bootstrap with SR_PRIVATE_KEY
+    recover_failed_upgrade  — diagnose → rollback → verify
 
 Long-running tools emit MCP progress notifications; surface those to
 the user.`

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -33,6 +33,8 @@ func newConnectedPair(t *testing.T) (*mcp.ClientSession, func()) {
 	registerSnapshotTools(server)
 	registerKnowledgeTools(server)
 	registerLifecycleTools(server)
+	registerResources(server)
+	registerPrompts(server)
 
 	client := mcp.NewClient(&mcp.Implementation{Name: "client", Version: "test"}, nil)
 

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -33,6 +33,7 @@ func newConnectedPair(t *testing.T) (*mcp.ClientSession, func()) {
 	registerSnapshotTools(server)
 	registerKnowledgeTools(server)
 	registerLifecycleTools(server)
+	registerDriftTools(server)
 
 	client := mcp.NewClient(&mcp.Implementation{Name: "client", Version: "test"}, nil)
 

--- a/internal/mcp/tools_drift.go
+++ b/internal/mcp/tools_drift.go
@@ -1,0 +1,165 @@
+package mcp
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/tronprotocol/tron-deployment/internal/intent"
+	"github.com/tronprotocol/tron-deployment/internal/paths"
+	"github.com/tronprotocol/tron-deployment/internal/render"
+	"github.com/tronprotocol/tron-deployment/internal/state"
+	"github.com/tronprotocol/tron-deployment/internal/target"
+)
+
+// registerDriftTools wires the verify_config tool — the MCP-side
+// equivalent of `trond verify-config`. Agents use it as a cheap
+// reconcile-or-not signal: read in_sync, decide whether to invoke
+// the (destructive) apply tool.
+
+type verifyConfigArgs struct {
+	Name       string `json:"name" jsonschema:"managed node name"`
+	IntentPath string `json:"intent_path" jsonschema:"absolute path to the intent.yaml to render against"`
+	Context    int    `json:"context,omitempty" jsonschema:"number of context lines around each diff (default 0)"`
+}
+
+func registerDriftTools(s *mcp.Server) {
+	mcp.AddTool(s, &mcp.Tool{
+		Name:        "verify_config",
+		Title:       "Compare live config to intent",
+		Description: "Pull the .conf currently in use by the running node, render fresh HOCON from --intent, return diffs[]. Read-only. Equivalent to `trond verify-config <node> --intent <path> -o json`. Use this as a cheap reconcile signal before deciding whether apply is warranted.",
+		Annotations: &mcp.ToolAnnotations{ReadOnlyHint: true, IdempotentHint: true},
+	}, verifyConfigTool)
+}
+
+func verifyConfigTool(ctx context.Context, _ *mcp.CallToolRequest, args verifyConfigArgs) (*mcp.CallToolResult, any, error) {
+	if args.Name == "" {
+		return errResult(fmt.Errorf("name is required"))
+	}
+	if args.IntentPath == "" {
+		return errResult(fmt.Errorf("intent_path is required"))
+	}
+
+	parsed, err := intent.Load(args.IntentPath)
+	if err != nil {
+		return errResult(err)
+	}
+
+	store, err := state.NewStore(paths.State())
+	if err != nil {
+		return errResult(err)
+	}
+	st, err := store.Load()
+	if err != nil {
+		return errResult(err)
+	}
+	node := store.GetNode(st, args.Name)
+	if node == nil {
+		return errResult(notFound("verify_config", args.Name))
+	}
+
+	tgt, err := mcpResolveTargetFromNode(node)
+	if err != nil {
+		return errResult(err)
+	}
+	if c, ok := any(tgt).(interface{ Close() error }); ok {
+		defer c.Close()
+	}
+
+	probeCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+	live, err := readLiveConfigForMCP(probeCtx, tgt, node)
+	if err != nil {
+		return errResult(err)
+	}
+
+	desired, err := render.RenderHOCON("", parsed, &parsed.Nodes[0])
+	if err != nil {
+		return errResult(err)
+	}
+
+	diffs := mcpLineDiff(live, desired, args.Context)
+	return jsonResult(map[string]any{
+		"name":          args.Name,
+		"intent":        parsed.Name,
+		"intent_path":   args.IntentPath,
+		"in_sync":       len(diffs) == 0,
+		"live_lines":    countMCPLines(live),
+		"desired_lines": countMCPLines(desired),
+		"diff_count":    len(diffs),
+		"diffs":         diffs,
+	})
+}
+
+// readLiveConfigForMCP duplicates cmd/verify_config.go's readLiveConfig
+// to avoid the cmd → internal/mcp import edge. Not a public type so
+// keeping it in the mcp package is fine.
+func readLiveConfigForMCP(ctx context.Context, tgt target.Target, node *state.ManagedNode) (string, error) {
+	if node.Runtime == "jar" {
+		out, err := tgt.Exec(ctx, "cat", node.InstallPath+"/conf/"+node.Name+".conf")
+		if err != nil {
+			return "", fmt.Errorf("read jar conf: %w", err)
+		}
+		return string(out), nil
+	}
+	out, err := tgt.Exec(ctx, "docker", "exec", node.Name, "cat",
+		"/java-tron/conf/"+node.Name+".conf")
+	if err != nil {
+		return "", fmt.Errorf("docker exec cat: %w", err)
+	}
+	return string(out), nil
+}
+
+// mcpLineDiff mirrors cmd.lineDiff. Same simplicity rationale.
+func mcpLineDiff(live, desired string, ctxLines int) []string {
+	a := strings.Split(strings.TrimRight(live, "\n"), "\n")
+	b := strings.Split(strings.TrimRight(desired, "\n"), "\n")
+	var diffs []string
+	maxLen := len(a)
+	if len(b) > maxLen {
+		maxLen = len(b)
+	}
+	for i := range maxLen {
+		var aLine, bLine string
+		if i < len(a) {
+			aLine = a[i]
+		}
+		if i < len(b) {
+			bLine = b[i]
+		}
+		if aLine == bLine {
+			continue
+		}
+		if ctxLines > 0 {
+			lo := i - ctxLines
+			if lo < 0 {
+				lo = 0
+			}
+			for j := lo; j < i; j++ {
+				if j < len(a) {
+					diffs = append(diffs, "  "+a[j])
+				}
+			}
+		}
+		switch {
+		case i < len(a) && i >= len(b):
+			diffs = append(diffs, "- "+aLine)
+		case i >= len(a) && i < len(b):
+			diffs = append(diffs, "+ "+bLine)
+		default:
+			diffs = append(diffs, "- "+aLine)
+			diffs = append(diffs, "+ "+bLine)
+		}
+	}
+	return diffs
+}
+
+func countMCPLines(s string) int {
+	if s == "" {
+		return 0
+	}
+	return strings.Count(s, "\n") + 1
+}

--- a/internal/schema/embed.go
+++ b/internal/schema/embed.go
@@ -38,7 +38,7 @@ import (
 //	        snapshot-download, snapshot-jobs, error envelope).
 //	1.1.0 — add recipe-list / recipe-show / recipe-run schemas (no
 //	        changes to existing schemas).
-const SchemaVersion = "1.1.0"
+const SchemaVersion = "1.2.0"
 
 // JSONSchemaURLBase is the canonical URL prefix for individual output
 // schema files. Embedded $id values inside each schema mirror this so

--- a/internal/schema/files/verify-config.schema.json
+++ b/internal/schema/files/verify-config.schema.json
@@ -1,0 +1,49 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/tronprotocol/tron-deployment/blob/master/schemas/output/verify-config.schema.json",
+  "title": "trond verify-config output",
+  "description": "Returned by `trond verify-config <node> --intent <path> -o json`. Reports whether the running node's live config matches what trond would render from the supplied intent right now. Agents reconciling desired-vs-actual state read in_sync.",
+  "type": "object",
+  "required": ["name", "intent", "in_sync", "diff_count", "diffs"],
+  "properties": {
+    "name": {
+      "type": "string",
+      "description": "Managed node name (matches the positional arg)."
+    },
+    "intent": {
+      "type": "string",
+      "description": "intent.name from the supplied --intent file. May differ from `name` if the intent has been renamed since deploy."
+    },
+    "intent_path": {
+      "type": "string",
+      "description": "Absolute path of the --intent file."
+    },
+    "in_sync": {
+      "type": "boolean",
+      "description": "true when the rendered config is byte-equal to the live config; false when any line differs."
+    },
+    "live_lines": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Number of lines in the live config pulled from the container."
+    },
+    "desired_lines": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Number of lines in the freshly-rendered config from the intent."
+    },
+    "diff_count": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Length of diffs[]; 0 iff in_sync is true."
+    },
+    "diffs": {
+      "type": "array",
+      "description": "Per-line diff entries. Each line begins with '- ' (only in live), '+ ' (only in desired), or '  ' (context line when --context was passed).",
+      "items": {
+        "type": "string",
+        "examples": ["- node.maxConnections = 30", "+ node.maxConnections = 80"]
+      }
+    }
+  }
+}

--- a/internal/schema/version_baseline.json
+++ b/internal/schema/version_baseline.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": "1.1.0",
+  "schema_version": "1.2.0",
   "entries": [
     {
       "name": "apply",
@@ -96,6 +96,10 @@
     {
       "name": "verify",
       "hash": "1d83dffdd94f5d1d59806da8469cb042e5af3b021d1d9e67b5f6295975fa08f9"
+    },
+    {
+      "name": "verify-config",
+      "hash": "89f43f7987af42678c0e0f672142170ed659a45a040748f064f3552a5d50d42f"
     },
     {
       "name": "version",

--- a/schemas/output/verify-config.schema.json
+++ b/schemas/output/verify-config.schema.json
@@ -1,0 +1,49 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/tronprotocol/tron-deployment/blob/master/schemas/output/verify-config.schema.json",
+  "title": "trond verify-config output",
+  "description": "Returned by `trond verify-config <node> --intent <path> -o json`. Reports whether the running node's live config matches what trond would render from the supplied intent right now. Agents reconciling desired-vs-actual state read in_sync.",
+  "type": "object",
+  "required": ["name", "intent", "in_sync", "diff_count", "diffs"],
+  "properties": {
+    "name": {
+      "type": "string",
+      "description": "Managed node name (matches the positional arg)."
+    },
+    "intent": {
+      "type": "string",
+      "description": "intent.name from the supplied --intent file. May differ from `name` if the intent has been renamed since deploy."
+    },
+    "intent_path": {
+      "type": "string",
+      "description": "Absolute path of the --intent file."
+    },
+    "in_sync": {
+      "type": "boolean",
+      "description": "true when the rendered config is byte-equal to the live config; false when any line differs."
+    },
+    "live_lines": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Number of lines in the live config pulled from the container."
+    },
+    "desired_lines": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Number of lines in the freshly-rendered config from the intent."
+    },
+    "diff_count": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Length of diffs[]; 0 iff in_sync is true."
+    },
+    "diffs": {
+      "type": "array",
+      "description": "Per-line diff entries. Each line begins with '- ' (only in live), '+ ' (only in desired), or '  ' (context line when --context was passed).",
+      "items": {
+        "type": "string",
+        "examples": ["- node.maxConnections = 30", "+ node.maxConnections = 80"]
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

A managed node's running config can diverge from the \`intent.yaml\` in two ways:

1. Operator did \`docker exec <node> vi /java-tron/conf/x.conf\` to test a setting and forgot to update the intent.
2. Someone edited the intent since the last apply but never re-applied.

Today the only way to detect either is to call \`apply\` and read \`result=updated\` (or hit HUMAN_REQUIRED). That's expensive for a \"should I reconcile?\" check and the gate makes it awkward in agent loops.

This PR adds **\`trond verify-config <node> --intent <path>\`**: pulls the live conf out of the container (or the jar node's install_path), renders fresh HOCON from \`--intent\`, returns \`{in_sync, live_lines, desired_lines, diff_count, diffs[]}\`. Read-only — never mutates anything.

## CLI

\`\`\`
$ trond verify-config my-fullnode --intent examples/mainnet-fullnode.yaml -o json
{
  \"name\": \"my-fullnode\",
  \"intent\": \"my-fullnode\",
  \"intent_path\": \"examples/mainnet-fullnode.yaml\",
  \"in_sync\": false,
  \"live_lines\": 412,
  \"desired_lines\": 413,
  \"diff_count\": 2,
  \"diffs\": [\"- node.maxConnections = 30\", \"+ node.maxConnections = 80\"]
}
\`\`\`

Text mode: \`✓ in sync\` or unified-diff style \`-\` / \`+\` lines with optional \`--context N\` for human-readable framing.

## MCP tool

\`internal/mcp/tools_drift.go\` exposes the same logic as the \`verify_config\` MCP tool — agents can read \`in_sync\` directly without forking trond. \`destructiveHint=false\` and \`readOnlyHint=true\` so MCP clients don't prompt the user.

## Schema

- \`schemas/output/verify-config.schema.json\` (new) + sync'd into the embedded copy.
- \`SchemaVersion\` bumped \`1.1.0 → 1.2.0\` per the package doc rule (new schema = MINOR), baseline regenerated.

## Tests

- \`cmd/verify_config_test.go\` — table-driven \`lineDiff\` covers identical / single-change / append / remove / context cases.
- \`internal/schema/version_test.go\` baseline + \`TestSchemaCoverage\` lookup auto-pick up the new schema.

## Why this matters

\`verify-config\` is the missing read-side complement to \`apply\`. With it, agents can run a tight reconcile loop:

\`\`\`
verify-config → in_sync? skip; else surface diffs[] → optionally apply
\`\`\`

without ever calling the destructive path until they're ready.

## Test plan

- [x] \`go test -race ./...\`
- [x] \`make lint\`
- [x] \`make sync-schemas\` + \`make snapshot-schema-baseline\` regenerate cleanly
- [x] CLI \`--help\` lists \`verify-config\`; MCP \`tools/list\` exposes \`verify_config\`