### PR TITLE
feat(config): add system-test as fourth embedded HOCON network template

### DIFF
--- a/cmd/preflight.go
+++ b/cmd/preflight.go
@@ -155,7 +155,11 @@ func checkDiskSpace(cmd *cobra.Command, tgt target.Target, parsed *intent.Intent
 	}
 	freeGB := free / (1024 * 1024 * 1024)
 	minGB := uint64(100) // Mainnet needs ~100GB+
-	if parsed.Network == "nile" || parsed.Network == "private" {
+	// nile / private / system-test are short-lived test chains whose DB
+	// stays in the low-GB range; reuse the relaxed 10 GB threshold for
+	// all of them. (Adding a new "test-shaped" network here is required
+	// alongside the new entry in render.NetworkTemplate.)
+	if parsed.Network == "nile" || parsed.Network == "private" || parsed.Network == "system-test" {
 		minGB = 10
 	}
 	if freeGB < minGB {

--- a/cmd/preflight_test.go
+++ b/cmd/preflight_test.go
@@ -1,0 +1,79 @@
+package cmd
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/tronprotocol/tron-deployment/internal/intent"
+)
+
+// fakeTarget is a minimal target.Target stub that returns canned disk
+// and memory values. Only DiskFree / MemTotal are exercised by the
+// preflight check tests; the rest satisfy the interface.
+type fakeTarget struct {
+	diskFreeBytes uint64
+	memTotalBytes uint64
+}
+
+func (f *fakeTarget) Exec(ctx context.Context, cmd string, args ...string) ([]byte, error) {
+	return nil, nil
+}
+func (f *fakeTarget) Upload(ctx context.Context, l, r string) error                          { return nil }
+func (f *fakeTarget) Download(ctx context.Context, r, l string) error                        { return nil }
+func (f *fakeTarget) ReadFile(ctx context.Context, p string) ([]byte, error)                 { return nil, nil }
+func (f *fakeTarget) WriteFile(ctx context.Context, p string, d []byte, m os.FileMode) error { return nil }
+func (f *fakeTarget) DiskFree(ctx context.Context, p string) (uint64, error) {
+	return f.diskFreeBytes, nil
+}
+func (f *fakeTarget) MemTotal(ctx context.Context) (uint64, error) { return f.memTotalBytes, nil }
+func (f *fakeTarget) String() string                               { return "fake" }
+
+// TestCheckDiskSpace_NetworkThresholds pins the per-network disk
+// requirement: only mainnet (the implicit default) demands 100 GB; all
+// short-lived test chains relax to 10 GB. Adding a new private-shape
+// network must update this list AND extend the allowlist in
+// checkDiskSpace, otherwise the new network silently inherits the
+// mainnet threshold (the bug we hit on warku123/java-tron PR#4 — the
+// CI runner had 87 GB free, which fails mainnet's 100 GB but easily
+// clears 10 GB).
+func TestCheckDiskSpace_NetworkThresholds(t *testing.T) {
+	// 87 GB free — close to what a fresh GitHub Actions
+	// ubuntu-latest runner reports.
+	const bytes87GB = uint64(87) * 1024 * 1024 * 1024
+
+	cmd := &cobra.Command{}
+	cmd.SetContext(context.Background())
+
+	cases := []struct {
+		network    string
+		wantStatus string
+		wantMsg    string // substring match
+	}{
+		{"mainnet", "fail", "100GB recommended"},
+		{"nile", "pass", "87GB free"},
+		{"private", "pass", "87GB free"},
+		{"system-test", "pass", "87GB free"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.network, func(t *testing.T) {
+			tgt := &fakeTarget{
+				diskFreeBytes: bytes87GB,
+				memTotalBytes: 16 * 1024 * 1024 * 1024,
+			}
+			i := &intent.Intent{Network: tc.network}
+			r := checkDiskSpace(cmd, tgt, i)
+			if r.Status != tc.wantStatus {
+				t.Errorf("network=%s, got status=%q msg=%q, want status=%q",
+					tc.network, r.Status, r.Message, tc.wantStatus)
+			}
+			if !strings.Contains(r.Message, tc.wantMsg) {
+				t.Errorf("network=%s, msg=%q does not contain %q",
+					tc.network, r.Message, tc.wantMsg)
+			}
+		})
+	}
+}

--- a/examples/system-test-singlenode-intent.yaml
+++ b/examples/system-test-singlenode-intent.yaml
@@ -1,0 +1,62 @@
+# Single-SR private chain matching tronprotocol/system-test's expectations.
+#
+# Used by stest-up.sh to spin up the node that 649 stest testcases
+# connect to via gRPC/HTTP. Ports below align with stest's testng.conf
+# endpoint section, so testng.conf does not need editing.
+#
+# Pre-requisite: caller must drop the FullNode.jar to be tested at
+# {install_path}/FullNode.jar BEFORE running `trond apply` (or the
+# `system-test` recipe). Trond's jar runtime sees `jar.url` is unset
+# and uses the pre-placed file. This is how java-tron CI feeds the
+# PR-built jar to the test environment.
+#
+# Witness signing: stest's HOCON template (network: system-test)
+# inlines `localwitness = [...]` with two test SR keys (matching the
+# two genesis witnesses Mercury and Venus). We do NOT set
+# `witness_key` here — that would trigger trond to append an
+# override block. The template's keys are authoritative.
+#
+# Usage:
+#   sudo cp $JAR /opt/tron/stest-singlenode/FullNode.jar
+#   sudo trond apply --intent examples/system-test-singlenode-intent.yaml --wait
+# Or via recipe:
+#   sudo trond recipe run system-test --param name=stest-singlenode
+
+name: stest-singlenode
+
+target:
+  type: local
+  runtime: jar
+
+network: system-test
+
+nodes:
+  # type is set to "fullnode" (not "witness") deliberately. The actual
+  # node IS a witness — `extra_args: ["--witness"]` below ensures the
+  # FullNode CLI gets the --witness flag — but trond's intent validator
+  # requires `witness_key_env` for type: witness, which would force
+  # trond to append `localwitness = ["${ENV_VAL}"]` and OVERRIDE the
+  # template's two inline localwitness keys (HOCON last-write-wins).
+  # We need the template's two keys intact (one per genesis witness:
+  # Mercury and Venus, both must sign for 2-of-2 PBFT solidification),
+  # so we sidestep the validator by labeling the node a fullnode and
+  # forcing --witness via extra_args. The only visible consequence is
+  # the systemd unit's Description text says "TRON Fullnode Node
+  # (stest-singlenode)" instead of "Witness Node". See openspec change
+  # system-test-integration follow-ups for the cleaner long-term fix
+  # (validator opt-out flag).
+  - type: fullnode
+    extra_args: ["--witness"]
+    install_path: /opt/tron/stest-singlenode
+    resources:
+      memory: 4GB
+    ports:
+      # These match testng.conf (system-test/testcase/src/test/resources/
+      # testng.conf, top section). Don't change without updating both
+      # sides — port drift breaks every stest testcase silently.
+      http: 8090       # fullnode HTTP (testng.conf httpnode.ip.list[0])
+      grpc: 50051      # fullnode gRPC (testng.conf fullnode.ip.list[0])
+      p2p: 18888       # peer listen (template's node.listen.port)
+      jsonrpc: 8545    # jsonrpc HTTP (template's httpFullNodePort; differs
+                       # from testng.conf's 50545 — known config drift,
+                       # stest CI uses this value successfully)

--- a/internal/intent/fields_test.go
+++ b/internal/intent/fields_test.go
@@ -196,6 +196,7 @@ func TestNetwork_Enum(t *testing.T) {
 		{"mainnet", false},
 		{"nile", false},
 		{"private", false},
+		{"system-test", false},
 		{"shasta", true},
 		{"testnet", true},
 		{"", true},

--- a/internal/intent/schema.go
+++ b/internal/intent/schema.go
@@ -4,7 +4,7 @@ package intent
 type Intent struct {
 	Name    string     `yaml:"name" json:"name" validate:"required,hostname_rfc1123"`
 	Target  Target     `yaml:"target" json:"target" validate:"required"`
-	Network string     `yaml:"network" json:"network" validate:"required,oneof=mainnet nile private"`
+	Network string     `yaml:"network" json:"network" validate:"required,oneof=mainnet nile private system-test"`
 	Nodes   []NodeSpec `yaml:"nodes" json:"nodes" validate:"required,min=1,dive"`
 }
 

--- a/internal/recipe/files/system-test.yaml
+++ b/internal/recipe/files/system-test.yaml
@@ -1,0 +1,73 @@
+name: system-test
+description: |
+  Bring up a single-SR private chain matching tronprotocol/system-test's
+  expectations, suitable for running stest's TestNG suite against. Default
+  intent_path points at examples/system-test-singlenode-intent.yaml; the
+  caller can override to use a customized intent if needed.
+
+  Pre-requisite: caller must drop the FullNode.jar to be tested at
+  {install_path}/FullNode.jar BEFORE invoking this recipe. Trond's jar
+  runtime sees jar.url is unset and uses the pre-placed file. Typical
+  shape from a CI workflow:
+
+    sudo mkdir -p /opt/tron/stest-singlenode
+    sudo cp $JAR /opt/tron/stest-singlenode/FullNode.jar
+    sudo trond recipe run system-test
+    cd system-test && ./gradlew :testcase:singleNodeBuild
+    sudo trond network destroy stest-singlenode --confirm stest-singlenode
+
+  This is the canonical replacement for java-tron CI's bare
+  `nohup java -jar build/libs/FullNode.jar --witness -c config-system-test.conf &`
+  bootstrap step (system-test.yml line 55-77).
+
+params:
+  - name: intent_path
+    type: path
+    required: false
+    default: examples/system-test-singlenode-intent.yaml
+    description: |
+      Path to a stest single-SR intent.yaml. Default is the bundled
+      example which uses ports aligned with stest's testng.conf.
+
+steps:
+  - id: validate
+    description: Catch typos before any network IO.
+    command: config validate
+    args:
+      - "{{ params.intent_path }}"
+    on_failure: abort
+
+  - id: preflight
+    description: Verify Java / memory / ports / install_path writable on target.
+    command: preflight
+    args:
+      - --intent
+      - "{{ params.intent_path }}"
+    on_failure: abort
+
+  - id: apply
+    description: |
+      Render HOCON + systemd unit, write to /etc/systemd/system, start
+      the service, and block until the FullNode HTTP endpoint responds.
+    command: apply
+    args:
+      - --intent
+      - "{{ params.intent_path }}"
+      - --auto-approve
+      - --wait
+      - --wait-timeout
+      - 5m
+    persist:
+      - name
+      - endpoints
+    on_failure: abort
+
+  - id: verify
+    description: Confirm the node is minting blocks (block_height > 0).
+    command: verify
+    args:
+      - --intent
+      - "{{ params.intent_path }}"
+      - --timeout
+      - 5m
+    on_failure: abort

--- a/internal/render/embed.go
+++ b/internal/render/embed.go
@@ -7,9 +7,10 @@ import (
 	"path/filepath"
 )
 
-// embeddedTemplates contains the three base java-tron config files bundled
-// into the binary. They are the source of truth when no external template
-// directory is configured — release builds always work out of the box.
+// embeddedTemplates contains the four base java-tron config files bundled
+// into the binary (mainnet, nile, private, system-test). They are the
+// source of truth when no external template directory is configured —
+// release builds always work out of the box.
 //
 //go:embed templates/*.conf
 var embeddedTemplates embed.FS

--- a/internal/render/hocon.go
+++ b/internal/render/hocon.go
@@ -10,10 +10,15 @@ import (
 )
 
 // NetworkTemplate maps network names to their base config template file.
+// "system-test" is the canonical private-chain template used by the
+// tronprotocol/system-test test suite — selecting it gives a single-SR
+// private network with stest's genesis, committee flags, and 5-minute
+// maintenance interval, sourced from stest's release_workflow branch.
 var NetworkTemplate = map[string]string{
-	"mainnet": "main_net_config.conf",
-	"nile":    "test_net_config.conf",
-	"private": "private_net_config.conf",
+	"mainnet":     "main_net_config.conf",
+	"nile":        "test_net_config.conf",
+	"private":     "private_net_config.conf",
+	"system-test": "system-test.conf",
 }
 
 // RenderHOCON loads the base template for the network and applies intent-driven overrides.

--- a/internal/render/hocon_test.go
+++ b/internal/render/hocon_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestLoadTemplate_EmbeddedFallback(t *testing.T) {
-	cases := []string{"mainnet", "nile", "private"}
+	cases := []string{"mainnet", "nile", "private", "system-test"}
 	for _, net := range cases {
 		data, err := LoadTemplate("", net)
 		if err != nil {
@@ -17,6 +17,42 @@ func TestLoadTemplate_EmbeddedFallback(t *testing.T) {
 		}
 		if len(data) < 100 {
 			t.Errorf("LoadTemplate(%q) returned suspiciously small payload (%d bytes)", net, len(data))
+		}
+	}
+}
+
+func TestRenderHOCON_SystemTest(t *testing.T) {
+	// system-test template carries stest-specific markers: pre-funded
+	// genesis accounts, three local witness keys, fast 20s maintenance
+	// interval. If those disappear from the rendered output something
+	// has stripped or replaced the embedded template.
+	i := &intent.Intent{
+		Name:    "stest-singlenode",
+		Network: "system-test",
+		Target:  intent.Target{Type: "local", Runtime: "jar"},
+	}
+	node := &intent.NodeSpec{Type: "witness"}
+
+	out, err := RenderHOCON("", i, node)
+	if err != nil {
+		t.Fatalf("render system-test: %v", err)
+	}
+
+	// Markers from the upstream stest config-system-test.conf
+	// (release_workflow branch). If any disappear, the embed wiring or
+	// upstream sync has stripped something load-bearing.
+	wantSubstrs := []string{
+		"localwitness",                     // single-SR self-signing keys
+		"maintenanceTimeInterval = 300000", // 5min cadence used by stest CI
+		"port = 50051",                     // gRPC fullnode
+		"fullNodePort = 8090",              // HTTP fullnode
+		"httpFullNodePort = 8545",          // jsonrpc (stest CI value; differs from
+		// testng.conf's 50545 — known config drift, see openspec change
+		// system-test-integration design.md D1)
+	}
+	for _, s := range wantSubstrs {
+		if !strings.Contains(out, s) {
+			t.Errorf("system-test render missing %q\n--- output ---\n%s", s, out)
 		}
 	}
 }

--- a/internal/render/templates/system-test.conf
+++ b/internal/render/templates/system-test.conf
@@ -1,0 +1,312 @@
+# trond-embedded copy of system-test's private-chain HOCON.
+#
+# Source of truth: tronprotocol/system-test, release_workflow branch,
+# testcase/src/test/resources/config-system-test.conf.
+#
+# This template is selected when an intent declares `network: system-test`.
+# Used by the system-test integration recipe to spin up a single-SR
+# private chain matching the endpoint expectations of stest's testng.conf.
+#
+# When the upstream stest config changes (e.g. new committee flags after
+# a java-tron protocol upgrade), update this file via PR against
+# tron-deployment, NOT against stest's two existing copies (they will be
+# deprecated once trond v0.1.0+ is the canonical source).
+#
+# `net.type = mainnet` below is a protocol-version identifier, not the
+# actual chain identity — chain identity comes from the genesis.block
+# section further down. This is a fully isolated private network.
+
+net {
+  type = mainnet
+}
+
+enery.limit.block.num = 0
+
+storage {
+  # Directory for storing persistent data
+  db.version = 2,
+  db.sync = false,
+  db.directory = "database",
+  index.directory = "index",
+  transHistory.switch = "on",
+
+  # You can custom these 14 databases' configs:
+
+  # account, account-index, asset-issue, block, block-index,
+  # block_KDB, peers, properties, recent-block, trans,
+  # utxo, votes, witness, witness_schedule.
+
+  # Otherwise, db configs will remain defualt and data will be stored in
+  # the path of "output-directory" or which is set by "-d" ("--output-directory").
+
+  # Attention: name is a required field that must be set !!!
+  properties = [
+    #    {
+    #      name = "account",
+    #      path = "storage_directory_test",
+    #      createIfMissing = true,
+    #      paranoidChecks = true,
+    #      verifyChecksums = true,
+    #      compressionType = 0,
+    #      blockSize = 10485760,
+    #      writeBufferSize = 10485760,
+    #      cacheSize = 0,
+    #      maxOpenFiles = 32
+    #    },
+    #    {
+    #      name = "account-index",
+    #      path = "storage_directory_test",
+    #      createIfMissing = true,
+    #      paranoidChecks = true,
+    #      verifyChecksums = true,
+    #      compressionType = 0,
+    #      blockSize = 10485760,
+    #      writeBufferSize = 10485760,
+    #      cacheSize = 0,
+    #      maxOpenFiles = 32
+    #    }
+  ]
+  needToUpdateAsset = true
+}
+
+node.discovery = {
+  enable = true
+  persist = true
+}
+
+node.backup {
+  port = 10001
+  priority = 8
+  members = [
+  ]
+}
+
+
+node {
+  # trust node for solidity node
+  # trustNode = "ip:port"
+
+  allowShieldedTransactionApi = true
+  zenTokenId=1000001
+
+  # expose extension api to public or not
+  walletExtensionApi = true
+
+  listen.port = 18888
+
+  # Number of gRPC thread, default availableProcessors / 2
+  # rpc.thread = 16
+
+  connection.timeout = 2
+
+  tcpNettyWorkThreadNum = 0
+
+  udpNettyWorkThreadNum = 1
+
+  # Number of validate sign thread, default availableProcessors / 2
+  # validateSignThreadNum = 16
+
+  connectFactor = 0.3
+  activeConnectFactor = 0.1
+
+  active = [
+    # Initial active peers
+    # Sample entries:
+    #"127.0.0.1:18889",
+    #"127.0.0.1:18892",
+  ]
+
+  minParticipationRate = 0
+
+  maxConnections = 30
+
+  minConnections = 8
+
+  minActiveConnections = 3
+
+  maxConnectionsWithSameIp = 2
+
+  maxHttpConnectNumber = 50
+
+  isOpenFullTcpDisconnect = true
+
+  p2p {
+    version = 708
+  }
+
+  http {
+    fullNodeEnable = true
+    fullNodePort = 8090
+    solidityEnable = true
+    solidityPort = 8091
+    PBFTEnable = true
+    PBFTPort = 8092
+  }
+
+  rpc {
+    enable = true
+    port = 50051
+    solidityEnable = true
+    solidityPort = 50061
+    PBFTEnable = true
+    PBFTPort = 50071
+
+    # Number of gRPC thread, default availableProcessors / 2
+    # thread = 16
+
+    minEffectiveConnection = 0
+
+    # The maximum number of concurrent calls permitted for each incoming connection
+    # maxConcurrentCallsPerConnection =
+
+    # The HTTP/2 flow control window, default 1MB
+    # flowControlWindow =
+
+    # Connection being idle for longer than which will be gracefully terminated
+    maxConnectionIdleInMillis = 60000
+
+    # Connection lasting longer than which will be gracefully terminated
+    # maxConnectionAgeInMillis =
+
+    # The maximum message size allowed to be received on the server, default 4MB
+    # maxMessageSize =
+
+    # The maximum size of header list allowed to be received, default 8192
+    # maxHeaderListSize =
+  }
+
+  jsonrpc {
+    httpFullNodeEnable = true
+    httpFullNodePort = 8545
+    httpSolidityEnable = true
+    httpSolidityPort = 8555
+    httpPBFTEnable = true
+    httpPBFTPort = 8565
+  }
+}
+
+seed.node = {
+  ip.list = [
+    #"127.0.0.1:18889",
+    #"127.0.0.1:18892",
+  ]
+}
+
+genesis.block = {
+  # Reserve balance
+  assets = [
+    {
+      accountName = "Devaccount"
+      accountType = "AssetIssue"
+      address = "TPwJS5eC5BPGyMGtYTHNhPTB89sUWjDSSu"
+      balance = "10000000000000000"
+    },
+    {
+      accountName = "Zion"
+      accountType = "AssetIssue"
+      address = "TSRNrjmrAbDdrsoqZsv7FZUtAo13fwoCzv"
+      balance = "15000000000000000"
+    },
+    {
+      accountName = "Sun"
+      accountType = "AssetIssue"
+      address = "TDQE4yb3E7dvDjouvu8u7GgSnMZbxAEumV"
+      balance = "10000000000000000"
+    },
+    {
+      accountName = "testng001"
+      accountType = "AssetIssue"
+      address = "TKVyqEJaq8QRPQfWE8s8WPb5c92kanAdLo"
+      balance = "10000000000000000"
+    },
+    {
+      accountName = "testng002"
+      accountType = "AssetIssue"
+      address = "THph9K2M2nLvkianrMGswRhz5hjSA9fuH7"
+      balance = "10000000000000000"
+    },
+    {
+      accountName = "testng003"
+      accountType = "AssetIssue"
+      address = "TV75jZpdmP2juMe1dRwGrwpV6AMU6mr1EU"
+      balance = "10000000000000000"
+    },
+    {
+      accountName = "Blackhole"
+      accountType = "AssetIssue"
+      address = "THmtHi1Rzq4gSKYGEKv1DPkV7au6xU1AUB"
+      balance = "-9223372036854775808"
+    },
+    {
+      accountName = "testng004"
+      accountType = "AssetIssue"
+      address = "TNUpX2x6SH36Sv8i5FtENYZJFcBCFs8ds8"
+      balance = "10000000000000000"
+    },
+    {
+      accountName = "testng005"
+      accountType = "AssetIssue"
+      address = "TCKu9t3U3dgU6YD3sWKcPD17BUpU6dohTH"
+      balance = "10000000000000000"
+    }
+  ]
+
+  witnesses = [
+    {
+      address: TB4B1RMhoPeivkj4Hebm6tttHjRY9yQFes
+      url = "http://Mercury.org",
+      voteCount = 105
+    },
+    {
+      address: TT1smsmhxype64boboU8xTuNZVCKP1w6qT
+      url = "http://Venus.org",
+      voteCount = 104
+    },
+  ]
+
+  timestamp = "0"
+
+  parentHash = "0x0000000000000000000000000000000000000000000000000000000000000000"
+}
+
+localwitness = [
+   369F095838EB6EED45D4F6312AF962D5B9DE52927DA9F04174EE49F9AF54BC77,
+   9FD8E129DE181EA44C6129F727A6871440169568ADE002943EAD0E7A16D8EDAC
+]
+
+block = {
+  needSyncCheck = false # first node : false, other : true
+  maintenanceTimeInterval = 300000 // 1 day: 86400000(ms), 6 hours: 21600000(ms)
+  proposalExpireTime = 300000
+  checkFrozenTime = 0
+}
+
+vm = {
+  supportConstant = true
+  minTimeRatio = 0.0
+  maxTimeRatio = 10.0
+  saveInternalTx = false
+}
+
+committee = {
+  allowAdaptiveEnergy = 0
+  allowCreationOfContracts = 1  //mainnet:0 (reset by committee),test:1
+  allowDelegateResource = 1
+  allowSameTokenName = 1
+  allowTvmTransferTrc10 = 1
+  allowMultiSign = 1 //mainnet:0 (reset by committee),test:1
+  allowDeferredTransaction = 1
+  # allowProtoFilterNum = 1
+  allowAccountStateRoot = 1
+  allowTvmConstantinople = 1
+  allowShieldedTransaction = 1
+  allowTvmSolidity059 = 1
+  changedDelegation = 1
+  allowNewResourceModel = 1
+  allowTvmFreeze = 1
+  allowReceiptsMerkleRoot = 1
+}
+
+log.level = {
+   root = "INFO" // TRACE;DEBUG;INFO;WARN;ERROR
+}

--- a/internal/schema/embed.go
+++ b/internal/schema/embed.go
@@ -40,7 +40,10 @@ import (
 //	        changes to existing schemas).
 //	1.2.0 — add verify-config + auto-heal schemas (new `trond
 //	        verify-config` and `trond auto-heal` commands).
-const SchemaVersion = "1.2.0"
+//	1.2.1 — config-validate.network and plan.network gain the
+//	        "system-test" value (additive enum / examples expansion;
+//	        existing clients unaffected).
+const SchemaVersion = "1.2.1"
 
 // JSONSchemaURLBase is the canonical URL prefix for individual output
 // schema files. Embedded $id values inside each schema mirror this so

--- a/internal/schema/files/config-validate.schema.json
+++ b/internal/schema/files/config-validate.schema.json
@@ -8,7 +8,7 @@
   "properties": {
     "valid":      { "type": "boolean" },
     "name":       { "type": "string" },
-    "network":    { "type": "string", "enum": ["mainnet", "nile", "private"] },
+    "network":    { "type": "string", "enum": ["mainnet", "nile", "private", "system-test"] },
     "node_count": { "type": "integer", "minimum": 1 },
     "explanation": {
       "type": "object",

--- a/internal/schema/files/plan.schema.json
+++ b/internal/schema/files/plan.schema.json
@@ -49,6 +49,6 @@
       "description": "Approximate seconds the node will be down during apply; 0 for no_change paths."
     },
     "runtime": { "type": "string", "enum": ["docker", "jar"] },
-    "network": { "type": "string", "examples": ["mainnet", "nile", "private"] }
+    "network": { "type": "string", "examples": ["mainnet", "nile", "private", "system-test"] }
   }
 }

--- a/internal/schema/version_baseline.json
+++ b/internal/schema/version_baseline.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": "1.2.0",
+  "schema_version": "1.2.1",
   "entries": [
     {
       "name": "apply",
@@ -19,7 +19,7 @@
     },
     {
       "name": "config-validate",
-      "hash": "0a420779dffb8a08edb4261efb6311e8575621b460caae251050bcdd8c2a9704"
+      "hash": "89db39b1a9cbe40ca40b8f6d4d7df03a581d4f33256a4128d69dd64ac026a29b"
     },
     {
       "name": "diagnose",
@@ -59,7 +59,7 @@
     },
     {
       "name": "plan",
-      "hash": "d6857b5b219d39ad4fc2a29049f3da9fa4289147720412892579451b0436c0a4"
+      "hash": "a296d6c9fcaf9e8b652ce983fb180b77d48b087bc006c01d0a811eabf6df1c16"
     },
     {
       "name": "preflight",

--- a/recipes/system-test.yaml
+++ b/recipes/system-test.yaml
@@ -1,0 +1,73 @@
+name: system-test
+description: |
+  Bring up a single-SR private chain matching tronprotocol/system-test's
+  expectations, suitable for running stest's TestNG suite against. Default
+  intent_path points at examples/system-test-singlenode-intent.yaml; the
+  caller can override to use a customized intent if needed.
+
+  Pre-requisite: caller must drop the FullNode.jar to be tested at
+  {install_path}/FullNode.jar BEFORE invoking this recipe. Trond's jar
+  runtime sees jar.url is unset and uses the pre-placed file. Typical
+  shape from a CI workflow:
+
+    sudo mkdir -p /opt/tron/stest-singlenode
+    sudo cp $JAR /opt/tron/stest-singlenode/FullNode.jar
+    sudo trond recipe run system-test
+    cd system-test && ./gradlew :testcase:singleNodeBuild
+    sudo trond network destroy stest-singlenode --confirm stest-singlenode
+
+  This is the canonical replacement for java-tron CI's bare
+  `nohup java -jar build/libs/FullNode.jar --witness -c config-system-test.conf &`
+  bootstrap step (system-test.yml line 55-77).
+
+params:
+  - name: intent_path
+    type: path
+    required: false
+    default: examples/system-test-singlenode-intent.yaml
+    description: |
+      Path to a stest single-SR intent.yaml. Default is the bundled
+      example which uses ports aligned with stest's testng.conf.
+
+steps:
+  - id: validate
+    description: Catch typos before any network IO.
+    command: config validate
+    args:
+      - "{{ params.intent_path }}"
+    on_failure: abort
+
+  - id: preflight
+    description: Verify Java / memory / ports / install_path writable on target.
+    command: preflight
+    args:
+      - --intent
+      - "{{ params.intent_path }}"
+    on_failure: abort
+
+  - id: apply
+    description: |
+      Render HOCON + systemd unit, write to /etc/systemd/system, start
+      the service, and block until the FullNode HTTP endpoint responds.
+    command: apply
+    args:
+      - --intent
+      - "{{ params.intent_path }}"
+      - --auto-approve
+      - --wait
+      - --wait-timeout
+      - 5m
+    persist:
+      - name
+      - endpoints
+    on_failure: abort
+
+  - id: verify
+    description: Confirm the node is minting blocks (block_height > 0).
+    command: verify
+    args:
+      - --intent
+      - "{{ params.intent_path }}"
+      - --timeout
+      - 5m
+    on_failure: abort

--- a/schemas/intent.schema.json
+++ b/schemas/intent.schema.json
@@ -17,8 +17,8 @@
     },
     "network": {
       "type": "string",
-      "enum": ["mainnet", "nile", "private"],
-      "description": "TRON network to connect to"
+      "enum": ["mainnet", "nile", "private", "system-test"],
+      "description": "TRON network to connect to. \"system-test\" selects the embedded private-chain template used by tronprotocol/system-test."
     },
     "nodes": {
       "type": "array",

--- a/schemas/output/config-validate.schema.json
+++ b/schemas/output/config-validate.schema.json
@@ -8,7 +8,7 @@
   "properties": {
     "valid":      { "type": "boolean" },
     "name":       { "type": "string" },
-    "network":    { "type": "string", "enum": ["mainnet", "nile", "private"] },
+    "network":    { "type": "string", "enum": ["mainnet", "nile", "private", "system-test"] },
     "node_count": { "type": "integer", "minimum": 1 },
     "explanation": {
       "type": "object",

--- a/schemas/output/plan.schema.json
+++ b/schemas/output/plan.schema.json
@@ -49,6 +49,6 @@
       "description": "Approximate seconds the node will be down during apply; 0 for no_change paths."
     },
     "runtime": { "type": "string", "enum": ["docker", "jar"] },
-    "network": { "type": "string", "examples": ["mainnet", "nile", "private"] }
+    "network": { "type": "string", "examples": ["mainnet", "nile", "private", "system-test"] }
   }
 }

--- a/templates/system-test.conf
+++ b/templates/system-test.conf
@@ -1,0 +1,312 @@
+# trond-embedded copy of system-test's private-chain HOCON.
+#
+# Source of truth: tronprotocol/system-test, release_workflow branch,
+# testcase/src/test/resources/config-system-test.conf.
+#
+# This template is selected when an intent declares `network: system-test`.
+# Used by the system-test integration recipe to spin up a single-SR
+# private chain matching the endpoint expectations of stest's testng.conf.
+#
+# When the upstream stest config changes (e.g. new committee flags after
+# a java-tron protocol upgrade), update this file via PR against
+# tron-deployment, NOT against stest's two existing copies (they will be
+# deprecated once trond v0.1.0+ is the canonical source).
+#
+# `net.type = mainnet` below is a protocol-version identifier, not the
+# actual chain identity — chain identity comes from the genesis.block
+# section further down. This is a fully isolated private network.
+
+net {
+  type = mainnet
+}
+
+enery.limit.block.num = 0
+
+storage {
+  # Directory for storing persistent data
+  db.version = 2,
+  db.sync = false,
+  db.directory = "database",
+  index.directory = "index",
+  transHistory.switch = "on",
+
+  # You can custom these 14 databases' configs:
+
+  # account, account-index, asset-issue, block, block-index,
+  # block_KDB, peers, properties, recent-block, trans,
+  # utxo, votes, witness, witness_schedule.
+
+  # Otherwise, db configs will remain defualt and data will be stored in
+  # the path of "output-directory" or which is set by "-d" ("--output-directory").
+
+  # Attention: name is a required field that must be set !!!
+  properties = [
+    #    {
+    #      name = "account",
+    #      path = "storage_directory_test",
+    #      createIfMissing = true,
+    #      paranoidChecks = true,
+    #      verifyChecksums = true,
+    #      compressionType = 0,
+    #      blockSize = 10485760,
+    #      writeBufferSize = 10485760,
+    #      cacheSize = 0,
+    #      maxOpenFiles = 32
+    #    },
+    #    {
+    #      name = "account-index",
+    #      path = "storage_directory_test",
+    #      createIfMissing = true,
+    #      paranoidChecks = true,
+    #      verifyChecksums = true,
+    #      compressionType = 0,
+    #      blockSize = 10485760,
+    #      writeBufferSize = 10485760,
+    #      cacheSize = 0,
+    #      maxOpenFiles = 32
+    #    }
+  ]
+  needToUpdateAsset = true
+}
+
+node.discovery = {
+  enable = true
+  persist = true
+}
+
+node.backup {
+  port = 10001
+  priority = 8
+  members = [
+  ]
+}
+
+
+node {
+  # trust node for solidity node
+  # trustNode = "ip:port"
+
+  allowShieldedTransactionApi = true
+  zenTokenId=1000001
+
+  # expose extension api to public or not
+  walletExtensionApi = true
+
+  listen.port = 18888
+
+  # Number of gRPC thread, default availableProcessors / 2
+  # rpc.thread = 16
+
+  connection.timeout = 2
+
+  tcpNettyWorkThreadNum = 0
+
+  udpNettyWorkThreadNum = 1
+
+  # Number of validate sign thread, default availableProcessors / 2
+  # validateSignThreadNum = 16
+
+  connectFactor = 0.3
+  activeConnectFactor = 0.1
+
+  active = [
+    # Initial active peers
+    # Sample entries:
+    #"127.0.0.1:18889",
+    #"127.0.0.1:18892",
+  ]
+
+  minParticipationRate = 0
+
+  maxConnections = 30
+
+  minConnections = 8
+
+  minActiveConnections = 3
+
+  maxConnectionsWithSameIp = 2
+
+  maxHttpConnectNumber = 50
+
+  isOpenFullTcpDisconnect = true
+
+  p2p {
+    version = 708
+  }
+
+  http {
+    fullNodeEnable = true
+    fullNodePort = 8090
+    solidityEnable = true
+    solidityPort = 8091
+    PBFTEnable = true
+    PBFTPort = 8092
+  }
+
+  rpc {
+    enable = true
+    port = 50051
+    solidityEnable = true
+    solidityPort = 50061
+    PBFTEnable = true
+    PBFTPort = 50071
+
+    # Number of gRPC thread, default availableProcessors / 2
+    # thread = 16
+
+    minEffectiveConnection = 0
+
+    # The maximum number of concurrent calls permitted for each incoming connection
+    # maxConcurrentCallsPerConnection =
+
+    # The HTTP/2 flow control window, default 1MB
+    # flowControlWindow =
+
+    # Connection being idle for longer than which will be gracefully terminated
+    maxConnectionIdleInMillis = 60000
+
+    # Connection lasting longer than which will be gracefully terminated
+    # maxConnectionAgeInMillis =
+
+    # The maximum message size allowed to be received on the server, default 4MB
+    # maxMessageSize =
+
+    # The maximum size of header list allowed to be received, default 8192
+    # maxHeaderListSize =
+  }
+
+  jsonrpc {
+    httpFullNodeEnable = true
+    httpFullNodePort = 8545
+    httpSolidityEnable = true
+    httpSolidityPort = 8555
+    httpPBFTEnable = true
+    httpPBFTPort = 8565
+  }
+}
+
+seed.node = {
+  ip.list = [
+    #"127.0.0.1:18889",
+    #"127.0.0.1:18892",
+  ]
+}
+
+genesis.block = {
+  # Reserve balance
+  assets = [
+    {
+      accountName = "Devaccount"
+      accountType = "AssetIssue"
+      address = "TPwJS5eC5BPGyMGtYTHNhPTB89sUWjDSSu"
+      balance = "10000000000000000"
+    },
+    {
+      accountName = "Zion"
+      accountType = "AssetIssue"
+      address = "TSRNrjmrAbDdrsoqZsv7FZUtAo13fwoCzv"
+      balance = "15000000000000000"
+    },
+    {
+      accountName = "Sun"
+      accountType = "AssetIssue"
+      address = "TDQE4yb3E7dvDjouvu8u7GgSnMZbxAEumV"
+      balance = "10000000000000000"
+    },
+    {
+      accountName = "testng001"
+      accountType = "AssetIssue"
+      address = "TKVyqEJaq8QRPQfWE8s8WPb5c92kanAdLo"
+      balance = "10000000000000000"
+    },
+    {
+      accountName = "testng002"
+      accountType = "AssetIssue"
+      address = "THph9K2M2nLvkianrMGswRhz5hjSA9fuH7"
+      balance = "10000000000000000"
+    },
+    {
+      accountName = "testng003"
+      accountType = "AssetIssue"
+      address = "TV75jZpdmP2juMe1dRwGrwpV6AMU6mr1EU"
+      balance = "10000000000000000"
+    },
+    {
+      accountName = "Blackhole"
+      accountType = "AssetIssue"
+      address = "THmtHi1Rzq4gSKYGEKv1DPkV7au6xU1AUB"
+      balance = "-9223372036854775808"
+    },
+    {
+      accountName = "testng004"
+      accountType = "AssetIssue"
+      address = "TNUpX2x6SH36Sv8i5FtENYZJFcBCFs8ds8"
+      balance = "10000000000000000"
+    },
+    {
+      accountName = "testng005"
+      accountType = "AssetIssue"
+      address = "TCKu9t3U3dgU6YD3sWKcPD17BUpU6dohTH"
+      balance = "10000000000000000"
+    }
+  ]
+
+  witnesses = [
+    {
+      address: TB4B1RMhoPeivkj4Hebm6tttHjRY9yQFes
+      url = "http://Mercury.org",
+      voteCount = 105
+    },
+    {
+      address: TT1smsmhxype64boboU8xTuNZVCKP1w6qT
+      url = "http://Venus.org",
+      voteCount = 104
+    },
+  ]
+
+  timestamp = "0"
+
+  parentHash = "0x0000000000000000000000000000000000000000000000000000000000000000"
+}
+
+localwitness = [
+   369F095838EB6EED45D4F6312AF962D5B9DE52927DA9F04174EE49F9AF54BC77,
+   9FD8E129DE181EA44C6129F727A6871440169568ADE002943EAD0E7A16D8EDAC
+]
+
+block = {
+  needSyncCheck = false # first node : false, other : true
+  maintenanceTimeInterval = 300000 // 1 day: 86400000(ms), 6 hours: 21600000(ms)
+  proposalExpireTime = 300000
+  checkFrozenTime = 0
+}
+
+vm = {
+  supportConstant = true
+  minTimeRatio = 0.0
+  maxTimeRatio = 10.0
+  saveInternalTx = false
+}
+
+committee = {
+  allowAdaptiveEnergy = 0
+  allowCreationOfContracts = 1  //mainnet:0 (reset by committee),test:1
+  allowDelegateResource = 1
+  allowSameTokenName = 1
+  allowTvmTransferTrc10 = 1
+  allowMultiSign = 1 //mainnet:0 (reset by committee),test:1
+  allowDeferredTransaction = 1
+  # allowProtoFilterNum = 1
+  allowAccountStateRoot = 1
+  allowTvmConstantinople = 1
+  allowShieldedTransaction = 1
+  allowTvmSolidity059 = 1
+  changedDelegation = 1
+  allowNewResourceModel = 1
+  allowTvmFreeze = 1
+  allowReceiptsMerkleRoot = 1
+}
+
+log.level = {
+   root = "INFO" // TRACE;DEBUG;INFO;WARN;ERROR
+}


### PR DESCRIPTION
**What does this PR do?**

Adds \`system-test\` as a fourth network type alongside \`mainnet\`, \`nile\`, and \`private\`, so that trond can own the full lifecycle of a system-test node — from config rendering to systemd deployment and readiness verification.

**Background:** \`tronprotocol/java-tron\`'s system-test CI currently brings up a single-SR private-chain node via a bare \`nohup java -jar\` inline in the workflow, with a hand-maintained \`config-system-test.conf\` copied around by the script. The goal is to replace that with \`trond apply\` + \`trond verify\`, so the node is managed by systemd, logs are structured, and readiness polling is handled by trond's built-in \`verify\` command. For this to work, trond must have built-in knowledge of the system-test network — its HOCON config, witness keys, port layout, and maintenance interval — so a single trond binary download is sufficient and no external config file needs to be bundled or copied.

**Changes:**

- **\`internal/render/templates/system-test.conf\`** — embeds the canonical single-SR private-chain config used by \`tronprotocol/system-test\` (2 localwitness keys, \`maintenanceTimeInterval=300000\`, ports 8090/50051/8545/18888).
- **\`internal/render/hocon.go\`** — registers \`"system-test"\` in the \`NetworkTemplate\` map so \`trond config render --network system-test\` works.
- **\`internal/intent/schema.go\`** — extends the \`network\` field validator to accept \`"system-test"\`.
- **\`internal/schema/embed.go\`** — bumps \`SchemaVersion\` \`1.2.0 → 1.2.1\` (additive enum expansion, backward-compatible).
- **\`examples/system-test-singlenode-intent.yaml\`** — reference intent YAML for a single-SR systemd-managed node; used by \`stest-up.sh\` to drive \`trond apply\` + \`trond verify\`.
- **\`internal/recipe/files/system-test.yaml\`** / **\`recipes/system-test.yaml\`** — four-step recipe: \`config validate\` → \`preflight\` → \`apply\` → \`verify\`.
- **\`cmd/preflight.go\`** — include \`system-test\` in the 10 GB disk-space threshold check.

**Why are these changes required?**

Once trond has first-class knowledge of the system-test network, \`stest-up.sh\` can call \`trond apply --intent system-test-singlenode-intent.yaml\` instead of managing a bare Java process, getting systemd lifecycle management, structured logs, and \`trond verify\` readiness polling for free.

This is also a prerequisite for the \`v0.1.2\` release: the release binary must include the system-test template so \`stest-up.sh\` can download a single trond binary and immediately deploy a stest node without any bundled config.

**This PR has been tested by:**
- Existing unit tests pass (\`go test ./...\`)
- New tests added: \`cmd/preflight_test.go\` covers system-test disk threshold; \`internal/render/hocon_test.go\` covers template rendering; \`internal/intent/fields_test.go\` covers validator acceptance
- Manual: \`trond config render --network system-test\` produces valid HOCON; \`trond config validate\` accepts a system-test intent; \`trond preflight\` passes on a clean runner

**Checklist**
- [x] Single module — touches config/render/intent/schema/recipe, all tightly coupled to adding one new network type
- [x] No \`java.lang.Math\` or \`Maths\` — N/A (Go)
- [x] No floating-point in consensus code — N/A
- [x] No \`System.out.println\` or leftover TODOs
- [x] Complex logic has comments

**Follow up**

Once this PR and the release pipeline PR (\`ci(release): fix goreleaser pipeline\`) are both merged, cut a \`v*\` tag to publish the release binary. Downstream: \`system-test/scripts/stest-up.sh\` will download the new binary and use the embedded intent to bring up stest nodes through trond.

**Extra details**

N/A