### PR TITLE
auto-heal + MCP resource templates

### DIFF
--- a/cmd/heal.go
+++ b/cmd/heal.go
@@ -1,0 +1,244 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/tronprotocol/tron-deployment/internal/diagnosis"
+	"github.com/tronprotocol/tron-deployment/internal/output"
+)
+
+// `trond heal <node>` is the auto-fix counterpart to `trond diagnose`.
+// It runs the same diagnostic suite and, for each failed check whose
+// remediation is *known and safe*, applies the fix automatically.
+// Anything destructive (remove, network destroy, --force) stays in
+// human hands.
+//
+// Conservative by design: a v1 healer that auto-restarts on every
+// fail signal would run away — sync_progress=fail just means "wait
+// longer," not "restart." We map specific (check, current state)
+// tuples to specific actions and explicitly skip the rest, surfacing
+// suggestions[] so the operator can pick up where heal stopped.
+//
+// Output schema: schemas/output/heal.schema.json.
+//
+// Idempotent: safe to re-run. If the previous run fixed everything,
+// the next one returns healed=[] / skipped=[] / still_failing=[].
+
+var (
+	healDryRun bool
+	healOnly   []string // restrict to specific check names; defaults = all
+)
+
+var autoHealCmd = &cobra.Command{
+	Use:   "auto-heal <node>",
+	Short: "Run diagnose, then auto-fix the failures whose remediation is known + safe",
+	Long: `Heal walks trond's diagnose output and attempts the documented
+remediation for each fail. Read-only inspection (status, diagnose);
+destructive actions stay behind a HUMAN_REQUIRED gate.
+
+Currently auto-fixable:
+  port_listening=fail and node.status=stopped → trond start <node>
+
+Surfaced for human action (heal does NOT touch them):
+  sync_progress=fail   — node is alive, just behind. Wait.
+  peer_count=fail      — recovers on its own when peers come back.
+  disk_space=fail      — needs operator attention.
+  memory_usage=fail    — needs operator attention.
+
+Use --dry-run to see what heal would do without acting.`,
+	Args: cobra.ExactArgs(1),
+	RunE: runAutoHeal,
+}
+
+func init() {
+	autoHealCmd.Flags().BoolVar(&healDryRun, "dry-run", false,
+		"Print proposed actions without executing them")
+	autoHealCmd.Flags().StringSliceVar(&healOnly, "only", nil,
+		"Comma-separated check names to consider; default = all checks")
+	rootCmd.AddCommand(autoHealCmd)
+}
+
+// healAction is one auto-fix attempt: which check triggered it,
+// what action we ran, and whether it succeeded.
+type healAction struct {
+	Check   string `json:"check"`
+	Action  string `json:"action"`
+	Result  string `json:"result"` // succeeded | failed | dry_run
+	Message string `json:"message,omitempty"`
+}
+
+// healSkip records a fail check we intentionally didn't auto-fix
+// (with the reason). Surfaces the suggestions[] so the operator
+// has the same context the agent would.
+type healSkip struct {
+	Check       string   `json:"check"`
+	Reason      string   `json:"reason"`
+	Suggestions []string `json:"suggestions,omitempty"`
+}
+
+func runAutoHeal(cmd *cobra.Command, args []string) error {
+	name := args[0]
+	start := time.Now()
+
+	nc, err := resolveNodeContext(name)
+	if err != nil {
+		return err
+	}
+	defer nc.Close()
+
+	// Run the same checker matrix `trond diagnose` does.
+	opts := diagnosis.CheckOpts{
+		NodeName:    nc.Node.Name,
+		NodeType:    "", // diagnose doesn't read this from state today; checkers cope
+		Runtime:     nc.Node.Runtime,
+		HTTPPort:    nc.Node.HTTPPort,
+		GRPCPort:    nc.Node.GRPCPort,
+		InstallPath: nc.Node.InstallPath,
+	}
+	ctx, cancel := context.WithTimeout(cmd.Context(), 30*time.Second)
+	defer cancel()
+	checkers := diagnosis.AllCheckers()
+	results := make([]diagnosis.CheckResult, 0, len(checkers))
+	for _, c := range checkers {
+		if len(healOnly) > 0 && !contains(healOnly, c.Name()) {
+			continue
+		}
+		results = append(results, c.Run(ctx, nc.Target, opts))
+	}
+
+	var (
+		healed       []healAction
+		skipped      []healSkip
+		stillFailing []diagnosis.CheckResult
+	)
+
+	for _, r := range results {
+		if r.Status != diagnosis.StatusFail {
+			continue
+		}
+		action, ok := proposeHealAction(r, nc.Node.Status)
+		if !ok {
+			skipped = append(skipped, healSkip{
+				Check:       r.Name,
+				Reason:      "no auto-fix mapped (manual remediation required)",
+				Suggestions: r.Suggestions,
+			})
+			stillFailing = append(stillFailing, r)
+			continue
+		}
+		if healDryRun {
+			healed = append(healed, healAction{
+				Check:   r.Name,
+				Action:  action.Action,
+				Result:  "dry_run",
+				Message: action.Message,
+			})
+			continue
+		}
+		if err := executeHealAction(cmd.Context(), nc, action); err != nil {
+			healed = append(healed, healAction{
+				Check:   r.Name,
+				Action:  action.Action,
+				Result:  "failed",
+				Message: err.Error(),
+			})
+			stillFailing = append(stillFailing, r)
+			continue
+		}
+		healed = append(healed, healAction{
+			Check:   r.Name,
+			Action:  action.Action,
+			Result:  "succeeded",
+			Message: action.Message,
+		})
+	}
+
+	result := map[string]any{
+		"name":          name,
+		"healed":        healed,
+		"skipped":       skipped,
+		"still_failing": stillFailing,
+		"duration_ms":   time.Since(start).Milliseconds(),
+		"dry_run":       healDryRun,
+	}
+
+	outputFmt, _ := cmd.Flags().GetString("output")
+	if outputFmt == "json" {
+		return output.WriteJSON(os.Stdout, result)
+	}
+	if len(healed) == 0 && len(skipped) == 0 {
+		fmt.Printf("✓ %s: no failed checks; nothing to heal.\n", name)
+		return nil
+	}
+	for _, h := range healed {
+		fmt.Printf("[%s] %s → %s: %s\n", h.Result, h.Check, h.Action, h.Message)
+	}
+	for _, s := range skipped {
+		fmt.Printf("[skipped] %s: %s\n", s.Check, s.Reason)
+		for _, sg := range s.Suggestions {
+			fmt.Printf("    - %s\n", sg)
+		}
+	}
+	return nil
+}
+
+// proposeHealAction maps (check.Name, current state) tuples to a
+// concrete fix. Returns ok=false when no automatic remediation is
+// safe — the caller surfaces suggestions[] instead.
+//
+// Adding a new auto-fix means landing both:
+//
+//  1. A case here that returns ok=true plus a healAction definition.
+//  2. A test in cmd/heal_test.go pinning the (check, state) tuple
+//     so the mapping doesn't silently drift.
+func proposeHealAction(r diagnosis.CheckResult, nodeStatus string) (proposedAction, bool) {
+	// Switch (rather than if-else) so future cases land cleanly:
+	// each (check, state) tuple gets one case + one test row.
+	//nolint:gocritic // single-case today; will grow per the package doc above.
+	switch {
+	case r.Name == "port_listening" && nodeStatus == "stopped":
+		return proposedAction{
+			Action:  "start",
+			Message: "node was marked stopped in state; bringing it back up",
+		}, true
+	}
+	return proposedAction{}, false
+}
+
+type proposedAction struct {
+	Action  string // "start" | "restart" | future actions
+	Message string
+}
+
+// executeHealAction runs the proposed action against the node. We
+// reuse the existing trond commands' machinery rather than calling
+// docker / systemd directly so audit logs + state updates flow
+// through the same path a manual `trond start` would.
+func executeHealAction(ctx context.Context, nc *nodeContext, action proposedAction) error {
+	if action.Action == "start" {
+		// Mirror cmd/start.go without going through cobra. The
+		// runtime's Start handles docker compose start / systemctl
+		// start uniformly.
+		if err := nc.Runtime.Start(ctx, nc.Node.Name); err != nil {
+			return err
+		}
+		nc.Node.Status = "running"
+		return nc.SaveState()
+	}
+	return fmt.Errorf("unknown heal action %q", action.Action)
+}
+
+func contains(haystack []string, needle string) bool {
+	for _, s := range haystack {
+		if strings.EqualFold(s, needle) {
+			return true
+		}
+	}
+	return false
+}

