### PR TITLE
chore: gitignore CLAUDE.md and redirect editing-agent guidance to AGENTS.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ Thumbs.db
 
 # Local Claude Code workspace state
 .claude/
+CLAUDE.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,9 +1,9 @@
 # AGENTS.md — for AI agents that call `trond`
 
 This file is **for agents that USE trond as a tool** (Claude, ChatGPT,
-Cursor, Cline, autonomous workflows, CI bots, etc.). If you are an
-agent EDITING this repository, read `CLAUDE.md` instead — that one
-covers code style and architecture rules for changes to trond itself.
+Cursor, Cline, autonomous workflows, CI bots, etc.). Agents editing
+this repository should also start here, then read the package-level
+doc comments under `internal/` for architecture detail.
 
 The contract here is meant to be self-contained: an agent that reads
 this file once should be able to deploy, diagnose, and recover TRON


### PR DESCRIPTION
## Summary

- Add `CLAUDE.md` to `.gitignore`. The file is a Claude-Code-only convenience
  that mostly duplicates `AGENTS.md`, plus a project-structure section already
  covered by README's Architecture diagram and per-package godoc.
- Update `AGENTS.md` preamble: it previously pointed editing-trond agents at
  `CLAUDE.md`, which no longer lives in the repo. Redirect those agents to
  start at `AGENTS.md` itself, then read `internal/*/` package doc comments
  for architecture detail.

## Why

`CLAUDE.md` was auto-generated content + a duplicate of `AGENTS.md`. Keeping
it tracked added two failure modes: (1) it drifts out of sync with the
canonical guide, (2) every contributor has to maintain a Claude-only file.
Coverage check before shipping:

| Original CLAUDE.md content | Where it lives now |
|---|---|
| Workflow / exit codes / commands / SDK | `AGENTS.md` (more detailed) |
| `make build / test / lint / e2e / build-all` | `README.md` ## Development |
| Architecture overview | `README.md` ## Architecture (data-flow diagram) |
| Project structure tree | `internal/*/` package docs (godoc) |
| Active Technologies / Recent Changes | spec scaffolding, no information value |

Local `CLAUDE.md` files are still picked up by Claude Code automatically
without being checked in.

## Test plan

- [x] `git check-ignore -v CLAUDE.md` matches the new `.gitignore` rule
- [x] `grep -rn "CLAUDE.md" --include="*.md" --include="*.go"` shows the
      remaining references are only in CHANGELOG / specs / .specify (historical
      planning artifacts, not onboarding entry points)