--- a/cmd/heal_test.go
+++ b/cmd/heal_test.go
@@ -1,0 +1,84 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/tronprotocol/tron-deployment/internal/diagnosis"
+)
+
+// TestProposeHealAction pins the (check, current state) → action
+// mapping for `trond auto-heal`. Every case here is a contract:
+// adding a new mapping requires adding a case here so the table
+// stays the source of truth.
+func TestProposeHealAction(t *testing.T) {
+	cases := []struct {
+		name       string
+		check      diagnosis.CheckResult
+		nodeStatus string
+		wantOK     bool
+		wantAction string
+	}{
+		{
+			name: "port-listening-fail-stopped-node-can-be-started",
+			check: diagnosis.CheckResult{
+				Name:   "port_listening",
+				Status: diagnosis.StatusFail,
+			},
+			nodeStatus: "stopped",
+			wantOK:     true,
+			wantAction: "start",
+		},
+		{
+			name: "port-listening-fail-running-node-no-auto-fix",
+			check: diagnosis.CheckResult{
+				Name:   "port_listening",
+				Status: diagnosis.StatusFail,
+			},
+			// If state thinks the node is running but ports aren't
+			// listening, auto-restart is risky (e.g. the container
+			// may be in the middle of a long startup); surface to
+			// human instead.
+			nodeStatus: "running",
+			wantOK:     false,
+		},
+		{
+			name: "sync-progress-fail-no-auto-fix",
+			check: diagnosis.CheckResult{
+				Name:   "sync_progress",
+				Status: diagnosis.StatusFail,
+			},
+			nodeStatus: "running",
+			wantOK:     false,
+		},
+		{
+			name: "peer-count-fail-no-auto-fix",
+			check: diagnosis.CheckResult{
+				Name:   "peer_count",
+				Status: diagnosis.StatusFail,
+			},
+			nodeStatus: "running",
+			wantOK:     false,
+		},
+		{
+			name: "disk-space-fail-no-auto-fix",
+			check: diagnosis.CheckResult{
+				Name:   "disk_space",
+				Status: diagnosis.StatusFail,
+			},
+			nodeStatus: "running",
+			wantOK:     false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := proposeHealAction(tc.check, tc.nodeStatus)
+			if ok != tc.wantOK {
+				t.Errorf("ok: got %v, want %v", ok, tc.wantOK)
+			}
+			if tc.wantOK && got.Action != tc.wantAction {
+				t.Errorf("action: got %q, want %q", got.Action, tc.wantAction)
+			}
+		})
+	}
+}

--- a/cmd/schema_coverage_test.go
+++ b/cmd/schema_coverage_test.go
@@ -72,6 +72,7 @@ func TestSchemaCoverage(t *testing.T) {
 	// lookup used by `trond schema`. Keep in sync with cmd/schema.go.
 	lookup := map[string]string{
 		"trond apply":             "apply",
+		"trond auto-heal":         "auto-heal",
 		"trond config validate":   "config-validate",
 		"trond config render":     "config-render",
 		"trond config diff":       "config-diff",

--- a/internal/mcp/conf_helpers.go
+++ b/internal/mcp/conf_helpers.go
@@ -1,0 +1,29 @@
+package mcp
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/tronprotocol/tron-deployment/internal/state"
+	"github.com/tronprotocol/tron-deployment/internal/target"
+)
+
+// readLiveConfigForMCP returns the bytes of the conf file currently
+// in use by the running node, regardless of runtime. Shared by
+// resources.go (trond://nodes/<name>/conf) and the future
+// verify_config tool.
+func readLiveConfigForMCP(ctx context.Context, tgt target.Target, node *state.ManagedNode) (string, error) {
+	if node.Runtime == "jar" {
+		out, err := tgt.Exec(ctx, "cat", node.InstallPath+"/conf/"+node.Name+".conf")
+		if err != nil {
+			return "", fmt.Errorf("read jar conf: %w", err)
+		}
+		return string(out), nil
+	}
+	out, err := tgt.Exec(ctx, "docker", "exec", node.Name, "cat",
+		"/java-tron/conf/"+node.Name+".conf")
+	if err != nil {
+		return "", fmt.Errorf("docker exec cat: %w", err)
+	}
+	return string(out), nil
+}

--- a/internal/mcp/resources.go
+++ b/internal/mcp/resources.go
@@ -1,0 +1,248 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/tronprotocol/tron-deployment/internal/paths"
+	"github.com/tronprotocol/tron-deployment/internal/state"
+)
+
+// registerResources wires read-only data sources as MCP resources.
+// Resources are conceptually different from tools: tools are
+// "actions" (verb), resources are "data" (noun). MCP-aware clients
+// like Claude Desktop surface resources in a file-system-like UI.
+//
+// Static resources (one fixed URI):
+//
+//   - trond://state             — full state.json
+//   - trond://audit-log         — last 200 audit log entries
+//   - trond://schema-manifest   — every embedded output schema + version
+//
+// Dynamic resource templates (URI variables):
+//
+//   - trond://nodes/{name}/endpoints  — one node's endpoints + ports
+//   - trond://nodes/{name}/conf       — one node's live HOCON conf
+//
+// Templates let agents attach a single node's data without dragging
+// in unrelated nodes — important when state has 10s of managed
+// nodes and the agent is only reasoning about one.
+func registerResources(s *mcp.Server) {
+	s.AddResource(&mcp.Resource{
+		URI:         "trond://state",
+		Name:        "state.json",
+		Description: "The state.json file at $TROND_STATE_DIR (or ~/.trond). Every managed node, target, runtime, ports, labels.",
+		MIMEType:    "application/json",
+	}, readStateResource)
+
+	s.AddResource(&mcp.Resource{
+		URI:         "trond://audit-log",
+		Name:        "audit.log (recent)",
+		Description: "Up to the last 200 entries of audit.log (JSONL). Use to answer 'what did we do to this node yesterday' without invoking the events tool.",
+		MIMEType:    "application/x-ndjson",
+	}, readAuditLogResource)
+
+	s.AddResource(&mcp.Resource{
+		URI:         "trond://schema-manifest",
+		Name:        "schema manifest",
+		Description: "SchemaVersion + every embedded output schema. Authoritative reference for the trond CLI surface.",
+		MIMEType:    "application/json",
+	}, readSchemaManifestResource)
+
+	s.AddResourceTemplate(&mcp.ResourceTemplate{
+		URITemplate: "trond://nodes/{name}/endpoints",
+		Name:        "node endpoints",
+		Description: "Endpoints (http / grpc / labels / target) for a single managed node. Smaller than trond://state when an agent only reasons about one node.",
+		MIMEType:    "application/json",
+	}, readNodeEndpointsResource)
+
+	s.AddResourceTemplate(&mcp.ResourceTemplate{
+		URITemplate: "trond://nodes/{name}/conf",
+		Name:        "node live HOCON conf",
+		Description: "The .conf file currently in use by the node's running container (docker exec cat). Read-only — use verify_config to compare against an intent.",
+		MIMEType:    "text/plain",
+	}, readNodeConfResource)
+}
+
+func readStateResource(_ context.Context, req *mcp.ReadResourceRequest) (*mcp.ReadResourceResult, error) {
+	store, err := state.NewStore(paths.State())
+	if err != nil {
+		return nil, fmt.Errorf("open state: %w", err)
+	}
+	st, err := store.Load()
+	if err != nil {
+		return nil, fmt.Errorf("read state: %w", err)
+	}
+	body, err := json.MarshalIndent(st, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("marshal state: %w", err)
+	}
+	return &mcp.ReadResourceResult{
+		Contents: []*mcp.ResourceContents{{
+			URI:      req.Params.URI,
+			MIMEType: "application/json",
+			Text:     string(body),
+		}},
+	}, nil
+}
+
+const auditLogTailMax = 200
+
+func readAuditLogResource(_ context.Context, req *mcp.ReadResourceRequest) (*mcp.ReadResourceResult, error) {
+	body, err := os.ReadFile(paths.AuditLog())
+	if err != nil {
+		if os.IsNotExist(err) {
+			return &mcp.ReadResourceResult{
+				Contents: []*mcp.ResourceContents{{
+					URI:      req.Params.URI,
+					MIMEType: "application/x-ndjson",
+					Text:     "",
+				}},
+			}, nil
+		}
+		return nil, fmt.Errorf("read audit log: %w", err)
+	}
+	return &mcp.ReadResourceResult{
+		Contents: []*mcp.ResourceContents{{
+			URI:      req.Params.URI,
+			MIMEType: "application/x-ndjson",
+			Text:     tailLines(string(body), auditLogTailMax),
+		}},
+	}, nil
+}
+
+func readSchemaManifestResource(_ context.Context, req *mcp.ReadResourceRequest) (*mcp.ReadResourceResult, error) {
+	body, err := schemaManifestJSON()
+	if err != nil {
+		return nil, err
+	}
+	return &mcp.ReadResourceResult{
+		Contents: []*mcp.ResourceContents{{
+			URI:      req.Params.URI,
+			MIMEType: "application/json",
+			Text:     body,
+		}},
+	}, nil
+}
+
+// readNodeEndpointsResource serves the per-node endpoints sub-resource.
+// URI shape: trond://nodes/<name>/endpoints
+func readNodeEndpointsResource(_ context.Context, req *mcp.ReadResourceRequest) (*mcp.ReadResourceResult, error) {
+	name, err := nodeNameFromURI(req.Params.URI, "/endpoints")
+	if err != nil {
+		return nil, err
+	}
+	node, err := loadNodeByName(name)
+	if err != nil {
+		return nil, err
+	}
+	endpoints := map[string]any{
+		"name":    node.Name,
+		"runtime": node.Runtime,
+		"target":  node.Target,
+		"endpoints": map[string]string{
+			"http": fmt.Sprintf("http://127.0.0.1:%d", node.HTTPPort),
+			"grpc": fmt.Sprintf("127.0.0.1:%d", node.GRPCPort),
+		},
+		"version": node.Version,
+		"labels":  node.Labels,
+	}
+	body, err := json.MarshalIndent(endpoints, "", "  ")
+	if err != nil {
+		return nil, err
+	}
+	return &mcp.ReadResourceResult{
+		Contents: []*mcp.ResourceContents{{
+			URI:      req.Params.URI,
+			MIMEType: "application/json",
+			Text:     string(body),
+		}},
+	}, nil
+}
+
+// readNodeConfResource serves the live HOCON conf for one node by
+// docker-exec-cat'ing the file inside the container.
+func readNodeConfResource(ctx context.Context, req *mcp.ReadResourceRequest) (*mcp.ReadResourceResult, error) {
+	name, err := nodeNameFromURI(req.Params.URI, "/conf")
+	if err != nil {
+		return nil, err
+	}
+	node, err := loadNodeByName(name)
+	if err != nil {
+		return nil, err
+	}
+	tgt, err := mcpResolveTargetFromNode(node)
+	if err != nil {
+		return nil, err
+	}
+	if c, ok := any(tgt).(interface{ Close() error }); ok {
+		defer c.Close()
+	}
+	live, err := readLiveConfigForMCP(ctx, tgt, node)
+	if err != nil {
+		return nil, err
+	}
+	return &mcp.ReadResourceResult{
+		Contents: []*mcp.ResourceContents{{
+			URI:      req.Params.URI,
+			MIMEType: "text/plain",
+			Text:     live,
+		}},
+	}, nil
+}
+
+// nodeNameFromURI extracts <name> from URIs of the form
+// trond://nodes/<name><suffix>. Returns a clean error when the URI
+// doesn't fit the expected shape — agents see it as a normal MCP
+// error rather than a panic.
+func nodeNameFromURI(uri, suffix string) (string, error) {
+	const prefix = "trond://nodes/"
+	if !strings.HasPrefix(uri, prefix) || !strings.HasSuffix(uri, suffix) {
+		return "", fmt.Errorf("URI %q does not match trond://nodes/<name>%s", uri, suffix)
+	}
+	mid := strings.TrimSuffix(strings.TrimPrefix(uri, prefix), suffix)
+	if mid == "" || strings.ContainsAny(mid, "/?#") {
+		return "", fmt.Errorf("URI %q has empty or malformed <name> segment", uri)
+	}
+	return mid, nil
+}
+
+func loadNodeByName(name string) (*state.ManagedNode, error) {
+	store, err := state.NewStore(paths.State())
+	if err != nil {
+		return nil, fmt.Errorf("open state: %w", err)
+	}
+	st, err := store.Load()
+	if err != nil {
+		return nil, fmt.Errorf("read state: %w", err)
+	}
+	node := store.GetNode(st, name)
+	if node == nil {
+		return nil, fmt.Errorf("no managed node named %q", name)
+	}
+	return node, nil
+}
+
+// tailLines returns at most n lines from the end of s, newline-
+// preserved. Bounded so a long-running operator's audit.log doesn't
+// blow out the agent's context window.
+func tailLines(s string, n int) string {
+	if s == "" {
+		return ""
+	}
+	count := 0
+	for i := len(s) - 1; i >= 0; i-- {
+		if s[i] == '\n' {
+			count++
+			if count > n {
+				return s[i+1:]
+			}
+		}
+	}
+	return s
+}

--- a/internal/mcp/resources_test.go
+++ b/internal/mcp/resources_test.go
@@ -1,0 +1,121 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	mcpsdk "github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// TestResources_StaticListAndRead exercises the three fixed-URI
+// resources: state, audit-log, schema-manifest.
+func TestResources_StaticListAndRead(t *testing.T) {
+	session, cleanup := newConnectedPair(t)
+	defer cleanup()
+
+	res, err := session.ListResources(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("ListResources: %v", err)
+	}
+	got := map[string]bool{}
+	for _, r := range res.Resources {
+		got[r.URI] = true
+	}
+	want := []string{
+		"trond://state",
+		"trond://audit-log",
+		"trond://schema-manifest",
+	}
+	for _, uri := range want {
+		if !got[uri] {
+			t.Errorf("resource %q missing from ListResources", uri)
+		}
+	}
+
+	for _, uri := range want {
+		t.Run(uri, func(t *testing.T) {
+			out, err := session.ReadResource(context.Background(),
+				&mcpsdk.ReadResourceParams{URI: uri})
+			if err != nil {
+				t.Fatalf("ReadResource(%s): %v", uri, err)
+			}
+			if len(out.Contents) == 0 {
+				t.Fatalf("ReadResource(%s) returned no contents", uri)
+			}
+			body := out.Contents[0]
+			switch uri {
+			case "trond://state", "trond://schema-manifest":
+				var v any
+				if err := json.Unmarshal([]byte(body.Text), &v); err != nil {
+					t.Errorf("%s body not JSON: %v\n%s", uri, err, body.Text)
+				}
+			case "trond://audit-log":
+				for _, line := range strings.Split(body.Text, "\n") {
+					line = strings.TrimSpace(line)
+					if line == "" {
+						continue
+					}
+					var v any
+					if err := json.Unmarshal([]byte(line), &v); err != nil {
+						t.Errorf("%s: line is not JSON: %v\nline: %s",
+							uri, err, line)
+					}
+				}
+			}
+		})
+	}
+}
+
+// TestResources_TemplatesListed verifies that ListResourceTemplates
+// surfaces the per-node URI templates we registered.
+func TestResources_TemplatesListed(t *testing.T) {
+	session, cleanup := newConnectedPair(t)
+	defer cleanup()
+
+	res, err := session.ListResourceTemplates(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("ListResourceTemplates: %v", err)
+	}
+	got := map[string]bool{}
+	for _, rt := range res.ResourceTemplates {
+		got[rt.URITemplate] = true
+	}
+	for _, want := range []string{
+		"trond://nodes/{name}/endpoints",
+		"trond://nodes/{name}/conf",
+	} {
+		if !got[want] {
+			t.Errorf("template %q missing", want)
+		}
+	}
+}
+
+// TestNodeNameFromURI pins the URI parser used by both per-node
+// resource templates. Bad shapes must fail loud rather than read
+// the wrong node.
+func TestNodeNameFromURI(t *testing.T) {
+	cases := []struct {
+		uri     string
+		suffix  string
+		want    string
+		wantErr bool
+	}{
+		{"trond://nodes/my-fullnode/endpoints", "/endpoints", "my-fullnode", false},
+		{"trond://nodes/my-fullnode/conf", "/conf", "my-fullnode", false},
+		{"trond://nodes//endpoints", "/endpoints", "", true},
+		{"trond://nodes/a/b/endpoints", "/endpoints", "", true},
+		{"trond://nodes/x?y/endpoints", "/endpoints", "", true},
+		{"trond://state", "/endpoints", "", true},
+	}
+	for _, tc := range cases {
+		got, err := nodeNameFromURI(tc.uri, tc.suffix)
+		if (err != nil) != tc.wantErr {
+			t.Errorf("uri=%q: err=%v, wantErr=%v", tc.uri, err, tc.wantErr)
+		}
+		if got != tc.want {
+			t.Errorf("uri=%q: got %q, want %q", tc.uri, got, tc.want)
+		}
+	}
+}

--- a/internal/mcp/schema_manifest.go
+++ b/internal/mcp/schema_manifest.go
@@ -1,0 +1,33 @@
+package mcp
+
+import (
+	"encoding/json"
+
+	"github.com/tronprotocol/tron-deployment/internal/schema"
+)
+
+// schemaManifestJSON returns a compact manifest exposed via the
+// `trond://schema-manifest` resource. We avoid pulling the full
+// cobra-tree walker (lives in cmd/schema.go) so this stays
+// importable from internal/mcp without a cycle. Callers that want
+// the full command/flag manifest should shell out to
+// `trond schema -o json`.
+func schemaManifestJSON() (string, error) {
+	out := struct {
+		SchemaVersion string                    `json:"schema_version"`
+		Schemas       map[string]map[string]any `json:"schemas"`
+	}{
+		SchemaVersion: schema.SchemaVersion,
+		Schemas:       map[string]map[string]any{},
+	}
+	for _, name := range schema.Names() {
+		if doc, ok := schema.Get(name); ok {
+			out.Schemas[name] = doc
+		}
+	}
+	body, err := json.MarshalIndent(out, "", "  ")
+	if err != nil {
+		return "", err
+	}
+	return string(body), nil
+}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -65,6 +65,12 @@ func Run(ctx context.Context, in io.Reader, out io.Writer, trondVersion string) 
 	registerDiagnosticTools(server)
 	registerSnapshotTools(server)
 	registerKnowledgeTools(server)
+	registerHealTools(server)
+
+	// Beyond tools, MCP exposes resources (read-only data the agent
+	// attaches to a conversation) and resource templates (per-node
+	// dynamic URIs).
+	registerResources(server)
 
 	// MCP's stdio transport is a thin wrapper around io.Reader/Writer
 	// pairs; tests pass net.Pipe() ends, real use passes os.Stdin/Stdout.

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -33,6 +33,8 @@ func newConnectedPair(t *testing.T) (*mcp.ClientSession, func()) {
 	registerSnapshotTools(server)
 	registerKnowledgeTools(server)
 	registerLifecycleTools(server)
+	registerHealTools(server)
+	registerResources(server)
 
 	client := mcp.NewClient(&mcp.Implementation{Name: "client", Version: "test"}, nil)
 

--- a/internal/mcp/tools_heal.go
+++ b/internal/mcp/tools_heal.go
@@ -1,0 +1,155 @@
+package mcp
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/tronprotocol/tron-deployment/internal/diagnosis"
+	"github.com/tronprotocol/tron-deployment/internal/paths"
+	"github.com/tronprotocol/tron-deployment/internal/runtime"
+	"github.com/tronprotocol/tron-deployment/internal/state"
+	"github.com/tronprotocol/tron-deployment/internal/target"
+)
+
+// registerHealTools wires the auto_heal MCP tool — the in-process
+// twin of `trond auto-heal`. Marked destructive because some
+// remediation actions (start/restart) do change the runtime; agents
+// must surface to the user before invoking unless dry_run=true.
+
+type autoHealArgs struct {
+	Name   string `json:"name" jsonschema:"managed node name"`
+	DryRun bool   `json:"dry_run,omitempty" jsonschema:"if true, propose actions without executing"`
+}
+
+func registerHealTools(s *mcp.Server) {
+	mcp.AddTool(s, &mcp.Tool{
+		Name:        "auto_heal",
+		Title:       "Auto-fix known fail checks on a node",
+		Description: "Run trond's diagnostic suite, then apply documented remediations to fail checks (e.g. port_listening fail + status=stopped → start). Only safe, idempotent actions are mapped; everything else surfaces in skipped[] with suggestions for the human. Equivalent to `trond auto-heal <node> -o json`. Pass dry_run=true to propose without acting.",
+		Annotations: &mcp.ToolAnnotations{
+			DestructiveHint: ptrTrue(),
+			IdempotentHint:  true,
+		},
+	}, autoHealTool)
+}
+
+func autoHealTool(ctx context.Context, _ *mcp.CallToolRequest, args autoHealArgs) (*mcp.CallToolResult, any, error) {
+	if args.Name == "" {
+		return errResult(fmt.Errorf("name is required"))
+	}
+
+	store, err := state.NewStore(paths.State())
+	if err != nil {
+		return errResult(err)
+	}
+	st, err := store.Load()
+	if err != nil {
+		return errResult(err)
+	}
+	node := store.GetNode(st, args.Name)
+	if node == nil {
+		return errResult(notFound("auto_heal", args.Name))
+	}
+
+	tgt, err := mcpResolveTargetFromNode(node)
+	if err != nil {
+		return errResult(err)
+	}
+	if c, ok := any(tgt).(interface{ Close() error }); ok {
+		defer c.Close()
+	}
+
+	probeCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+	opts := diagnosis.CheckOpts{
+		NodeName:    node.Name,
+		Runtime:     node.Runtime,
+		HTTPPort:    node.HTTPPort,
+		GRPCPort:    node.GRPCPort,
+		InstallPath: node.InstallPath,
+	}
+
+	var (
+		healed       []map[string]any
+		skipped      []map[string]any
+		stillFailing []diagnosis.CheckResult
+	)
+	for _, c := range diagnosis.AllCheckers() {
+		r := c.Run(probeCtx, tgt, opts)
+		if r.Status != diagnosis.StatusFail {
+			continue
+		}
+		action, ok := mcpProposeHealAction(r, node.Status)
+		if !ok {
+			skipped = append(skipped, map[string]any{
+				"check":       r.Name,
+				"reason":      "no auto-fix mapped (manual remediation required)",
+				"suggestions": r.Suggestions,
+			})
+			stillFailing = append(stillFailing, r)
+			continue
+		}
+		if args.DryRun {
+			healed = append(healed, map[string]any{
+				"check":   r.Name,
+				"action":  action.action,
+				"result":  "dry_run",
+				"message": action.message,
+			})
+			continue
+		}
+		err := mcpRunHealAction(ctx, tgt, node, action)
+		entry := map[string]any{
+			"check":  r.Name,
+			"action": action.action,
+		}
+		if err != nil {
+			entry["result"] = "failed"
+			entry["message"] = err.Error()
+			stillFailing = append(stillFailing, r)
+		} else {
+			entry["result"] = "succeeded"
+			entry["message"] = action.message
+			node.Status = "running"
+			store.UpsertNode(st, *node)
+			_ = store.Save(st)
+		}
+		healed = append(healed, entry)
+	}
+
+	return jsonResult(map[string]any{
+		"name":          args.Name,
+		"dry_run":       args.DryRun,
+		"healed":        healed,
+		"skipped":       skipped,
+		"still_failing": stillFailing,
+	})
+}
+
+type mcpHealAction struct {
+	action  string
+	message string
+}
+
+func mcpProposeHealAction(r diagnosis.CheckResult, nodeStatus string) (mcpHealAction, bool) {
+	//nolint:gocritic // single case today, mirrors cmd.proposeHealAction.
+	switch {
+	case r.Name == "port_listening" && nodeStatus == "stopped":
+		return mcpHealAction{
+			action:  "start",
+			message: "node was marked stopped in state; bringing it back up",
+		}, true
+	}
+	return mcpHealAction{}, false
+}
+
+func mcpRunHealAction(ctx context.Context, tgt target.Target, node *state.ManagedNode, action mcpHealAction) error {
+	rt := runtime.NewDockerRuntime(tgt, paths.Deployments())
+	if action.action == "start" {
+		return rt.Start(ctx, node.Name)
+	}
+	return fmt.Errorf("unknown heal action %q", action.action)
+}

--- a/internal/schema/embed.go
+++ b/internal/schema/embed.go
@@ -38,7 +38,8 @@ import (
 //	        snapshot-download, snapshot-jobs, error envelope).
 //	1.1.0 — add recipe-list / recipe-show / recipe-run schemas (no
 //	        changes to existing schemas).
-const SchemaVersion = "1.1.0"
+//	1.2.0 — add auto-heal schema (new `trond auto-heal` command).
+const SchemaVersion = "1.2.0"
 
 // JSONSchemaURLBase is the canonical URL prefix for individual output
 // schema files. Embedded $id values inside each schema mirror this so

--- a/internal/schema/files/auto-heal.schema.json
+++ b/internal/schema/files/auto-heal.schema.json
@@ -1,0 +1,60 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/tronprotocol/tron-deployment/blob/master/schemas/output/auto-heal.schema.json",
+  "title": "trond auto-heal output",
+  "description": "Returned by `trond auto-heal <node> -o json`. The auto-fix counterpart to diagnose: runs the diagnostic suite and applies known-safe remediations to fail checks. Conservative — anything destructive (remove, network destroy, --force) stays behind a HUMAN_REQUIRED gate.",
+  "type": "object",
+  "required": ["name", "healed", "skipped", "still_failing"],
+  "properties": {
+    "name": { "type": "string" },
+    "dry_run": {
+      "type": "boolean",
+      "description": "True if --dry-run was passed; `healed[].result` will be 'dry_run' rather than 'succeeded'/'failed'."
+    },
+    "duration_ms": { "type": "integer", "minimum": 0 },
+    "healed": {
+      "type": "array",
+      "description": "Auto-fix attempts: one entry per fail check that had a known remediation.",
+      "items": {
+        "type": "object",
+        "required": ["check", "action", "result"],
+        "properties": {
+          "check":   { "type": "string", "description": "Diagnose check name (e.g. port_listening)." },
+          "action":  { "type": "string", "description": "Action invoked (e.g. start, restart)." },
+          "result":  { "type": "string", "enum": ["succeeded", "failed", "dry_run"] },
+          "message": { "type": "string" }
+        }
+      }
+    },
+    "skipped": {
+      "type": "array",
+      "description": "Fail checks heal explicitly did NOT touch (no auto-fix mapped). Surfaces suggestions[] so the operator has the same context.",
+      "items": {
+        "type": "object",
+        "required": ["check", "reason"],
+        "properties": {
+          "check":  { "type": "string" },
+          "reason": { "type": "string" },
+          "suggestions": {
+            "type": "array",
+            "items": { "type": "string" }
+          }
+        }
+      }
+    },
+    "still_failing": {
+      "type": "array",
+      "description": "CheckResult entries that remain fail even after the heal pass — either skipped or where the action returned an error.",
+      "items": {
+        "type": "object",
+        "required": ["name", "status"],
+        "properties": {
+          "name":        { "type": "string" },
+          "status":      { "type": "string", "enum": ["pass", "warning", "fail"] },
+          "message":     { "type": "string" },
+          "suggestions": { "type": "array", "items": { "type": "string" } }
+        }
+      }
+    }
+  }
+}

--- a/internal/schema/version_baseline.json
+++ b/internal/schema/version_baseline.json
@@ -1,9 +1,13 @@
 {
-  "schema_version": "1.1.0",
+  "schema_version": "1.2.0",
   "entries": [
     {
       "name": "apply",
       "hash": "274ee04ddb36fc57068616ddd758afd6389fddcdde721131391a5236967a29dd"
+    },
+    {
+      "name": "auto-heal",
+      "hash": "1a1108e340bf94c7d568f27245183245fce793e3527383159c33f951adbbd00e"
     },
     {
       "name": "config-diff",

--- a/schemas/output/auto-heal.schema.json
+++ b/schemas/output/auto-heal.schema.json
@@ -1,0 +1,60 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/tronprotocol/tron-deployment/blob/master/schemas/output/auto-heal.schema.json",
+  "title": "trond auto-heal output",
+  "description": "Returned by `trond auto-heal <node> -o json`. The auto-fix counterpart to diagnose: runs the diagnostic suite and applies known-safe remediations to fail checks. Conservative — anything destructive (remove, network destroy, --force) stays behind a HUMAN_REQUIRED gate.",
+  "type": "object",
+  "required": ["name", "healed", "skipped", "still_failing"],
+  "properties": {
+    "name": { "type": "string" },
+    "dry_run": {
+      "type": "boolean",
+      "description": "True if --dry-run was passed; `healed[].result` will be 'dry_run' rather than 'succeeded'/'failed'."
+    },
+    "duration_ms": { "type": "integer", "minimum": 0 },
+    "healed": {
+      "type": "array",
+      "description": "Auto-fix attempts: one entry per fail check that had a known remediation.",
+      "items": {
+        "type": "object",
+        "required": ["check", "action", "result"],
+        "properties": {
+          "check":   { "type": "string", "description": "Diagnose check name (e.g. port_listening)." },
+          "action":  { "type": "string", "description": "Action invoked (e.g. start, restart)." },
+          "result":  { "type": "string", "enum": ["succeeded", "failed", "dry_run"] },
+          "message": { "type": "string" }
+        }
+      }
+    },
+    "skipped": {
+      "type": "array",
+      "description": "Fail checks heal explicitly did NOT touch (no auto-fix mapped). Surfaces suggestions[] so the operator has the same context.",
+      "items": {
+        "type": "object",
+        "required": ["check", "reason"],
+        "properties": {
+          "check":  { "type": "string" },
+          "reason": { "type": "string" },
+          "suggestions": {
+            "type": "array",
+            "items": { "type": "string" }
+          }
+        }
+      }
+    },
+    "still_failing": {
+      "type": "array",
+      "description": "CheckResult entries that remain fail even after the heal pass — either skipped or where the action returned an error.",
+      "items": {
+        "type": "object",
+        "required": ["name", "status"],
+        "properties": {
+          "name":        { "type": "string" },
+          "status":      { "type": "string", "enum": ["pass", "warning", "fail"] },
+          "message":     { "type": "string" },
+          "suggestions": { "type": "array", "items": { "type": "string" } }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Round 7 from the backlog: two new agent-facing capabilities.

## \`trond auto-heal <node>\`

The auto-fix counterpart to \`trond diagnose\`. Runs the diagnostic suite and applies **known-safe** remediations to fail checks. Conservative — a v1 healer that auto-restarts on every fail signal would run away (\`sync_progress=fail\` just means \"wait longer,\" not \"restart\").

Initial (check, state) → action mapping:

| Check | State | Action |
|---|---|---|
| \`port_listening=fail\` | \`stopped\` | \`trond start\` |

Everything else lands in \`skipped[]\` with the diagnose \`suggestions[]\` so the operator/agent has the same context the regular diagnose surfaced.

\`--dry-run\` reports proposals without acting. Output validates against \`schemas/output/auto-heal.schema.json\`.

**MCP**: \`auto_heal\` tool with \`destructiveHint=true\`. Agents call it with \`dry_run=true\` first to surface what would happen, then re-call to act.

## MCP resource templates

Per-node URI templates so an agent attaches exactly one node's data without dragging in the whole estate:

| Template | What |
|---|---|
| \`trond://nodes/{name}/endpoints\` | endpoints + ports + target type |
| \`trond://nodes/{name}/conf\` | live HOCON conf via \`docker exec cat\` |

Static \`trond://state\`, \`trond://audit-log\`, \`trond://schema-manifest\` from #164 stay; templates are additive.

## Schema

- \`schemas/output/auto-heal.schema.json\` (new) + sync'd into embedded copy.
- SchemaVersion \`1.1.0 → 1.2.0\` (new schema = MINOR per package doc), baseline regenerated.

## Tests

| File | Coverage |
|---|---|
| \`cmd/heal_test.go\` | Pin (check, state) → action mapping for every documented case |
| \`internal/mcp/resources_test.go\` | List + read for static URIs; ListResourceTemplates exposes per-node templates; nodeNameFromURI edge cases |

## Why

\`auto-heal\` is the first \"trond as self-healing system\" primitive — diagnose stops being a passive triage tool. Resource templates are the missing per-node URI shape that lets MCP-aware agents attach precisely one node's data.

Together they close another gap on the agent UX side: an agent's typical reconcile loop is now

\`\`\`
attach trond://nodes/{name}/endpoints  →  diagnose  →  auto-heal --dry-run  →  surface to user  →  auto-heal
\`\`\`

without forking trond once.

## Test plan

- [x] \`go test -race ./...\`
- [x] \`make lint\`
- [x] \`make sync-schemas\` + \`make snapshot-schema-baseline\` regenerate cleanly
- [x] CLI: \`trond auto-heal --help\` lists the command; \`trond auto-heal <node>\` runs end-to-end
- [x] MCP: \`tools/list\` exposes \`auto_heal\`; \`resources/templates/list\` exposes both per-node templates