### PR TITLE
feat(tools): add replay — mainnet tx replay HTTP client

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -150,6 +150,12 @@ nfpms:
 # path is still the cleaner UX for CLI tools.
 brews:
   - name: trond
+    # Scope to the trond archive only — the homebrew tap installs the
+    # main CLI, not the sibling replay tool. Without ids, goreleaser
+    # tries to package both archives under the same OS/Arch slot and
+    # errors with "one tap can handle only one archive".
+    ids:
+      - default
     repository:
       owner: tronprotocol
       name: homebrew-tap

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -24,8 +24,24 @@ builds:
       - -X github.com/tronprotocol/tron-deployment/cmd.commit={{.Commit}}
       - -X github.com/tronprotocol/tron-deployment/cmd.buildTime={{.Date}}
 
+  - id: replay
+    main: ./tools/replay
+    binary: replay
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - darwin
+    goarch:
+      - amd64
+      - arm64
+    ldflags:
+      - -s -w
+
 archives:
   - id: default
+    builds:
+      - trond
     formats:
       - tar.gz
     name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
@@ -34,6 +50,17 @@ archives:
       - LICENSE*
       - examples/*
       - schemas/*
+
+  - id: replay
+    builds:
+      - replay
+    formats:
+      - tar.gz
+    name_template: "replay_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    files:
+      - LICENSE*
+      - src: tools/replay/README.md
+        dst: README.md
 
 checksum:
   name_template: "checksums.txt"

--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ endif
 
 GOFLAGS    ?=
 
-.PHONY: build test lint e2e build-all clean clean-all fmt vet tidy sync-templates sync-schemas snapshot-schema-baseline update-render-golden docs man cover vuln bootstrap-go
+.PHONY: build test lint e2e build-all clean clean-all fmt vet tidy sync-templates sync-schemas snapshot-schema-baseline update-render-golden docs man cover vuln bootstrap-go build-replay install-replay
 
 ## bootstrap-go: Download + verify the project-local Go toolchain
 ##               (idempotent; safe to re-run; no-op if already current)
@@ -163,3 +163,18 @@ snapshot-schema-baseline: $(GO_BOOTSTRAP)
 update-render-golden: $(GO_BOOTSTRAP)
 	TROND_UPDATE_GOLDEN=1 $(GO) test -run TestRenderHOCON_Golden ./internal/render/
 	@echo "render golden files refreshed under internal/render/testdata/golden/."
+
+## build-replay: Build the tools/replay binary into bin/replay.
+##               replay is a standalone Go binary (no java-tron source
+##               dependency) that streams mainnet historical transactions
+##               from TronGrid to a private chain over HTTP. See
+##               tools/replay/README.md and tools/replay/IMPROVEMENTS.md.
+build-replay: $(GO_BOOTSTRAP)
+	@mkdir -p bin
+	$(GO) build -ldflags "$(LDFLAGS)" -o bin/replay ./tools/replay
+	@echo "✓ bin/replay built"
+
+## install-replay: Build + copy bin/replay into $(GOBIN).
+install-replay: build-replay
+	cp bin/replay $(GOBIN)/replay
+	@echo "✓ replay installed at $(GOBIN)/replay"

--- a/README.md
+++ b/README.md
@@ -580,9 +580,9 @@ In addition to the `trond` CLI, this repo ships sibling Go tools under
 `tools/` for adjacent test/operations workflows. They build into separate
 binaries and have separate release tarballs.
 
-| Tool | Path | Purpose |
-|---|---|---|
-| **`replay`** | [`tools/replay/`](tools/replay/README.md) | Streams mainnet historical transactions from TronGrid HTTP API to a private chain. Pure-Go external HTTP client (no java-tron source dependency). Used for PQ test setup, stress harness, snapshot validation. |
+| Tool | Path | Purpose                                                                                                                                                                                                        |
+|---|---|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| **`replay`** | [`tools/replay/`](tools/replay/README.md) | Streams mainnet historical transactions from TronGrid HTTP API to a private chain. Pure-Go external HTTP client (no java-tron source dependency). Used for testing setup, stress harness, snapshot validation. |
 
 Build:
 

--- a/README.md
+++ b/README.md
@@ -574,6 +574,26 @@ remain at the repo root. `make sync-templates` re-fetches them from
 upstream into both the root and the CLI's embedded copy so the two stay
 in lockstep.
 
+## Companion Tools
+
+In addition to the `trond` CLI, this repo ships sibling Go tools under
+`tools/` for adjacent test/operations workflows. They build into separate
+binaries and have separate release tarballs.
+
+| Tool | Path | Purpose |
+|---|---|---|
+| **`replay`** | [`tools/replay/`](tools/replay/README.md) | Streams mainnet historical transactions from TronGrid HTTP API to a private chain. Pure-Go external HTTP client (no java-tron source dependency). Used for PQ test setup, stress harness, snapshot validation. |
+
+Build:
+
+```bash
+make build-replay        # → bin/replay
+make install-replay      # → $(GOBIN)/replay
+```
+
+Each tool ships as its own tarball (`replay_<version>_<os>_<arch>.tar.gz`)
+in releases, alongside the main `trond` tarball.
+
 ## Configuration Templates
 
 Base java-tron configuration templates rendered into per-node HOCON. The

--- a/tools/replay/README.md
+++ b/tools/replay/README.md
@@ -342,15 +342,3 @@ Reasons that show up in `replay-failures.jsonl`:
 | Rate control | fixed `tpsLimit` | `tps-multiplier` derived from SR ratio |
 
 The reverse direction also holds: `stress_test` covers synthetic transaction generation (TRX / TRC10 / TRC20) and multi-target broadcast, which `replay` does not implement.
-
----
-
-## Roadmap
-
-Functionality on the near-term list:
-
-- **PQ tx re-signing** — strip mainnet ECDSA signatures and re-sign with Falcon-512 keys before broadcast. Required for replaying mainnet load against a PQ-upgraded private chain.
-- **Multi-target broadcast** — accept a list of private nodes and round-robin across them. Matches `stress_test`'s `broadcastUrl` list capability.
-- **Prometheus metrics** — expose block-level OK / fail / pace metrics for Grafana dashboards.
-- **Mainnet follow-head mode** — `--follow-head` to continuously catch up to mainnet's latest block (a lightweight shadow-fork-ish mode).
-- **Synthetic tx generation** — TRX / TRC10 / TRC20 / PQ tx templates, with optional blending of synthetic and replayed traffic. Parity with `stress_test`'s `generate` stage.

--- a/tools/replay/README.md
+++ b/tools/replay/README.md
@@ -32,21 +32,12 @@ The codebase is split by module: `main.go` / `state.go` / `trongrid.go` / `priva
 
 Mainnet transactions carry `ref_block_hash` / `expiration` / `timestamp` fields baked against mainnet time and block numbers. None of these are valid on a private chain. To let `broadcast` succeed, your private chain node must skip 4 checks. 
 
-### Patch 1 — `TransactionCapsule.checkExpiration` (clear method body)
+### Patch 1 — `TransactionCapsule.checkExpiration`
 
 File: `chainbase/src/main/java/org/tron/core/capsule/TransactionCapsule.java`
 
 ```java
-// before
-public void checkExpiration(long nextSlotTime) throws TransactionExpirationException {
-  if (getExpiration() < nextSlotTime) {
-    throw new TransactionExpirationException(String.format(
-        "Transaction expiration time is %d, but next slot time is %d",
-        getExpiration(), nextSlotTime));
-  }
-}
-
-// after
+// clear method body to skip expiration check
 public void checkExpiration(long nextSlotTime) throws TransactionExpirationException {
   // Replay mode: skip expiration check.
   // Mainnet tx expiration is signed against mainnet time; private chain
@@ -55,30 +46,17 @@ public void checkExpiration(long nextSlotTime) throws TransactionExpirationExcep
 }
 ```
 
-### Patch 2 — `Manager.java` expiration-window check (comment out)
+### Patch 2 — `Manager.java` expiration-window check
 
 File: `framework/src/main/java/org/tron/core/db/Manager.java`
 
-There are two expiration checks in this file; both must be disabled.
-
-**Check A — TaPos / refBlockHash validator:**
-
-```java
-// validateTapos()
-//   skipped — mainnet tx ref_block_bytes + ref_block_hash point at a
-//   mainnet block whose hash doesn't exist on the private chain
-```
-
-**Check B — inside `validateCommon()`** — comment out the entire conditional:
+There are two expiration checks in function `processTransaction`; both must be disabled.
+**TaPos / refBlockHash validator**
+**Expiration vs head block time validator**
 
 ```java
-// if (transactionExpiration <= headBlockTime
-//     || transactionExpiration > headBlockTime + Constant.MAXIMUM_TIME_UNTIL_EXPIRATION) {
-//   throw new TransactionExpirationException(
-//       String.format(
-//       "Transaction expiration, transaction expiration time is %d, but headBlockTime is %d",
-//           transactionExpiration, headBlockTime));
-// }
+// validateTapos(trxCap);
+// validateCommon(trxCap);
 ```
 
 ### Patch 3 — `TransactionsMsgHandler` network-layer expiration check
@@ -88,8 +66,8 @@ File: `framework/src/main/java/org/tron/core/net/messagehandler/TransactionsMsgH
 Comment out the `checkExpiration` call and its catch arm below:
 
 ```java
-//   trx.getTransactionCapsule().checkExpiration(chainBaseManager.getNextBlockSlotTime());
-...
+//  trx.getTransactionCapsule().checkExpiration(chainBaseManager.getNextBlockSlotTime());
+// ...
 // catch (TransactionExpirationException e) {
 //   logger.warn("Transaction expiration, transaction id: {}, error: {}",
 //       trx.getTransactionCapsule().getTransactionId(), e.getMessage());

--- a/tools/replay/README.md
+++ b/tools/replay/README.md
@@ -1,0 +1,356 @@
+# replay
+
+Streams mainnet historical transactions from TronGrid HTTP API to a private chain. Pure-Go external HTTP client — no java-tron source dependency.
+
+Useful for:
+- Stress harness with real mainnet traffic
+- Snapshot validation (replay TXs after a `db fork` snapshot to verify the cloned state)
+
+## Install
+
+```bash
+# From the tron-deployment repo root
+make build-replay        # → bin/replay
+make install-replay      # → $(GOBIN)/replay
+```
+
+Requires Go 1.21+. No external dependencies (stdlib only). Produces an ~8 MB single binary you can `scp` to any target host.
+
+The codebase is split by module: `main.go` / `state.go` / `trongrid.go` / `private.go` / `filter.go` / `logger.go` / `replayer.go`. `go build .` compiles the entire package.
+
+---
+
+## Prerequisites
+
+1. **Private chain node is running** — built from a `relay_skip_signature`-style branch (see below); at least one SR producing blocks.
+2. **Private chain has mainnet state imported** — typically via `Toolkit.jar db fork` to trim a mainnet snapshot down to the private chain's SR set.
+3. **TronGrid API key** — get one free at [trongrid.io](https://www.trongrid.io/). The free tier (~15 QPS / 100k req/day) is more than enough.
+
+---
+
+## Required java-tron patches
+
+Mainnet transactions carry `ref_block_hash` / `expiration` / `timestamp` fields baked against mainnet time and block numbers. None of these are valid on a private chain. To let `broadcast` succeed, your private chain node must skip 4 checks. 
+
+### Patch 1 — `TransactionCapsule.checkExpiration` (clear method body)
+
+File: `chainbase/src/main/java/org/tron/core/capsule/TransactionCapsule.java`
+
+```java
+// before
+public void checkExpiration(long nextSlotTime) throws TransactionExpirationException {
+  if (getExpiration() < nextSlotTime) {
+    throw new TransactionExpirationException(String.format(
+        "Transaction expiration time is %d, but next slot time is %d",
+        getExpiration(), nextSlotTime));
+  }
+}
+
+// after
+public void checkExpiration(long nextSlotTime) throws TransactionExpirationException {
+  // Replay mode: skip expiration check.
+  // Mainnet tx expiration is signed against mainnet time; private chain
+  // time will never line up. One patch here covers all three callers:
+  // Wallet, Manager, TransactionsMsgHandler.
+}
+```
+
+### Patch 2 — `Manager.java` expiration-window check (comment out)
+
+File: `framework/src/main/java/org/tron/core/db/Manager.java`
+
+There are two expiration checks in this file; both must be disabled.
+
+**Check A — TaPos / refBlockHash validator:**
+
+```java
+// validateTapos()
+//   skipped — mainnet tx ref_block_bytes + ref_block_hash point at a
+//   mainnet block whose hash doesn't exist on the private chain
+```
+
+**Check B — inside `validateCommon()`** — comment out the entire conditional:
+
+```java
+// if (transactionExpiration <= headBlockTime
+//     || transactionExpiration > headBlockTime + Constant.MAXIMUM_TIME_UNTIL_EXPIRATION) {
+//   throw new TransactionExpirationException(
+//       String.format(
+//       "Transaction expiration, transaction expiration time is %d, but headBlockTime is %d",
+//           transactionExpiration, headBlockTime));
+// }
+```
+
+### Patch 3 — `TransactionsMsgHandler` network-layer expiration check
+
+File: `framework/src/main/java/org/tron/core/net/messagehandler/TransactionsMsgHandler.java`
+
+Comment out the `checkExpiration` call and its catch arm below:
+
+```java
+//   trx.getTransactionCapsule().checkExpiration(chainBaseManager.getNextBlockSlotTime());
+...
+// catch (TransactionExpirationException e) {
+//   logger.warn("Transaction expiration, transaction id: {}, error: {}",
+//       trx.getTransactionCapsule().getTransactionId(), e.getMessage());
+//   return new ResponseMessage(false, e.getMessage());
+// }
+```
+
+### Patch 4 — `ProposalCapsule.hasExpired` (optional for faster proposal testing)
+
+Mainnet proposals are designed to expire 3 days after creation. For private-chain testing that's far too slow — every protocol change needs to wait 3 days before it can activate. Force the check to always return `true` so the next maintenance window processes every pending proposal immediately.
+
+File: `chainbase/src/main/java/org/tron/core/capsule/ProposalCapsule.java`
+
+```java
+public boolean hasExpired(long time) {
+  return true; // private chain test mode — process at next maintenance regardless
+}
+```
+
+After above patches applied, rebuild and restart and java-tron nodes:
+
+```bash
+./gradlew clean build -x test
+# restart all FullNode / SR processes
+```
+
+Then, broadcast logs should no longer contain `Transaction expiration time is X, but next slot time is Y` or `Transaction expiration, transaction expiration time is X, but headBlockTime is Y`. Any remaining failures (`account does not exist`, `balance is not sufficient`, etc.) are state-layer issues unrelated to these patches.
+
+---
+
+## Usage
+
+### First run — pass `--start` explicitly
+
+```bash
+export TRONGRID_API_KEY=<your-key> # skip if the free tier (~15 QPS / 100k req/day) is enough
+
+./replay \
+    --private-node http://private_node_ip:8090 \
+    --start 82510633     # = snapshot's last mainnet block + 1
+    --end 82510700       # optional; default = start + 10 (safety cap)
+```
+
+`--start` is **mandatory on the first run**. Private chain `getnowblock` returns the private chain's own block number, which decouples from mainnet's block number as soon as the chain produces its first block. The only reliable answer to "where do we resume from?" is the operator providing the value explicitly.
+
+How to figure out the right `--start`:
+
+```bash
+# Immediately after importing the snapshot (before private chain produces any block),
+# the private chain head equals the snapshot's mainnet block.
+curl -s -X POST http://private_node_ip:8090/wallet/getnowblock \
+    | jq .block_header.raw_data.number
+# e.g. 82510632 → use --start 82510633
+
+# Don't use this command after the private chain has been running.
+```
+
+### Subsequent runs — resume from state file
+
+```bash
+./replay --private-node http://private_node_ip:8090
+```
+
+On restart without `--start`, `replay-state.json`'s `last_mainnet_block` is read and replay continues from `+1`.
+
+### Replay an explicit range
+
+```bash
+./replay \
+    --private-node http://private_node_ip:8090 \
+    --start 75630273 \
+    --end 75637473
+```
+
+### Include Vote / Witness / Withdraw txs (off by default)
+
+```bash
+./replay \
+    --private-node http://private_node_ip:8090 \
+    --include-all
+```
+
+By default, these contract types are skipped because they're guaranteed to fail on a private chain:
+
+- `VoteWitnessContract`
+- `WitnessUpdateContract`
+- `WitnessCreateContract`
+- `WithdrawBalanceContract`
+
+Use `--include-all` to forward them anyway — useful when observing failure modes (records land in `replay-failures.jsonl`).
+
+### All flags
+
+```
+--trongrid-url       TronGrid API base URL (default: https://api.trongrid.io)
+--trongrid-key       TronGrid API key (or env TRONGRID_API_KEY)
+--trongrid-qps       TronGrid request rate limit (default: 1)
+--tps-multiplier     Private chain TPS as a multiplier of mainnet TPS.
+                     pace_sec = 3 / multiplier.
+                     Default 0.333 (~1/3 mainnet TPS, 9 s/block — matches 3 SR
+                     private vs 27 SR mainnet). 1 → 3 s/block (mainnet speed),
+                     0.5 → 6 s/block (half speed), 2 → 1.5 s/block (double speed).
+--private-node       Private chain HTTP API base, e.g. http://10.0.0.1:8090 (required)
+--start              Start MAINNET block (inclusive). 0 = resume from state file
+                     (required on first run; do NOT use private chain head).
+--end                End block (inclusive). 0 = start + 10 (safety default).
+--state-file         Resume state file (default: ./replay-state.json)
+--fail-log           Failed broadcasts log, JSONL (default: ./replay-failures.jsonl)
+--skip-log           Skipped txs log, JSONL (default: ./replay-skips.jsonl)
+--include-all        Do not skip Vote/Witness/Withdraw contracts
+```
+
+State is flushed to `replay-state.json` after every block — no interval to configure.
+
+---
+
+## Pacing algorithm
+
+`--tps-multiplier` controls the private chain's TPS relative to mainnet:
+
+```
+pace_sec = 3 / multiplier             # mainnet block period is 3 s
+slots    = max(1, floor(pace_sec))    # ~1 slot per second
+```
+
+| multiplier | pace | slots | use case |
+|---|---|---|---|
+| `1.0` | 3 s | 3 | replay at mainnet speed |
+| `0.5` | 6 s | 6 | half speed |
+| **`0.333`** (default) | **9 s** | **9** | **3 SR private vs 27 SR mainnet** |
+| `2.0` | 1.5 s | 1 | 2× speedup |
+
+Within each block, transactions are split into `slots` batches. Each batch fires its share of txs back-to-back, then waits for the absolute slot boundary. For a 150-tx block at `multiplier=0.333`:
+
+```
+slot 0 (0..1s):  tx[0..16]    fire 17 back-to-back  → wait until 1.0 s
+slot 1 (1..2s):  tx[17..33]   fire 17 back-to-back  → wait until 2.0 s
+slot 2 (2..3s):  tx[34..50]   fire 17 back-to-back  → wait until 3.0 s
+...
+slot 8 (8..9s):  tx[134..149] fire 16 back-to-back  → wait until 9.0 s
+                                                       → advance to next block
+```
+
+Distribution: each slot gets `floor(n/slots)` txs; the first `n % slots` slots get one extra. Total always equals `n`.
+
+**Why per-second batching instead of per-tx pacing**: 150 individual `time.After` channels per block is wasteful; per-second batching collapses that to 9. The trade-off — txs are bursty within each second — has no impact at the private chain's 3 s block granularity.
+
+Absolute slot deadlines (`blockStart + slotDuration * (s+1)`) prevent drift: an over-long broadcast doesn't accumulate into the next slot. Empty blocks advance immediately rather than waste full `paceTotal`.
+
+---
+
+## Output files
+
+All three files below are **generated at runtime** and grow as `replay`
+runs. They are intentionally `.gitignore`d — they contain run-specific
+data and should not be committed.
+
+### `replay-state.json` — resume state
+
+Written after every block. `last_mainnet_block` is the **mainnet** block
+we've replayed up to, not the private chain head (the two diverge as soon
+as the private chain produces its own blocks).
+
+```json
+{
+  "last_mainnet_block": 82510650,
+  "total_fetched": 1234,
+  "total_broadcast_ok": 1180,
+  "total_broadcast_fail": 30,
+  "total_skipped": 24
+}
+```
+
+### `replay-failures.jsonl` — failed broadcasts
+
+One JSON object per line, appended in order. `reason` is the node's
+response code plus the hex-decoded `message` field.
+
+```jsonl
+{"block":82510633,"txID":"93d1a857da5c354b...","reason":"CONTRACT_VALIDATE_ERROR: balance is not sufficient"}
+{"block":82510633,"txID":"91924a2f6bc44cfe...","reason":"DUP_TRANSACTION_ERROR"}
+{"block":82510634,"txID":"a8331f4123d0302c...","reason":"NETWORK_ERROR: Post \"http://10.0.0.1:8090/wallet/broadcasttransaction\": dial tcp: i/o timeout"}
+```
+
+### `replay-skips.jsonl` — skipped transactions
+
+Same structure as failures, but for txs filtered out before broadcast.
+`reason` is `skip_type:<ContractType>` for the default-skipped types, or
+`parse_error` / `no_contract` for malformed input.
+
+```jsonl
+{"block":82510651,"txID":"a501305be664a25a...","reason":"skip_type:VoteWitnessContract"}
+{"block":82510653,"txID":"221db85dfae01009...","reason":"skip_type:WithdrawBalanceContract"}
+{"block":82510657,"txID":"491bcabf8d372252...","reason":"skip_type:WithdrawBalanceContract"}
+```
+
+## Monitoring
+
+```bash
+# state (last_mainnet_block = mainnet block number we've replayed up to)
+cat replay-state.json
+
+# is the private chain itself advancing ~3 s/block? (unrelated to last_mainnet_block)
+watch -n 1 'curl -s -X POST http://private_node_ip:8090/wallet/getnowblock \
+    | jq .block_header.raw_data.number'
+
+# top failure reasons
+jq -r .reason replay-failures.jsonl | sort | uniq -c | sort -rn
+
+# skip stats
+jq -r .reason replay-skips.jsonl | sort | uniq -c
+```
+
+## Interrupt and resume
+
+Ctrl+C triggers a graceful shutdown: the current block finishes processing, state is flushed, and the program exits. Restart without `--start` to continue.
+
+---
+
+## Common failure modes
+
+Reasons that show up in `replay-failures.jsonl`:
+
+| Reason | Cause | Fix |
+|---|---|---|
+| `CONTRACT_VALIDATE_ERROR: balance is not sufficient` | Private chain account doesn't have enough TRX | Top up balance during `db fork`, or skip txs from this account |
+| `CONTRACT_VALIDATE_ERROR: account does not exist` | Mainnet account isn't in the private chain snapshot | Re-fork including that account, or ignore |
+| `DUP_TRANSACTION_ERROR` | Same tx already replayed | Normal during resume — ignore |
+| `BAD_TRANSACTION_ERROR: validateSignature` | Node hasn't applied the patches above | Recompile the node from a `relay_skip_signature` branch |
+| `BAD_TRANSACTION_ERROR: too big` | Tx exceeds size limit | Raise `block.maxTimeUntilExpiration` in node config |
+| `NETWORK_ERROR: ...` | Private chain node unreachable | Check process state + HTTP port |
+
+---
+
+## How this compares to `tron-docker/stress_test`
+
+`tron-docker/tools/stress_test` provides similar functionality via a different architecture:
+
+| Dimension | `tron-docker/stress_test` | `replay` |
+|---|---|---|
+| Relation to java-tron | embedded fork of FullNode | external HTTP client |
+| Compile dependency on java-tron | yes (BroadcastNode embeds java-tron source) | none |
+| Artifact | jar + JDK runtime | single ~8 MB Go binary |
+| Transport | gRPC + in-process broadcast | HTTP / JSON |
+| Data flow | two-stage: generate → CSV → broadcast | single-stage streaming |
+| Resume | none | per-block via `state.json` |
+| Pre-filter known-failing contract types | no | yes (default-on; `--include-all` opts out) |
+| Failure log | unstructured / via node logs | structured JSONL |
+| All-fail block detection | no | yes (auto-aborts) |
+| Rate control | fixed `tpsLimit` | `tps-multiplier` derived from SR ratio |
+
+The reverse direction also holds: `stress_test` covers synthetic transaction generation (TRX / TRC10 / TRC20) and multi-target broadcast, which `replay` does not implement.
+
+---
+
+## Roadmap
+
+Functionality on the near-term list:
+
+- **PQ tx re-signing** — strip mainnet ECDSA signatures and re-sign with Falcon-512 keys before broadcast. Required for replaying mainnet load against a PQ-upgraded private chain.
+- **Multi-target broadcast** — accept a list of private nodes and round-robin across them. Matches `stress_test`'s `broadcastUrl` list capability.
+- **Prometheus metrics** — expose block-level OK / fail / pace metrics for Grafana dashboards.
+- **Mainnet follow-head mode** — `--follow-head` to continuously catch up to mainnet's latest block (a lightweight shadow-fork-ish mode).
+- **Synthetic tx generation** — TRX / TRC10 / TRC20 / PQ tx templates, with optional blending of synthetic and replayed traffic. Parity with `stress_test`'s `generate` stage.

--- a/tools/replay/README.md
+++ b/tools/replay/README.md
@@ -202,7 +202,7 @@ Use `--include-all` to forward them anyway — useful when observing failure mod
 --include-all        Do not skip Vote/Witness/Withdraw contracts
 ```
 
-State is flushed to `replay-state.json` after every block — no interval to configure.
+State is flushed to `replay-state.json` after **every transaction** so the resume point is precise to a single tx (covers SIGKILL / OOM / power-loss). Block completion does an atomic flush that advances `last_mainnet_block` and clears `in_progress_block` / `in_progress_tx_index` together — no grey state where txs were re-broadcast but the block counter hasn't moved.
 
 ---
 
@@ -249,13 +249,21 @@ data and should not be committed.
 
 ### `replay-state.json` — resume state
 
-Written after every block. `last_mainnet_block` is the **mainnet** block
-we've replayed up to, not the private chain head (the two diverge as soon
-as the private chain produces its own blocks).
+Written after every **transaction** for SIGKILL-grade resume precision.
+`last_mainnet_block` is the **mainnet** block we've replayed up to, not
+the private chain head (the two diverge as soon as the private chain
+produces its own blocks).
+
+`in_progress_block` and `in_progress_tx_index` are the per-tx checkpoint:
+both are `0` (or absent) when no block is in flight; non-zero
+`in_progress_block` means a previous run was killed midway and the next
+start will resume from `in_progress_tx_index` of that block.
 
 ```json
 {
   "last_mainnet_block": 82510650,
+  "in_progress_block": 82510651,
+  "in_progress_tx_index": 87,
   "total_fetched": 1234,
   "total_broadcast_ok": 1180,
   "total_broadcast_fail": 30,
@@ -305,7 +313,18 @@ jq -r .reason replay-skips.jsonl | sort | uniq -c
 
 ## Interrupt and resume
 
-Ctrl+C triggers a graceful shutdown: the current block finishes processing, state is flushed, and the program exits. Restart without `--start` to continue.
+All three interrupt scenarios resume cleanly. In every case, restart without `--start` and replay reads the state file automatically.
+
+| Scenario | State at interrupt | Resume point |
+|---|---|---|
+| `Ctrl+C` (SIGINT/SIGTERM) | Current tx finishes, state already flushed | The next tx in the in-progress block |
+| `kill -9` / OOM / power loss | State is flushed after every tx, so the most recent durable checkpoint is `in_progress_block` + `in_progress_tx_index` | `in_progress_tx_index` of `in_progress_block` (at most one tx may be re-broadcast → typically a single `DUP_TRANSACTION_ERROR` in the fail log) |
+| All-fail block aborts | `in_progress_block` preserved, `in_progress_tx_index` reset to `0` | After the operator fixes the underlying issue, replay restarts the aborted block from **tx 0** |
+
+How it works:
+- Every processed tx (broadcast / failed / skipped) flushes state, so the resume point is precise to a single tx.
+- Block completion is a single atomic flush that advances `last_mainnet_block` and clears `in_progress_*` together. There's no grey state where txs were re-broadcast but the block counter hasn't moved.
+- A resumed block sends the remaining txs back-to-back (the slot algorithm depends on the block-start wallclock, which is no longer meaningful after a restart). Pacing returns to normal at the next block.
 
 ---
 

--- a/tools/replay/filter.go
+++ b/tools/replay/filter.go
@@ -2,13 +2,15 @@ package main
 
 import "encoding/json"
 
-// defaultSkipContractTypes 列出默认跳过的合约类型。
+// defaultSkipContractTypes lists the contract types skipped by default.
 //
-// 这几类在重放路径上注定失败（参考 0.5.3 节）：
-//   - VoteWitness / WitnessUpdate / WitnessCreate：私链 witness 与主网不同
-//   - WithdrawBalance：投票奖励金额无法跟主网一致，会级联影响后续交易
+// These are guaranteed to fail when replayed on a private chain:
+//   - VoteWitness / WitnessUpdate / WitnessCreate: the private chain's
+//     witness set is different from mainnet's
+//   - WithdrawBalance: voting rewards don't match mainnet amounts, which
+//     cascades into subsequent balance-dependent transactions
 //
-// 用 --include-all 关闭此过滤。
+// Pass --include-all to disable this filter.
 var defaultSkipContractTypes = map[string]struct{}{
 	"VoteWitnessContract":     {},
 	"WitnessUpdateContract":   {},
@@ -16,7 +18,8 @@ var defaultSkipContractTypes = map[string]struct{}{
 	"WithdrawBalanceContract": {},
 }
 
-// txPeek 只解 txID + contract.type，避免把整个交易 unmarshal 一遍。
+// txPeek only decodes txID + contract.type, avoiding a full transaction
+// unmarshal when we only need to decide whether to skip.
 type txPeek struct {
 	TxID    string `json:"txID"`
 	RawData struct {
@@ -26,9 +29,10 @@ type txPeek struct {
 	} `json:"raw_data"`
 }
 
-// shouldSkip 返回跳过原因（空字符串表示不跳过）+ 解析出的 peek 信息。
+// shouldSkip returns the skip reason ("" = do not skip) plus the parsed
+// peek info.
 //
-// 调用方拿 peek 是为了写日志时附带 txID，避免再 unmarshal 一遍。
+// Callers use the peek to log the txID without unmarshaling again.
 func shouldSkip(tx json.RawMessage, skipTypes map[string]struct{}) (string, txPeek) {
 	var p txPeek
 	if err := json.Unmarshal(tx, &p); err != nil {

--- a/tools/replay/filter.go
+++ b/tools/replay/filter.go
@@ -1,0 +1,45 @@
+package main
+
+import "encoding/json"
+
+// defaultSkipContractTypes 列出默认跳过的合约类型。
+//
+// 这几类在重放路径上注定失败（参考 0.5.3 节）：
+//   - VoteWitness / WitnessUpdate / WitnessCreate：私链 witness 与主网不同
+//   - WithdrawBalance：投票奖励金额无法跟主网一致，会级联影响后续交易
+//
+// 用 --include-all 关闭此过滤。
+var defaultSkipContractTypes = map[string]struct{}{
+	"VoteWitnessContract":     {},
+	"WitnessUpdateContract":   {},
+	"WitnessCreateContract":   {},
+	"WithdrawBalanceContract": {},
+}
+
+// txPeek 只解 txID + contract.type，避免把整个交易 unmarshal 一遍。
+type txPeek struct {
+	TxID    string `json:"txID"`
+	RawData struct {
+		Contract []struct {
+			Type string `json:"type"`
+		} `json:"contract"`
+	} `json:"raw_data"`
+}
+
+// shouldSkip 返回跳过原因（空字符串表示不跳过）+ 解析出的 peek 信息。
+//
+// 调用方拿 peek 是为了写日志时附带 txID，避免再 unmarshal 一遍。
+func shouldSkip(tx json.RawMessage, skipTypes map[string]struct{}) (string, txPeek) {
+	var p txPeek
+	if err := json.Unmarshal(tx, &p); err != nil {
+		return "parse_error", p
+	}
+	if len(p.RawData.Contract) == 0 {
+		return "no_contract", p
+	}
+	ctype := p.RawData.Contract[0].Type
+	if _, ok := skipTypes[ctype]; ok {
+		return "skip_type:" + ctype, p
+	}
+	return "", p
+}

--- a/tools/replay/logger.go
+++ b/tools/replay/logger.go
@@ -5,9 +5,10 @@ import (
 	"os"
 )
 
-// jsonlLogger 把每条记录序列化为一行 JSON 写入文件，append 模式。
+// jsonlLogger writes each record as one JSON line to a file in append mode.
 //
-// 故意保持简单（不带 buffer），方便用 tail -F 实时观察。
+// Deliberately kept simple (no buffering) so `tail -F` shows progress in
+// real time.
 type jsonlLogger struct {
 	f *os.File
 }

--- a/tools/replay/logger.go
+++ b/tools/replay/logger.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+)
+
+// jsonlLogger 把每条记录序列化为一行 JSON 写入文件，append 模式。
+//
+// 故意保持简单（不带 buffer），方便用 tail -F 实时观察。
+type jsonlLogger struct {
+	f *os.File
+}
+
+func openJsonlLogger(path string) (*jsonlLogger, error) {
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+	if err != nil {
+		return nil, err
+	}
+	return &jsonlLogger{f: f}, nil
+}
+
+func (l *jsonlLogger) writeRecord(rec map[string]any) {
+	data, _ := json.Marshal(rec)
+	_, _ = l.f.Write(data)
+	_, _ = l.f.Write([]byte("\n"))
+}
+
+func (l *jsonlLogger) Close() { _ = l.f.Close() }

--- a/tools/replay/main.go
+++ b/tools/replay/main.go
@@ -1,27 +1,30 @@
 // TRON Mainnet → Private Chain Transaction Replayer.
 //
-// 流程：
-//  1. 从 TronGrid API 拉取主网区块
-//  2. 提取每个区块里的交易
-//  3. 直接 POST 到私链节点的 /wallet/broadcasttransaction
-//  4. 失败 / 跳过写日志，成功推进 state.json 断点
+// Flow:
+//  1. Fetch mainnet blocks via the TronGrid HTTP API.
+//  2. Extract transactions from each block.
+//  3. POST each transaction to the private node's
+//     /wallet/broadcasttransaction endpoint.
+//  4. Write failed / skipped txs to JSONL logs; advance state.json after
+//     each successful block.
 //
-// 私链节点必须运行 relay_skip_signature 分支
-// （跳过 refBlockHash / expiration / TaPos / 部分签名校验）。
+// The private chain node must run a relay_skip_signature-style branch
+// that disables refBlockHash / expiration / TaPos and selected signature
+// checks. See the README "Required java-tron patches" section.
 //
-// 用法：见同目录 README.md
+// Usage: see README.md in this directory.
 //
-// 依赖：纯 Go 标准库
-// Go 版本：1.21+
+// Dependencies: Go standard library only.
+// Go version: 1.21+
 //
-// 文件组织：
-//  - main.go      入口、CLI、Config
-//  - state.go     state 文件读写
-//  - trongrid.go  TronGrid 客户端
-//  - private.go   私链广播客户端
-//  - filter.go    交易过滤规则
-//  - logger.go    jsonl 日志写入
-//  - replayer.go  主循环、节奏控制
+// File layout:
+//   - main.go      entry point, CLI flags, Config
+//   - state.go     state file read/write
+//   - trongrid.go  TronGrid API client
+//   - private.go   private chain broadcast client
+//   - filter.go    transaction filter rules
+//   - logger.go    JSONL logger
+//   - replayer.go  main loop, pacing control
 package main
 
 import (
@@ -35,12 +38,12 @@ import (
 	"syscall"
 )
 
-// Config 是命令行参数 + 环境变量解析出的运行时配置。
+// Config is the runtime configuration parsed from CLI flags + env vars.
 type Config struct {
 	TrongridURL   string
 	TrongridKey   string
 	TrongridQPS   int
-	TpsMultiplier float64 // 私链 TPS = 主网 TPS × 此倍率；pace_sec = 3 / multiplier
+	TpsMultiplier float64 // private TPS = mainnet TPS * multiplier; pace_sec = 3 / multiplier
 	PrivateNode   string
 	Start         int64
 	End           int64
@@ -84,7 +87,7 @@ func parseArgs() Config {
 	return c
 }
 
-// keysOf 返回 map 的所有键，仅用于启动日志。
+// keysOf returns all keys of m, used only for startup logging.
 func keysOf(m map[string]struct{}) []string {
 	out := make([]string, 0, len(m))
 	for k := range m {

--- a/tools/replay/main.go
+++ b/tools/replay/main.go
@@ -97,6 +97,16 @@ func keysOf(m map[string]struct{}) []string {
 }
 
 func main() {
+	if err := run(); err != nil {
+		log.Printf("error: %v", err)
+		os.Exit(1)
+	}
+}
+
+// run is the real entry point. It returns an error instead of calling
+// log.Fatalf so deferred cleanups (signal.NotifyContext restore, jsonl
+// loggers close, etc.) actually run before the process exits.
+func run() error {
 	cfg := parseArgs()
 
 	ctx, stop := signal.NotifyContext(context.Background(),
@@ -110,12 +120,12 @@ func main() {
 
 	failLog, err := openJsonlLogger(cfg.FailLog)
 	if err != nil {
-		log.Fatalf("open fail log: %v", err)
+		return fmt.Errorf("open fail log: %w", err)
 	}
 	defer failLog.Close()
 	skipLog, err := openJsonlLogger(cfg.SkipLog)
 	if err != nil {
-		log.Fatalf("open skip log: %v", err)
+		return fmt.Errorf("open skip log: %w", err)
 	}
 	defer skipLog.Close()
 
@@ -130,6 +140,7 @@ func main() {
 	}
 
 	if err := r.Run(ctx); err != nil && !errors.Is(err, context.Canceled) {
-		log.Fatalf("run: %v", err)
+		return fmt.Errorf("run: %w", err)
 	}
+	return nil
 }

--- a/tools/replay/main.go
+++ b/tools/replay/main.go
@@ -1,0 +1,132 @@
+// TRON Mainnet → Private Chain Transaction Replayer.
+//
+// 流程：
+//  1. 从 TronGrid API 拉取主网区块
+//  2. 提取每个区块里的交易
+//  3. 直接 POST 到私链节点的 /wallet/broadcasttransaction
+//  4. 失败 / 跳过写日志，成功推进 state.json 断点
+//
+// 私链节点必须运行 relay_skip_signature 分支
+// （跳过 refBlockHash / expiration / TaPos / 部分签名校验）。
+//
+// 用法：见同目录 README.md
+//
+// 依赖：纯 Go 标准库
+// Go 版本：1.21+
+//
+// 文件组织：
+//  - main.go      入口、CLI、Config
+//  - state.go     state 文件读写
+//  - trongrid.go  TronGrid 客户端
+//  - private.go   私链广播客户端
+//  - filter.go    交易过滤规则
+//  - logger.go    jsonl 日志写入
+//  - replayer.go  主循环、节奏控制
+package main
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"os/signal"
+	"syscall"
+)
+
+// Config 是命令行参数 + 环境变量解析出的运行时配置。
+type Config struct {
+	TrongridURL   string
+	TrongridKey   string
+	TrongridQPS   int
+	TpsMultiplier float64 // 私链 TPS = 主网 TPS × 此倍率；pace_sec = 3 / multiplier
+	PrivateNode   string
+	Start         int64
+	End           int64
+	StateFile     string
+	FailLog       string
+	SkipLog       string
+	IncludeAll    bool
+}
+
+func parseArgs() Config {
+	var c Config
+	flag.StringVar(&c.TrongridURL, "trongrid-url", trongridDefaultURL, "TronGrid API base URL")
+	flag.StringVar(&c.TrongridKey, "trongrid-key", os.Getenv("TRONGRID_API_KEY"),
+		"TronGrid API key (or env TRONGRID_API_KEY)")
+	flag.IntVar(&c.TrongridQPS, "trongrid-qps", trongridDefaultQPS,
+		"TronGrid request rate limit (queries per second)")
+	flag.Float64Var(&c.TpsMultiplier, "tps-multiplier", tpsMultiplierDefault,
+		"Private chain TPS as a fraction of mainnet TPS. "+
+			"pace_sec = 3 / multiplier. "+
+			"Examples: 1 → 3s/block (mainnet speed), 0.5 → 6s/block, "+
+			"default ~0.333 → 9s/block (3 SR private vs 27 SR mainnet)")
+	flag.StringVar(&c.PrivateNode, "private-node", "",
+		"Private chain HTTP API base, e.g. http://10.0.0.1:8090 (required)")
+	flag.Int64Var(&c.Start, "start", 0,
+		"Start MAINNET block (inclusive). 0 = resume from state file "+
+			"(required on first run; do NOT use private chain head)")
+	flag.Int64Var(&c.End, "end", 0,
+		"End block (inclusive). 0 = start + 10 (short range for safety; "+
+			"set explicitly for longer runs)")
+	flag.StringVar(&c.StateFile, "state-file", "./replay-state.json", "Resume state file")
+	flag.StringVar(&c.FailLog, "fail-log", "./replay-failures.jsonl", "Failed broadcast log")
+	flag.StringVar(&c.SkipLog, "skip-log", "./replay-skips.jsonl", "Skipped txs log")
+	flag.BoolVar(&c.IncludeAll, "include-all", false,
+		"Do not skip Vote/Witness/Withdraw txs (default skips them, see 0.5.3)")
+	flag.Parse()
+	if c.PrivateNode == "" {
+		fmt.Fprintln(os.Stderr, "error: --private-node is required")
+		flag.Usage()
+		os.Exit(2)
+	}
+	return c
+}
+
+// keysOf 返回 map 的所有键，仅用于启动日志。
+func keysOf(m map[string]struct{}) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}
+
+func main() {
+	cfg := parseArgs()
+
+	ctx, stop := signal.NotifyContext(context.Background(),
+		syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+
+	skipTypes := map[string]struct{}{}
+	if !cfg.IncludeAll {
+		skipTypes = defaultSkipContractTypes
+	}
+
+	failLog, err := openJsonlLogger(cfg.FailLog)
+	if err != nil {
+		log.Fatalf("open fail log: %v", err)
+	}
+	defer failLog.Close()
+	skipLog, err := openJsonlLogger(cfg.SkipLog)
+	if err != nil {
+		log.Fatalf("open skip log: %v", err)
+	}
+	defer skipLog.Close()
+
+	r := &Replayer{
+		cfg:       cfg,
+		trongrid:  newTronGridClient(cfg.TrongridURL, cfg.TrongridKey, cfg.TrongridQPS),
+		private:   newPrivateNodeClient(cfg.PrivateNode),
+		state:     loadState(cfg.StateFile),
+		skipTypes: skipTypes,
+		failLog:   failLog,
+		skipLog:   skipLog,
+	}
+
+	if err := r.Run(ctx); err != nil && !errors.Is(err, context.Canceled) {
+		log.Fatalf("run: %v", err)
+	}
+}

--- a/tools/replay/private.go
+++ b/tools/replay/private.go
@@ -13,13 +13,14 @@ import (
 
 const privateNodeTimeoutSec = 5
 
-// PrivateNodeClient 把主网交易转发给私链节点的 HTTP API。
+// PrivateNodeClient forwards mainnet transactions to the private chain
+// node's HTTP API.
 type PrivateNodeClient struct {
 	baseURL string
 	client  *http.Client
 }
 
-// broadcastResp 是 /wallet/broadcasttransaction 的响应结构。
+// broadcastResp is the response shape of /wallet/broadcasttransaction.
 type broadcastResp struct {
 	Result  bool   `json:"result"`
 	Code    string `json:"code"`
@@ -33,9 +34,12 @@ func newPrivateNodeClient(baseURL string) *PrivateNodeClient {
 	}
 }
 
-// broadcast 直接把主网 tx json 转发给私链，不做任何字段改写。
-// 返回 (success, message)。success=true 表示节点接受了交易；
-// 落块成功需 getTransactionInfoById 单独确认，本工具不做。
+// broadcast forwards a mainnet tx JSON to the private chain as-is,
+// without rewriting any fields.
+// Returns (success, message). success=true means the node accepted the
+// transaction into its pending pool; confirming the tx actually landed
+// in a block requires a separate getTransactionInfoById call, which
+// this tool does not perform.
 func (c *PrivateNodeClient) broadcast(ctx context.Context, tx json.RawMessage) (bool, string) {
 	req, err := http.NewRequestWithContext(ctx, "POST",
 		c.baseURL+"/wallet/broadcasttransaction", bytes.NewReader(tx))
@@ -57,7 +61,7 @@ func (c *PrivateNodeClient) broadcast(ctx context.Context, tx json.RawMessage) (
 		return true, "OK"
 	}
 	msg := r.Message
-	// java-tron message 字段常是 hex-encoded，解一下提高可读性
+	// java-tron's message field is usually hex-encoded; decode for readability
 	if msg != "" {
 		if decoded, err := hex.DecodeString(msg); err == nil {
 			msg = string(decoded)

--- a/tools/replay/private.go
+++ b/tools/replay/private.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/hex"
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+const privateNodeTimeoutSec = 5
+
+// PrivateNodeClient 把主网交易转发给私链节点的 HTTP API。
+type PrivateNodeClient struct {
+	baseURL string
+	client  *http.Client
+}
+
+// broadcastResp 是 /wallet/broadcasttransaction 的响应结构。
+type broadcastResp struct {
+	Result  bool   `json:"result"`
+	Code    string `json:"code"`
+	Message string `json:"message"`
+}
+
+func newPrivateNodeClient(baseURL string) *PrivateNodeClient {
+	return &PrivateNodeClient{
+		baseURL: strings.TrimRight(baseURL, "/"),
+		client:  &http.Client{Timeout: privateNodeTimeoutSec * time.Second},
+	}
+}
+
+// broadcast 直接把主网 tx json 转发给私链，不做任何字段改写。
+// 返回 (success, message)。success=true 表示节点接受了交易；
+// 落块成功需 getTransactionInfoById 单独确认，本工具不做。
+func (c *PrivateNodeClient) broadcast(ctx context.Context, tx json.RawMessage) (bool, string) {
+	req, err := http.NewRequestWithContext(ctx, "POST",
+		c.baseURL+"/wallet/broadcasttransaction", bytes.NewReader(tx))
+	if err != nil {
+		return false, "BUILD_REQ_ERROR: " + err.Error()
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return false, "NETWORK_ERROR: " + err.Error()
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	var r broadcastResp
+	if err := json.Unmarshal(body, &r); err != nil {
+		return false, "PARSE_ERROR: " + string(body)
+	}
+	if r.Result {
+		return true, "OK"
+	}
+	msg := r.Message
+	// java-tron message 字段常是 hex-encoded，解一下提高可读性
+	if msg != "" {
+		if decoded, err := hex.DecodeString(msg); err == nil {
+			msg = string(decoded)
+		}
+	}
+	return false, r.Code + ": " + msg
+}

--- a/tools/replay/replayer.go
+++ b/tools/replay/replayer.go
@@ -1,0 +1,240 @@
+package main
+
+import (
+    "context"
+    "encoding/json"
+    "errors"
+    "fmt"
+    "log"
+    "sync/atomic"
+    "time"
+)
+
+const (
+    // mainnetBlockSec 主网出块间隔；每个主网块就是 3s 的主网时间。
+    mainnetBlockSec = 3
+
+    // tpsMultiplierDefault 默认私链 TPS ≈ 1/3 主网 TPS。
+    // 对应 pace ≈ 9 秒，即每主网块铺到 9s 私链时间。
+    // 适用 3 SR 私链对 27 SR 主网的场景（私链每槽位负担约 9 倍主网密度）。
+    // 用 0.333 而非 1.0/3.0 是为了 --help 显示更干净（pace 实际 9.009s 与 9s 无差别）。
+    tpsMultiplierDefault = 0.333
+)
+
+// Replayer 是主重放循环的状态机：
+//   - 拉主网块 → 过滤 → 按节奏广播到私链 → 推进 state
+//   - 失败 / 跳过的交易落 jsonl 日志
+//   - 支持 Ctrl+C 安全退出 + state 持久化续跑
+type Replayer struct {
+    cfg       Config
+    trongrid  *TronGridClient
+    private   *PrivateNodeClient
+    state     ReplayState
+    skipTypes map[string]struct{}
+    failLog   *jsonlLogger
+    skipLog   *jsonlLogger
+}
+
+// defaultEndOffset 不显式指定 --end 时，默认只跑 start + 这个偏移量。
+// 避免一不小心把"到主网最高块"作为默认，导致跑几小时停不下来。
+// 想跑大区间显式 --end 即可。
+const defaultEndOffset = 10
+
+func (r *Replayer) Run(ctx context.Context) error {
+    start, err := r.resolveStartBlock(ctx)
+    if err != nil {
+        return fmt.Errorf("resolve start block: %w", err)
+    }
+    end := r.cfg.End
+    if end <= 0 {
+        end = start + defaultEndOffset
+        log.Printf("--end not set, defaulting to start + %d = %d", defaultEndOffset, end)
+    }
+    log.Printf("Replay range: [%d, %d], skip types: %v", start, end, keysOf(r.skipTypes))
+
+    for n := start; n <= end; n++ {
+        select {
+        case <-ctx.Done():
+            log.Printf("ctx cancelled, exit at block %d", n)
+            return r.flushState()
+        default:
+        }
+        blockOk, blockFail, blockSkip, err := r.processBlock(ctx, n)
+        if err != nil {
+            // 不推进 LastMainnetBlock；但保存最新累计计数器供排查
+            if flushErr := r.flushState(); flushErr != nil {
+                log.Printf("save state failed: %v", flushErr)
+            }
+            log.Printf("ABORTING at block %d: %v", n, err)
+            log.Printf("state preserved at last_mainnet_block=%d (not advanced to %d); "+
+                "check %s for failure details", r.state.LastMainnetBlock, n, r.cfg.FailLog)
+            return err
+        }
+        r.state.LastMainnetBlock = n
+        if err := r.flushState(); err != nil {
+            log.Printf("save state failed: %v", err)
+        }
+        log.Printf("block %d done | block: ok=%d fail=%d skip=%d | cum: ok=%d fail=%d skip=%d",
+            n, blockOk, blockFail, blockSkip,
+            r.state.TotalBroadcastOk, r.state.TotalBroadcastFail, r.state.TotalSkipped)
+    }
+    if err := r.flushState(); err != nil {
+        return err
+    }
+    log.Printf("DONE | last=%d fetched=%d ok=%d fail=%d skip=%d",
+        r.state.LastMainnetBlock, r.state.TotalFetched,
+        r.state.TotalBroadcastOk, r.state.TotalBroadcastFail, r.state.TotalSkipped)
+    return nil
+}
+
+// resolveStartBlock 决定从哪个**主网**块开始抓。
+//
+// 优先级：
+//  1. --start 显式指定
+//  2. state 文件里上次断点 + 1
+//
+// 注意：**绝对不能**用私链 getnowblock + 1 作为起点。私链自己也在
+// 出块，head 是私链自己的计数，与主网块号无关；第一次启动必须由
+// 用户显式提供 --start（通常是 snapshot 裁剪时的最后一个主网块 + 1）。
+func (r *Replayer) resolveStartBlock(_ context.Context) (int64, error) {
+    if r.cfg.Start > 0 {
+        return r.cfg.Start, nil
+    }
+    if r.state.LastMainnetBlock > 0 {
+        return r.state.LastMainnetBlock + 1, nil
+    }
+    return 0, errors.New(
+        "no start block: pass --start <mainnet_block_after_snapshot> on first run " +
+            "(or run with an existing state file from a previous run)")
+}
+
+// processBlock 处理单个主网块：拉取 → 按"槽"分批发送到私链。
+//
+// 节奏算法：
+//   - paceTotal = mainnetBlockSec / TpsMultiplier
+//     例：multiplier=1   → pace=3s
+//         multiplier=0.5 → pace=6s
+//         multiplier=1/3 → pace=9s
+//   - slots = max(1, floor(paceTotal / 1s))，每槽约 1 秒
+//     例：pace=3s → 3 槽；pace=9s → 9 槽；pace=1.5s → 1 槽
+//   - n 笔交易尽量均分到这些槽里：前 (n%slots) 个槽各 ceil(n/slots) 笔
+//   - 每个槽内交易**连续发送**无 sleep，整批完后等到该槽的绝对边界
+//   - 总定时器数：slots 次（典型 3-9 次），而非 n 次（典型 150 次）
+//
+// 拉块失败仍等满 paceTotal 保持节奏；空块 / 区块不存在直接 return，
+// 不占整块时间，让重放更快推进。
+//
+// 返回 (blockOk, blockFail, blockSkip, err)。
+// err 非 nil 当且仅当：本块发起过广播 (attempted > 0) 但全部失败 (ok == 0)。
+// 此时调用方 (Run) 应当停服，避免在私链状态有问题时盲目推进 state。
+func (r *Replayer) processBlock(ctx context.Context, num int64) (int64, int64, int64, error) {
+    blockStart := time.Now()
+
+    okBefore := atomic.LoadInt64(&r.state.TotalBroadcastOk)
+    failBefore := atomic.LoadInt64(&r.state.TotalBroadcastFail)
+    skipBefore := atomic.LoadInt64(&r.state.TotalSkipped)
+
+    multiplier := r.cfg.TpsMultiplier
+    if multiplier <= 0 {
+        multiplier = tpsMultiplierDefault
+    }
+    paceTotal := time.Duration(float64(mainnetBlockSec*time.Second) / multiplier)
+
+    blk, err := r.trongrid.getBlock(ctx, num)
+    if err != nil {
+        log.Printf("block %d fetch failed: %v", num, err)
+        r.waitUntil(ctx, blockStart.Add(paceTotal))
+        return 0, 0, 0, nil // 拉块失败属于 TronGrid 侧问题，不算"全失败"，继续下一块
+    }
+    if blk == nil {
+        log.Printf("block %d not found", num)
+        return 0, 0, 0, nil
+    }
+    n := len(blk.Transactions)
+    atomic.AddInt64(&r.state.TotalFetched, int64(n))
+
+    if n == 0 {
+        return 0, 0, 0, nil
+    }
+
+    // 槽数约等于 paceTotal 的整数秒；slotDuration = paceTotal/slots
+    // 吸收小数秒余量，保证最后一个槽 deadline 恰好是 blockStart + paceTotal
+    slots := int(paceTotal / time.Second)
+    if slots < 1 {
+        slots = 1
+    }
+    slotDuration := paceTotal / time.Duration(slots)
+    baseSize := n / slots
+    remainder := n % slots // 前 remainder 个槽多分 1 笔
+
+    idx := 0
+    for s := 0; s < slots; s++ {
+        size := baseSize
+        if s < remainder {
+            size++
+        }
+        // 本槽连续发送 size 笔（无 sleep）
+        for k := 0; k < size; k++ {
+            select {
+            case <-ctx.Done():
+                return atomic.LoadInt64(&r.state.TotalBroadcastOk) - okBefore,
+                    atomic.LoadInt64(&r.state.TotalBroadcastFail) - failBefore,
+                    atomic.LoadInt64(&r.state.TotalSkipped) - skipBefore,
+                    nil
+            default:
+            }
+            r.processTx(ctx, num, blk.Transactions[idx])
+            idx++
+        }
+        // 等到该槽的绝对边界（避免漂移）
+        target := blockStart.Add(slotDuration * time.Duration(s+1))
+        r.waitUntil(ctx, target)
+    }
+
+    blockOk := atomic.LoadInt64(&r.state.TotalBroadcastOk) - okBefore
+    blockFail := atomic.LoadInt64(&r.state.TotalBroadcastFail) - failBefore
+    blockSkip := atomic.LoadInt64(&r.state.TotalSkipped) - skipBefore
+
+    // 广播试过 (blockFail > 0) 但全失败 (blockOk == 0) → 触发停服
+    // 跳过的（VoteWitness 等）不算在内，因为根本没尝试发出去
+    if ctx.Err() == nil && blockFail > 0 && blockOk == 0 {
+        return blockOk, blockFail, blockSkip,
+            fmt.Errorf("block %d: all %d broadcast attempts failed", num, blockFail)
+    }
+    return blockOk, blockFail, blockSkip, nil
+}
+
+// processTx 处理单笔交易：先过滤，过则广播。
+func (r *Replayer) processTx(ctx context.Context, blockNum int64, tx json.RawMessage) {
+    reason, peek := shouldSkip(tx, r.skipTypes)
+    if reason != "" {
+        atomic.AddInt64(&r.state.TotalSkipped, 1)
+        r.skipLog.writeRecord(map[string]any{
+            "block": blockNum, "txID": peek.TxID, "reason": reason,
+        })
+        return
+    }
+    ok, msg := r.private.broadcast(ctx, tx)
+    if ok {
+        atomic.AddInt64(&r.state.TotalBroadcastOk, 1)
+    } else {
+        atomic.AddInt64(&r.state.TotalBroadcastFail, 1)
+        r.failLog.writeRecord(map[string]any{
+            "block": blockNum, "txID": peek.TxID, "reason": msg,
+        })
+    }
+}
+
+// waitUntil 阻塞直到 deadline 或 ctx 取消；已过时刻立刻返回。
+func (r *Replayer) waitUntil(ctx context.Context, deadline time.Time) {
+    d := time.Until(deadline)
+    if d <= 0 {
+        return
+    }
+    select {
+    case <-ctx.Done():
+    case <-time.After(d):
+    }
+}
+
+func (r *Replayer) flushState() error { return r.state.save(r.cfg.StateFile) }

--- a/tools/replay/replayer.go
+++ b/tools/replay/replayer.go
@@ -11,20 +11,24 @@ import (
 )
 
 const (
-    // mainnetBlockSec 主网出块间隔；每个主网块就是 3s 的主网时间。
+    // mainnetBlockSec is the mainnet block interval. Each mainnet block
+    // represents 3 seconds of mainnet time.
     mainnetBlockSec = 3
 
-    // tpsMultiplierDefault 默认私链 TPS ≈ 1/3 主网 TPS。
-    // 对应 pace ≈ 9 秒，即每主网块铺到 9s 私链时间。
-    // 适用 3 SR 私链对 27 SR 主网的场景（私链每槽位负担约 9 倍主网密度）。
-    // 用 0.333 而非 1.0/3.0 是为了 --help 显示更干净（pace 实际 9.009s 与 9s 无差别）。
+    // tpsMultiplierDefault: default private TPS is ~1/3 of mainnet TPS.
+    // This corresponds to a 9-second pace (one mainnet block spread over
+    // 9 s of private chain time) and matches the 3 SR private vs 27 SR
+    // mainnet topology (each private SR carries ~9x the mainnet density).
+    // 0.333 is preferred over 1.0/3.0 for a cleaner --help output;
+    // 9.009 s vs 9 s makes no practical difference.
     tpsMultiplierDefault = 0.333
 )
 
-// Replayer 是主重放循环的状态机：
-//   - 拉主网块 → 过滤 → 按节奏广播到私链 → 推进 state
-//   - 失败 / 跳过的交易落 jsonl 日志
-//   - 支持 Ctrl+C 安全退出 + state 持久化续跑
+// Replayer is the state machine driving the main replay loop:
+//   - pull mainnet block → filter → broadcast to private chain with pacing
+//     → advance state
+//   - failed / skipped txs go to JSONL logs
+//   - Ctrl+C triggers a graceful exit with state flushed for resume
 type Replayer struct {
     cfg       Config
     trongrid  *TronGridClient
@@ -35,9 +39,10 @@ type Replayer struct {
     skipLog   *jsonlLogger
 }
 
-// defaultEndOffset 不显式指定 --end 时，默认只跑 start + 这个偏移量。
-// 避免一不小心把"到主网最高块"作为默认，导致跑几小时停不下来。
-// 想跑大区间显式 --end 即可。
+// defaultEndOffset is how many blocks to advance when --end is not set.
+// We deliberately avoid defaulting to "current mainnet head" so that
+// running the tool without --end can't accidentally turn into a multi-hour
+// job. Pass --end explicitly for longer ranges.
 const defaultEndOffset = 10
 
 func (r *Replayer) Run(ctx context.Context) error {
@@ -61,7 +66,8 @@ func (r *Replayer) Run(ctx context.Context) error {
         }
         blockOk, blockFail, blockSkip, err := r.processBlock(ctx, n)
         if err != nil {
-            // 不推进 LastMainnetBlock；但保存最新累计计数器供排查
+            // Don't advance LastMainnetBlock, but flush the cumulative
+            // counters so they're visible for post-mortem.
             if flushErr := r.flushState(); flushErr != nil {
                 log.Printf("save state failed: %v", flushErr)
             }
@@ -87,15 +93,17 @@ func (r *Replayer) Run(ctx context.Context) error {
     return nil
 }
 
-// resolveStartBlock 决定从哪个**主网**块开始抓。
+// resolveStartBlock decides which **mainnet** block to start pulling from.
 //
-// 优先级：
-//  1. --start 显式指定
-//  2. state 文件里上次断点 + 1
+// Priority:
+//  1. --start explicitly passed by the user
+//  2. last_mainnet_block from the state file + 1
 //
-// 注意：**绝对不能**用私链 getnowblock + 1 作为起点。私链自己也在
-// 出块，head 是私链自己的计数，与主网块号无关；第一次启动必须由
-// 用户显式提供 --start（通常是 snapshot 裁剪时的最后一个主网块 + 1）。
+// IMPORTANT: never use the private chain's getnowblock + 1 as the start.
+// The private chain produces its own blocks, so its head is the private
+// chain's own counter — unrelated to mainnet's block number. On first
+// run the user MUST pass --start explicitly (typically the snapshot's
+// last mainnet block + 1).
 func (r *Replayer) resolveStartBlock(_ context.Context) (int64, error) {
     if r.cfg.Start > 0 {
         return r.cfg.Start, nil
@@ -108,25 +116,31 @@ func (r *Replayer) resolveStartBlock(_ context.Context) (int64, error) {
             "(or run with an existing state file from a previous run)")
 }
 
-// processBlock 处理单个主网块：拉取 → 按"槽"分批发送到私链。
+// processBlock handles a single mainnet block: fetch → split into per-second
+// slots → broadcast to the private chain.
 //
-// 节奏算法：
+// Pacing algorithm:
 //   - paceTotal = mainnetBlockSec / TpsMultiplier
-//     例：multiplier=1   → pace=3s
-//         multiplier=0.5 → pace=6s
-//         multiplier=1/3 → pace=9s
-//   - slots = max(1, floor(paceTotal / 1s))，每槽约 1 秒
-//     例：pace=3s → 3 槽；pace=9s → 9 槽；pace=1.5s → 1 槽
-//   - n 笔交易尽量均分到这些槽里：前 (n%slots) 个槽各 ceil(n/slots) 笔
-//   - 每个槽内交易**连续发送**无 sleep，整批完后等到该槽的绝对边界
-//   - 总定时器数：slots 次（典型 3-9 次），而非 n 次（典型 150 次）
+//     e.g. multiplier=1   → pace=3s
+//          multiplier=0.5 → pace=6s
+//          multiplier=1/3 → pace=9s
+//   - slots = max(1, floor(paceTotal / 1s)), ~1 second per slot
+//     e.g. pace=3s → 3 slots, pace=9s → 9 slots, pace=1.5s → 1 slot
+//   - n txs are spread across slots as evenly as possible: the first
+//     (n % slots) slots get one extra (ceil(n/slots)) tx.
+//   - Within a slot, txs are sent back-to-back with no sleep; after the
+//     batch we wait until the slot's absolute deadline.
+//   - Total timer invocations: `slots` (typically 3-9), not `n` (typically 150).
 //
-// 拉块失败仍等满 paceTotal 保持节奏；空块 / 区块不存在直接 return，
-// 不占整块时间，让重放更快推进。
+// On fetch failure we still wait for the full paceTotal to keep the
+// schedule steady. Empty blocks / non-existent blocks return immediately
+// without burning the full pace so replay advances faster.
 //
-// 返回 (blockOk, blockFail, blockSkip, err)。
-// err 非 nil 当且仅当：本块发起过广播 (attempted > 0) 但全部失败 (ok == 0)。
-// 此时调用方 (Run) 应当停服，避免在私链状态有问题时盲目推进 state。
+// Returns (blockOk, blockFail, blockSkip, err).
+// err is non-nil iff this block attempted broadcasts (attempted > 0) and
+// all of them failed (ok == 0). In that case the caller (Run) should
+// stop the service to avoid blindly advancing state while the private
+// chain is in a bad state.
 func (r *Replayer) processBlock(ctx context.Context, num int64) (int64, int64, int64, error) {
     blockStart := time.Now()
 
@@ -144,7 +158,7 @@ func (r *Replayer) processBlock(ctx context.Context, num int64) (int64, int64, i
     if err != nil {
         log.Printf("block %d fetch failed: %v", num, err)
         r.waitUntil(ctx, blockStart.Add(paceTotal))
-        return 0, 0, 0, nil // 拉块失败属于 TronGrid 侧问题，不算"全失败"，继续下一块
+        return 0, 0, 0, nil // fetch failure is a TronGrid-side issue; not "all-fail", continue
     }
     if blk == nil {
         log.Printf("block %d not found", num)
@@ -157,15 +171,16 @@ func (r *Replayer) processBlock(ctx context.Context, num int64) (int64, int64, i
         return 0, 0, 0, nil
     }
 
-    // 槽数约等于 paceTotal 的整数秒；slotDuration = paceTotal/slots
-    // 吸收小数秒余量，保证最后一个槽 deadline 恰好是 blockStart + paceTotal
+    // Slot count ~= paceTotal in integer seconds. slotDuration = paceTotal/slots
+    // absorbs any fractional remainder so the final slot's deadline lands
+    // exactly at blockStart + paceTotal.
     slots := int(paceTotal / time.Second)
     if slots < 1 {
         slots = 1
     }
     slotDuration := paceTotal / time.Duration(slots)
     baseSize := n / slots
-    remainder := n % slots // 前 remainder 个槽多分 1 笔
+    remainder := n % slots // the first `remainder` slots each get one extra tx
 
     idx := 0
     for s := 0; s < slots; s++ {
@@ -173,7 +188,7 @@ func (r *Replayer) processBlock(ctx context.Context, num int64) (int64, int64, i
         if s < remainder {
             size++
         }
-        // 本槽连续发送 size 笔（无 sleep）
+        // Send this slot's `size` txs back-to-back, no sleep between.
         for k := 0; k < size; k++ {
             select {
             case <-ctx.Done():
@@ -186,7 +201,7 @@ func (r *Replayer) processBlock(ctx context.Context, num int64) (int64, int64, i
             r.processTx(ctx, num, blk.Transactions[idx])
             idx++
         }
-        // 等到该槽的绝对边界（避免漂移）
+        // Wait until the slot's absolute boundary (avoids drift).
         target := blockStart.Add(slotDuration * time.Duration(s+1))
         r.waitUntil(ctx, target)
     }
@@ -195,8 +210,9 @@ func (r *Replayer) processBlock(ctx context.Context, num int64) (int64, int64, i
     blockFail := atomic.LoadInt64(&r.state.TotalBroadcastFail) - failBefore
     blockSkip := atomic.LoadInt64(&r.state.TotalSkipped) - skipBefore
 
-    // 广播试过 (blockFail > 0) 但全失败 (blockOk == 0) → 触发停服
-    // 跳过的（VoteWitness 等）不算在内，因为根本没尝试发出去
+    // If we attempted broadcasts (blockFail > 0) and all of them failed
+    // (blockOk == 0), trigger a shutdown. Skipped txs (VoteWitness etc.)
+    // are excluded because we never attempted to broadcast them.
     if ctx.Err() == nil && blockFail > 0 && blockOk == 0 {
         return blockOk, blockFail, blockSkip,
             fmt.Errorf("block %d: all %d broadcast attempts failed", num, blockFail)
@@ -204,7 +220,8 @@ func (r *Replayer) processBlock(ctx context.Context, num int64) (int64, int64, i
     return blockOk, blockFail, blockSkip, nil
 }
 
-// processTx 处理单笔交易：先过滤，过则广播。
+// processTx handles a single transaction: filter first; if it passes
+// the filter, broadcast it.
 func (r *Replayer) processTx(ctx context.Context, blockNum int64, tx json.RawMessage) {
     reason, peek := shouldSkip(tx, r.skipTypes)
     if reason != "" {
@@ -225,7 +242,8 @@ func (r *Replayer) processTx(ctx context.Context, blockNum int64, tx json.RawMes
     }
 }
 
-// waitUntil 阻塞直到 deadline 或 ctx 取消；已过时刻立刻返回。
+// waitUntil blocks until `deadline` or until ctx is cancelled. Returns
+// immediately if the deadline has already passed.
 func (r *Replayer) waitUntil(ctx context.Context, deadline time.Time) {
     d := time.Until(deadline)
     if d <= 0 {

--- a/tools/replay/replayer.go
+++ b/tools/replay/replayer.go
@@ -68,6 +68,12 @@ func (r *Replayer) Run(ctx context.Context) error {
 		if err != nil {
 			// Don't advance LastMainnetBlock, but flush the cumulative
 			// counters so they're visible for post-mortem.
+			// Reset InProgressTxIndex to 0: an abort means "all broadcasts
+			// in this block failed". After the operator investigates and
+			// retries, we want to attempt the block from tx 0 again, not
+			// have the next start mistake InProgressTxIndex==n for
+			// "already completed" and skip the block entirely.
+			r.state.InProgressTxIndex = 0
 			if flushErr := r.flushState(); flushErr != nil {
 				log.Printf("save state failed: %v", flushErr)
 			}
@@ -76,7 +82,15 @@ func (r *Replayer) Run(ctx context.Context) error {
 				"check %s for failure details", r.state.LastMainnetBlock, n, r.cfg.FailLog)
 			return err
 		}
+		// One flush atomically clears the in-progress markers and advances
+		// LastMainnetBlock, so "block done" is a single atomic event. If a
+		// SIGKILL lands between the two writes, the next start enters
+		// processBlock with InProgressTxIndex already past the block's tx
+		// count and treats it as already completed — there's no grey state
+		// where txs were re-broadcast but LastMainnetBlock hasn't moved.
 		r.state.LastMainnetBlock = n
+		r.state.InProgressBlock = 0
+		r.state.InProgressTxIndex = 0
 		if err := r.flushState(); err != nil {
 			log.Printf("save state failed: %v", err)
 		}
@@ -107,6 +121,14 @@ func (r *Replayer) Run(ctx context.Context) error {
 func (r *Replayer) resolveStartBlock(_ context.Context) (int64, error) {
 	if r.cfg.Start > 0 {
 		return r.cfg.Start, nil
+	}
+	// SIGKILL / OOM mid-block: replay the in-progress block first,
+	// processBlock will resume from InProgressTxIndex without
+	// re-broadcasting txs that were already processed.
+	if r.state.InProgressBlock > 0 {
+		log.Printf("resume mid-block: block=%d tx_index=%d",
+			r.state.InProgressBlock, r.state.InProgressTxIndex)
+		return r.state.InProgressBlock, nil
 	}
 	if r.state.LastMainnetBlock > 0 {
 		return r.state.LastMainnetBlock + 1, nil
@@ -171,25 +193,38 @@ func (r *Replayer) processBlock(ctx context.Context, num int64) (int64, int64, i
 		return 0, 0, 0, nil
 	}
 
-	// Slot count ~= paceTotal in integer seconds. slotDuration = paceTotal/slots
-	// absorbs any fractional remainder so the final slot's deadline lands
-	// exactly at blockStart + paceTotal.
-	slots := int(paceTotal / time.Second)
-	if slots < 1 {
-		slots = 1
-	}
-	slotDuration := paceTotal / time.Duration(slots)
-	baseSize := n / slots
-	remainder := n % slots // the first `remainder` slots each get one extra tx
-
-	idx := 0
-	for s := 0; s < slots; s++ {
-		size := baseSize
-		if s < remainder {
-			size++
+	// Resume path: the previous run was killed partway through this block.
+	// Pick up from InProgressTxIndex. If the index already equals or exceeds
+	// the block's tx count, the previous run actually finished the block
+	// but didn't get a chance to advance LastMainnetBlock — treat it as
+	// completed (Run will advance LastMainnetBlock and clear in-progress).
+	startIdx := 0
+	resuming := r.state.InProgressBlock == num && r.state.InProgressTxIndex > 0
+	if resuming {
+		if r.state.InProgressTxIndex >= n {
+			log.Printf("block %d: state idx %d >= n=%d, treating as already completed",
+				num, r.state.InProgressTxIndex, n)
+			return 0, 0, 0, nil
 		}
-		// Send this slot's `size` txs back-to-back, no sleep between.
-		for k := 0; k < size; k++ {
+		startIdx = r.state.InProgressTxIndex
+		log.Printf("block %d: resuming from tx %d/%d", num, startIdx, n)
+	}
+
+	// Mark the block as in-progress; every processed tx below flushes the
+	// updated InProgressTxIndex.
+	r.state.InProgressBlock = num
+	r.state.InProgressTxIndex = startIdx
+	if err := r.flushState(); err != nil {
+		log.Printf("save state failed at block %d entry: %v", num, err)
+	}
+
+	// Resume path: skip the slot allocation and send the remaining txs
+	// back-to-back. The slot algorithm depends on blockStart wallclock
+	// time, which is no longer meaningful after a restart; trying to
+	// reconstruct it would only introduce drift. The next block returns
+	// to normal pacing automatically.
+	if resuming {
+		for idx := startIdx; idx < n; idx++ {
 			select {
 			case <-ctx.Done():
 				return atomic.LoadInt64(&r.state.TotalBroadcastOk) - okBefore,
@@ -199,11 +234,50 @@ func (r *Replayer) processBlock(ctx context.Context, num int64) (int64, int64, i
 			default:
 			}
 			r.processTx(ctx, num, blk.Transactions[idx])
-			idx++
+			r.state.InProgressTxIndex = idx + 1
+			if err := r.flushState(); err != nil {
+				log.Printf("save state failed at block %d tx %d: %v", num, idx, err)
+			}
 		}
-		// Wait until the slot's absolute boundary (avoids drift).
-		target := blockStart.Add(slotDuration * time.Duration(s+1))
-		r.waitUntil(ctx, target)
+	} else {
+		// Slot count ~= paceTotal in integer seconds. slotDuration = paceTotal/slots
+		// absorbs any fractional remainder so the final slot's deadline lands
+		// exactly at blockStart + paceTotal.
+		slots := int(paceTotal / time.Second)
+		if slots < 1 {
+			slots = 1
+		}
+		slotDuration := paceTotal / time.Duration(slots)
+		baseSize := n / slots
+		remainder := n % slots // the first `remainder` slots each get one extra tx
+
+		idx := 0
+		for s := 0; s < slots; s++ {
+			size := baseSize
+			if s < remainder {
+				size++
+			}
+			// Send this slot's `size` txs back-to-back, no sleep between.
+			for k := 0; k < size; k++ {
+				select {
+				case <-ctx.Done():
+					return atomic.LoadInt64(&r.state.TotalBroadcastOk) - okBefore,
+						atomic.LoadInt64(&r.state.TotalBroadcastFail) - failBefore,
+						atomic.LoadInt64(&r.state.TotalSkipped) - skipBefore,
+						nil
+				default:
+				}
+				r.processTx(ctx, num, blk.Transactions[idx])
+				idx++
+				r.state.InProgressTxIndex = idx
+				if err := r.flushState(); err != nil {
+					log.Printf("save state failed at block %d tx %d: %v", num, idx, err)
+				}
+			}
+			// Wait until the slot's absolute boundary (avoids drift).
+			target := blockStart.Add(slotDuration * time.Duration(s+1))
+			r.waitUntil(ctx, target)
+		}
 	}
 
 	blockOk := atomic.LoadInt64(&r.state.TotalBroadcastOk) - okBefore

--- a/tools/replay/replayer.go
+++ b/tools/replay/replayer.go
@@ -1,27 +1,27 @@
 package main
 
 import (
-    "context"
-    "encoding/json"
-    "errors"
-    "fmt"
-    "log"
-    "sync/atomic"
-    "time"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log"
+	"sync/atomic"
+	"time"
 )
 
 const (
-    // mainnetBlockSec is the mainnet block interval. Each mainnet block
-    // represents 3 seconds of mainnet time.
-    mainnetBlockSec = 3
+	// mainnetBlockSec is the mainnet block interval. Each mainnet block
+	// represents 3 seconds of mainnet time.
+	mainnetBlockSec = 3
 
-    // tpsMultiplierDefault: default private TPS is ~1/3 of mainnet TPS.
-    // This corresponds to a 9-second pace (one mainnet block spread over
-    // 9 s of private chain time) and matches the 3 SR private vs 27 SR
-    // mainnet topology (each private SR carries ~9x the mainnet density).
-    // 0.333 is preferred over 1.0/3.0 for a cleaner --help output;
-    // 9.009 s vs 9 s makes no practical difference.
-    tpsMultiplierDefault = 0.333
+	// tpsMultiplierDefault: default private TPS is ~1/3 of mainnet TPS.
+	// This corresponds to a 9-second pace (one mainnet block spread over
+	// 9 s of private chain time) and matches the 3 SR private vs 27 SR
+	// mainnet topology (each private SR carries ~9x the mainnet density).
+	// 0.333 is preferred over 1.0/3.0 for a cleaner --help output;
+	// 9.009 s vs 9 s makes no practical difference.
+	tpsMultiplierDefault = 0.333
 )
 
 // Replayer is the state machine driving the main replay loop:
@@ -30,13 +30,13 @@ const (
 //   - failed / skipped txs go to JSONL logs
 //   - Ctrl+C triggers a graceful exit with state flushed for resume
 type Replayer struct {
-    cfg       Config
-    trongrid  *TronGridClient
-    private   *PrivateNodeClient
-    state     ReplayState
-    skipTypes map[string]struct{}
-    failLog   *jsonlLogger
-    skipLog   *jsonlLogger
+	cfg       Config
+	trongrid  *TronGridClient
+	private   *PrivateNodeClient
+	state     ReplayState
+	skipTypes map[string]struct{}
+	failLog   *jsonlLogger
+	skipLog   *jsonlLogger
 }
 
 // defaultEndOffset is how many blocks to advance when --end is not set.
@@ -46,51 +46,51 @@ type Replayer struct {
 const defaultEndOffset = 10
 
 func (r *Replayer) Run(ctx context.Context) error {
-    start, err := r.resolveStartBlock(ctx)
-    if err != nil {
-        return fmt.Errorf("resolve start block: %w", err)
-    }
-    end := r.cfg.End
-    if end <= 0 {
-        end = start + defaultEndOffset
-        log.Printf("--end not set, defaulting to start + %d = %d", defaultEndOffset, end)
-    }
-    log.Printf("Replay range: [%d, %d], skip types: %v", start, end, keysOf(r.skipTypes))
+	start, err := r.resolveStartBlock(ctx)
+	if err != nil {
+		return fmt.Errorf("resolve start block: %w", err)
+	}
+	end := r.cfg.End
+	if end <= 0 {
+		end = start + defaultEndOffset
+		log.Printf("--end not set, defaulting to start + %d = %d", defaultEndOffset, end)
+	}
+	log.Printf("Replay range: [%d, %d], skip types: %v", start, end, keysOf(r.skipTypes))
 
-    for n := start; n <= end; n++ {
-        select {
-        case <-ctx.Done():
-            log.Printf("ctx cancelled, exit at block %d", n)
-            return r.flushState()
-        default:
-        }
-        blockOk, blockFail, blockSkip, err := r.processBlock(ctx, n)
-        if err != nil {
-            // Don't advance LastMainnetBlock, but flush the cumulative
-            // counters so they're visible for post-mortem.
-            if flushErr := r.flushState(); flushErr != nil {
-                log.Printf("save state failed: %v", flushErr)
-            }
-            log.Printf("ABORTING at block %d: %v", n, err)
-            log.Printf("state preserved at last_mainnet_block=%d (not advanced to %d); "+
-                "check %s for failure details", r.state.LastMainnetBlock, n, r.cfg.FailLog)
-            return err
-        }
-        r.state.LastMainnetBlock = n
-        if err := r.flushState(); err != nil {
-            log.Printf("save state failed: %v", err)
-        }
-        log.Printf("block %d done | block: ok=%d fail=%d skip=%d | cum: ok=%d fail=%d skip=%d",
-            n, blockOk, blockFail, blockSkip,
-            r.state.TotalBroadcastOk, r.state.TotalBroadcastFail, r.state.TotalSkipped)
-    }
-    if err := r.flushState(); err != nil {
-        return err
-    }
-    log.Printf("DONE | last=%d fetched=%d ok=%d fail=%d skip=%d",
-        r.state.LastMainnetBlock, r.state.TotalFetched,
-        r.state.TotalBroadcastOk, r.state.TotalBroadcastFail, r.state.TotalSkipped)
-    return nil
+	for n := start; n <= end; n++ {
+		select {
+		case <-ctx.Done():
+			log.Printf("ctx cancelled, exit at block %d", n)
+			return r.flushState()
+		default:
+		}
+		blockOk, blockFail, blockSkip, err := r.processBlock(ctx, n)
+		if err != nil {
+			// Don't advance LastMainnetBlock, but flush the cumulative
+			// counters so they're visible for post-mortem.
+			if flushErr := r.flushState(); flushErr != nil {
+				log.Printf("save state failed: %v", flushErr)
+			}
+			log.Printf("ABORTING at block %d: %v", n, err)
+			log.Printf("state preserved at last_mainnet_block=%d (not advanced to %d); "+
+				"check %s for failure details", r.state.LastMainnetBlock, n, r.cfg.FailLog)
+			return err
+		}
+		r.state.LastMainnetBlock = n
+		if err := r.flushState(); err != nil {
+			log.Printf("save state failed: %v", err)
+		}
+		log.Printf("block %d done | block: ok=%d fail=%d skip=%d | cum: ok=%d fail=%d skip=%d",
+			n, blockOk, blockFail, blockSkip,
+			r.state.TotalBroadcastOk, r.state.TotalBroadcastFail, r.state.TotalSkipped)
+	}
+	if err := r.flushState(); err != nil {
+		return err
+	}
+	log.Printf("DONE | last=%d fetched=%d ok=%d fail=%d skip=%d",
+		r.state.LastMainnetBlock, r.state.TotalFetched,
+		r.state.TotalBroadcastOk, r.state.TotalBroadcastFail, r.state.TotalSkipped)
+	return nil
 }
 
 // resolveStartBlock decides which **mainnet** block to start pulling from.
@@ -105,15 +105,15 @@ func (r *Replayer) Run(ctx context.Context) error {
 // run the user MUST pass --start explicitly (typically the snapshot's
 // last mainnet block + 1).
 func (r *Replayer) resolveStartBlock(_ context.Context) (int64, error) {
-    if r.cfg.Start > 0 {
-        return r.cfg.Start, nil
-    }
-    if r.state.LastMainnetBlock > 0 {
-        return r.state.LastMainnetBlock + 1, nil
-    }
-    return 0, errors.New(
-        "no start block: pass --start <mainnet_block_after_snapshot> on first run " +
-            "(or run with an existing state file from a previous run)")
+	if r.cfg.Start > 0 {
+		return r.cfg.Start, nil
+	}
+	if r.state.LastMainnetBlock > 0 {
+		return r.state.LastMainnetBlock + 1, nil
+	}
+	return 0, errors.New(
+		"no start block: pass --start <mainnet_block_after_snapshot> on first run " +
+			"(or run with an existing state file from a previous run)")
 }
 
 // processBlock handles a single mainnet block: fetch → split into per-second
@@ -122,8 +122,8 @@ func (r *Replayer) resolveStartBlock(_ context.Context) (int64, error) {
 // Pacing algorithm:
 //   - paceTotal = mainnetBlockSec / TpsMultiplier
 //     e.g. multiplier=1   → pace=3s
-//          multiplier=0.5 → pace=6s
-//          multiplier=1/3 → pace=9s
+//     multiplier=0.5 → pace=6s
+//     multiplier=1/3 → pace=9s
 //   - slots = max(1, floor(paceTotal / 1s)), ~1 second per slot
 //     e.g. pace=3s → 3 slots, pace=9s → 9 slots, pace=1.5s → 1 slot
 //   - n txs are spread across slots as evenly as possible: the first
@@ -142,117 +142,117 @@ func (r *Replayer) resolveStartBlock(_ context.Context) (int64, error) {
 // stop the service to avoid blindly advancing state while the private
 // chain is in a bad state.
 func (r *Replayer) processBlock(ctx context.Context, num int64) (int64, int64, int64, error) {
-    blockStart := time.Now()
+	blockStart := time.Now()
 
-    okBefore := atomic.LoadInt64(&r.state.TotalBroadcastOk)
-    failBefore := atomic.LoadInt64(&r.state.TotalBroadcastFail)
-    skipBefore := atomic.LoadInt64(&r.state.TotalSkipped)
+	okBefore := atomic.LoadInt64(&r.state.TotalBroadcastOk)
+	failBefore := atomic.LoadInt64(&r.state.TotalBroadcastFail)
+	skipBefore := atomic.LoadInt64(&r.state.TotalSkipped)
 
-    multiplier := r.cfg.TpsMultiplier
-    if multiplier <= 0 {
-        multiplier = tpsMultiplierDefault
-    }
-    paceTotal := time.Duration(float64(mainnetBlockSec*time.Second) / multiplier)
+	multiplier := r.cfg.TpsMultiplier
+	if multiplier <= 0 {
+		multiplier = tpsMultiplierDefault
+	}
+	paceTotal := time.Duration(float64(mainnetBlockSec*time.Second) / multiplier)
 
-    blk, err := r.trongrid.getBlock(ctx, num)
-    if err != nil {
-        log.Printf("block %d fetch failed: %v", num, err)
-        r.waitUntil(ctx, blockStart.Add(paceTotal))
-        return 0, 0, 0, nil // fetch failure is a TronGrid-side issue; not "all-fail", continue
-    }
-    if blk == nil {
-        log.Printf("block %d not found", num)
-        return 0, 0, 0, nil
-    }
-    n := len(blk.Transactions)
-    atomic.AddInt64(&r.state.TotalFetched, int64(n))
+	blk, err := r.trongrid.getBlock(ctx, num)
+	if err != nil {
+		log.Printf("block %d fetch failed: %v", num, err)
+		r.waitUntil(ctx, blockStart.Add(paceTotal))
+		return 0, 0, 0, nil // fetch failure is a TronGrid-side issue; not "all-fail", continue
+	}
+	if blk == nil {
+		log.Printf("block %d not found", num)
+		return 0, 0, 0, nil
+	}
+	n := len(blk.Transactions)
+	atomic.AddInt64(&r.state.TotalFetched, int64(n))
 
-    if n == 0 {
-        return 0, 0, 0, nil
-    }
+	if n == 0 {
+		return 0, 0, 0, nil
+	}
 
-    // Slot count ~= paceTotal in integer seconds. slotDuration = paceTotal/slots
-    // absorbs any fractional remainder so the final slot's deadline lands
-    // exactly at blockStart + paceTotal.
-    slots := int(paceTotal / time.Second)
-    if slots < 1 {
-        slots = 1
-    }
-    slotDuration := paceTotal / time.Duration(slots)
-    baseSize := n / slots
-    remainder := n % slots // the first `remainder` slots each get one extra tx
+	// Slot count ~= paceTotal in integer seconds. slotDuration = paceTotal/slots
+	// absorbs any fractional remainder so the final slot's deadline lands
+	// exactly at blockStart + paceTotal.
+	slots := int(paceTotal / time.Second)
+	if slots < 1 {
+		slots = 1
+	}
+	slotDuration := paceTotal / time.Duration(slots)
+	baseSize := n / slots
+	remainder := n % slots // the first `remainder` slots each get one extra tx
 
-    idx := 0
-    for s := 0; s < slots; s++ {
-        size := baseSize
-        if s < remainder {
-            size++
-        }
-        // Send this slot's `size` txs back-to-back, no sleep between.
-        for k := 0; k < size; k++ {
-            select {
-            case <-ctx.Done():
-                return atomic.LoadInt64(&r.state.TotalBroadcastOk) - okBefore,
-                    atomic.LoadInt64(&r.state.TotalBroadcastFail) - failBefore,
-                    atomic.LoadInt64(&r.state.TotalSkipped) - skipBefore,
-                    nil
-            default:
-            }
-            r.processTx(ctx, num, blk.Transactions[idx])
-            idx++
-        }
-        // Wait until the slot's absolute boundary (avoids drift).
-        target := blockStart.Add(slotDuration * time.Duration(s+1))
-        r.waitUntil(ctx, target)
-    }
+	idx := 0
+	for s := 0; s < slots; s++ {
+		size := baseSize
+		if s < remainder {
+			size++
+		}
+		// Send this slot's `size` txs back-to-back, no sleep between.
+		for k := 0; k < size; k++ {
+			select {
+			case <-ctx.Done():
+				return atomic.LoadInt64(&r.state.TotalBroadcastOk) - okBefore,
+					atomic.LoadInt64(&r.state.TotalBroadcastFail) - failBefore,
+					atomic.LoadInt64(&r.state.TotalSkipped) - skipBefore,
+					nil
+			default:
+			}
+			r.processTx(ctx, num, blk.Transactions[idx])
+			idx++
+		}
+		// Wait until the slot's absolute boundary (avoids drift).
+		target := blockStart.Add(slotDuration * time.Duration(s+1))
+		r.waitUntil(ctx, target)
+	}
 
-    blockOk := atomic.LoadInt64(&r.state.TotalBroadcastOk) - okBefore
-    blockFail := atomic.LoadInt64(&r.state.TotalBroadcastFail) - failBefore
-    blockSkip := atomic.LoadInt64(&r.state.TotalSkipped) - skipBefore
+	blockOk := atomic.LoadInt64(&r.state.TotalBroadcastOk) - okBefore
+	blockFail := atomic.LoadInt64(&r.state.TotalBroadcastFail) - failBefore
+	blockSkip := atomic.LoadInt64(&r.state.TotalSkipped) - skipBefore
 
-    // If we attempted broadcasts (blockFail > 0) and all of them failed
-    // (blockOk == 0), trigger a shutdown. Skipped txs (VoteWitness etc.)
-    // are excluded because we never attempted to broadcast them.
-    if ctx.Err() == nil && blockFail > 0 && blockOk == 0 {
-        return blockOk, blockFail, blockSkip,
-            fmt.Errorf("block %d: all %d broadcast attempts failed", num, blockFail)
-    }
-    return blockOk, blockFail, blockSkip, nil
+	// If we attempted broadcasts (blockFail > 0) and all of them failed
+	// (blockOk == 0), trigger a shutdown. Skipped txs (VoteWitness etc.)
+	// are excluded because we never attempted to broadcast them.
+	if ctx.Err() == nil && blockFail > 0 && blockOk == 0 {
+		return blockOk, blockFail, blockSkip,
+			fmt.Errorf("block %d: all %d broadcast attempts failed", num, blockFail)
+	}
+	return blockOk, blockFail, blockSkip, nil
 }
 
 // processTx handles a single transaction: filter first; if it passes
 // the filter, broadcast it.
 func (r *Replayer) processTx(ctx context.Context, blockNum int64, tx json.RawMessage) {
-    reason, peek := shouldSkip(tx, r.skipTypes)
-    if reason != "" {
-        atomic.AddInt64(&r.state.TotalSkipped, 1)
-        r.skipLog.writeRecord(map[string]any{
-            "block": blockNum, "txID": peek.TxID, "reason": reason,
-        })
-        return
-    }
-    ok, msg := r.private.broadcast(ctx, tx)
-    if ok {
-        atomic.AddInt64(&r.state.TotalBroadcastOk, 1)
-    } else {
-        atomic.AddInt64(&r.state.TotalBroadcastFail, 1)
-        r.failLog.writeRecord(map[string]any{
-            "block": blockNum, "txID": peek.TxID, "reason": msg,
-        })
-    }
+	reason, peek := shouldSkip(tx, r.skipTypes)
+	if reason != "" {
+		atomic.AddInt64(&r.state.TotalSkipped, 1)
+		r.skipLog.writeRecord(map[string]any{
+			"block": blockNum, "txID": peek.TxID, "reason": reason,
+		})
+		return
+	}
+	ok, msg := r.private.broadcast(ctx, tx)
+	if ok {
+		atomic.AddInt64(&r.state.TotalBroadcastOk, 1)
+	} else {
+		atomic.AddInt64(&r.state.TotalBroadcastFail, 1)
+		r.failLog.writeRecord(map[string]any{
+			"block": blockNum, "txID": peek.TxID, "reason": msg,
+		})
+	}
 }
 
 // waitUntil blocks until `deadline` or until ctx is cancelled. Returns
 // immediately if the deadline has already passed.
 func (r *Replayer) waitUntil(ctx context.Context, deadline time.Time) {
-    d := time.Until(deadline)
-    if d <= 0 {
-        return
-    }
-    select {
-    case <-ctx.Done():
-    case <-time.After(d):
-    }
+	d := time.Until(deadline)
+	if d <= 0 {
+		return
+	}
+	select {
+	case <-ctx.Done():
+	case <-time.After(d):
+	}
 }
 
 func (r *Replayer) flushState() error { return r.state.save(r.cfg.StateFile) }

--- a/tools/replay/state.go
+++ b/tools/replay/state.go
@@ -5,11 +5,13 @@ import (
 	"os"
 )
 
-// ReplayState 记录我们从主网拉到了哪一块。
+// ReplayState records which mainnet block we've pulled up to.
 //
-// 重要：LastMainnetBlock 是**主网块号**，不是私链最高块号。
-// 私链自己也在出块，私链 head 是私链链上的计数，与主网块号脱钩；
-// 唯一可靠的"下次从哪抓"信息只有这里。
+// IMPORTANT: LastMainnetBlock is the **mainnet block number**, not the
+// private chain head. The private chain produces its own blocks; its
+// head is the private chain's own counter and quickly decouples from
+// the mainnet block number. The only reliable "where to resume from"
+// information lives in this file.
 type ReplayState struct {
 	LastMainnetBlock   int64 `json:"last_mainnet_block"`
 	TotalFetched       int64 `json:"total_fetched"`
@@ -18,7 +20,8 @@ type ReplayState struct {
 	TotalSkipped       int64 `json:"total_skipped"`
 }
 
-// loadState 读取 state 文件；不存在 / 解析失败均返回零值。
+// loadState reads the state file; missing or unparseable files return
+// a zero-valued ReplayState.
 func loadState(path string) ReplayState {
 	var s ReplayState
 	data, err := os.ReadFile(path)

--- a/tools/replay/state.go
+++ b/tools/replay/state.go
@@ -12,8 +12,24 @@ import (
 // head is the private chain's own counter and quickly decouples from
 // the mainnet block number. The only reliable "where to resume from"
 // information lives in this file.
+//
+// Per-tx checkpoint (InProgressBlock + InProgressTxIndex):
+// covers SIGKILL / OOM / power-loss scenarios where graceful shutdown
+// can't run. The tx index is flushed after every processed tx; on
+// restart, a non-zero InProgressBlock tells us to resume from
+// InProgressTxIndex within that block instead of re-broadcasting the
+// whole block (which would otherwise flood replay-failures.jsonl
+// with DUP_TRANSACTION_ERROR entries).
+//
+// When a block completes successfully, Run flushes a single atomic
+// transition that advances LastMainnetBlock and clears the in-progress
+// fields. If that final flush is itself killed, the next start re-enters
+// processBlock with InProgressTxIndex >= the block's tx count, which is
+// recognized and treated as already-completed.
 type ReplayState struct {
 	LastMainnetBlock   int64 `json:"last_mainnet_block"`
+	InProgressBlock    int64 `json:"in_progress_block,omitempty"`
+	InProgressTxIndex  int   `json:"in_progress_tx_index,omitempty"`
 	TotalFetched       int64 `json:"total_fetched"`
 	TotalBroadcastOk   int64 `json:"total_broadcast_ok"`
 	TotalBroadcastFail int64 `json:"total_broadcast_fail"`

--- a/tools/replay/state.go
+++ b/tools/replay/state.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+)
+
+// ReplayState 记录我们从主网拉到了哪一块。
+//
+// 重要：LastMainnetBlock 是**主网块号**，不是私链最高块号。
+// 私链自己也在出块，私链 head 是私链链上的计数，与主网块号脱钩；
+// 唯一可靠的"下次从哪抓"信息只有这里。
+type ReplayState struct {
+	LastMainnetBlock   int64 `json:"last_mainnet_block"`
+	TotalFetched       int64 `json:"total_fetched"`
+	TotalBroadcastOk   int64 `json:"total_broadcast_ok"`
+	TotalBroadcastFail int64 `json:"total_broadcast_fail"`
+	TotalSkipped       int64 `json:"total_skipped"`
+}
+
+// loadState 读取 state 文件；不存在 / 解析失败均返回零值。
+func loadState(path string) ReplayState {
+	var s ReplayState
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return s
+	}
+	_ = json.Unmarshal(data, &s)
+	return s
+}
+
+func (s *ReplayState) save(path string) error {
+	data, err := json.MarshalIndent(s, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, data, 0o644)
+}

--- a/tools/replay/trongrid.go
+++ b/tools/replay/trongrid.go
@@ -14,13 +14,14 @@ import (
 
 const (
 	trongridDefaultURL = "https://api.trongrid.io"
-	trongridDefaultQPS = 1 // 每秒拉一个区块够用（主网 3s 一块，3x 速度重放）
+	trongridDefaultQPS = 1 // 1 block/sec is plenty (mainnet produces a block every 3s; this is 3x replay)
 	trongridTimeoutSec = 10
 	retryMax           = 3
 	retryBackoffSec    = 2
 )
 
-// Block 仅解 number + 保留 transactions 原始 json，避免无谓的反序列化。
+// Block only decodes the block number and keeps the transactions as raw
+// JSON, avoiding an unnecessary deep unmarshal of every transaction.
 type Block struct {
 	BlockHeader struct {
 		RawData struct {
@@ -30,12 +31,12 @@ type Block struct {
 	Transactions []json.RawMessage `json:"transactions"`
 }
 
-// TronGridClient 封装对 TronGrid HTTP API 的访问，含内置速率限制。
+// TronGridClient wraps the TronGrid HTTP API with a built-in rate limiter.
 type TronGridClient struct {
 	baseURL string
 	apiKey  string
 	client  *http.Client
-	ticker  *time.Ticker // 速率限制：每 1/qps 秒放一个请求过去
+	ticker  *time.Ticker // rate limiter: lets one request through every 1/qps seconds
 }
 
 func newTronGridClient(baseURL, apiKey string, qps int) *TronGridClient {
@@ -51,7 +52,8 @@ func newTronGridClient(baseURL, apiKey string, qps int) *TronGridClient {
 	}
 }
 
-// post 是底层请求方法，统一过速率门 + 注入 API key。
+// post is the underlying request method; all calls go through the rate
+// limiter and the API key is injected here.
 func (c *TronGridClient) post(ctx context.Context, path string, body any) ([]byte, error) {
 	<-c.ticker.C
 	buf, err := json.Marshal(body)
@@ -78,7 +80,8 @@ func (c *TronGridClient) post(ctx context.Context, path string, body any) ([]byt
 	return io.ReadAll(resp.Body)
 }
 
-// getBlock 拉取指定高度区块，含重试 + 退避。返回 nil 表示区块不存在。
+// getBlock fetches the block at the given height with retry + backoff.
+// A nil return value (without error) means the block does not exist.
 func (c *TronGridClient) getBlock(ctx context.Context, num int64) (*Block, error) {
 	var lastErr error
 	for attempt := 0; attempt < retryMax; attempt++ {
@@ -89,7 +92,7 @@ func (c *TronGridClient) getBlock(ctx context.Context, num int64) (*Block, error
 			if jerr := json.Unmarshal(body, &blk); jerr != nil {
 				return nil, jerr
 			}
-			// 空响应 / 区块不存在
+			// empty response / block does not exist
 			if blk.BlockHeader.RawData.Number == 0 && len(blk.Transactions) == 0 {
 				return nil, nil
 			}
@@ -108,7 +111,7 @@ func (c *TronGridClient) getBlock(ctx context.Context, num int64) (*Block, error
 	return nil, lastErr
 }
 
-// getNowBlockNum 取主网当前最高块号。
+// getNowBlockNum returns the current mainnet head block number.
 func (c *TronGridClient) getNowBlockNum(ctx context.Context) (int64, error) {
 	body, err := c.post(ctx, "/wallet/getnowblock", map[string]any{})
 	if err != nil {

--- a/tools/replay/trongrid.go
+++ b/tools/replay/trongrid.go
@@ -1,0 +1,122 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"strings"
+	"time"
+)
+
+const (
+	trongridDefaultURL = "https://api.trongrid.io"
+	trongridDefaultQPS = 1 // 每秒拉一个区块够用（主网 3s 一块，3x 速度重放）
+	trongridTimeoutSec = 10
+	retryMax           = 3
+	retryBackoffSec    = 2
+)
+
+// Block 仅解 number + 保留 transactions 原始 json，避免无谓的反序列化。
+type Block struct {
+	BlockHeader struct {
+		RawData struct {
+			Number int64 `json:"number"`
+		} `json:"raw_data"`
+	} `json:"block_header"`
+	Transactions []json.RawMessage `json:"transactions"`
+}
+
+// TronGridClient 封装对 TronGrid HTTP API 的访问，含内置速率限制。
+type TronGridClient struct {
+	baseURL string
+	apiKey  string
+	client  *http.Client
+	ticker  *time.Ticker // 速率限制：每 1/qps 秒放一个请求过去
+}
+
+func newTronGridClient(baseURL, apiKey string, qps int) *TronGridClient {
+	if qps <= 0 {
+		qps = trongridDefaultQPS
+	}
+	interval := time.Second / time.Duration(qps)
+	return &TronGridClient{
+		baseURL: strings.TrimRight(baseURL, "/"),
+		apiKey:  apiKey,
+		client:  &http.Client{Timeout: trongridTimeoutSec * time.Second},
+		ticker:  time.NewTicker(interval),
+	}
+}
+
+// post 是底层请求方法，统一过速率门 + 注入 API key。
+func (c *TronGridClient) post(ctx context.Context, path string, body any) ([]byte, error) {
+	<-c.ticker.C
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	req, err := http.NewRequestWithContext(ctx, "POST",
+		c.baseURL+path, bytes.NewReader(buf))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if c.apiKey != "" {
+		req.Header.Set("TRON-PRO-API-KEY", c.apiKey)
+	}
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 400 {
+		return nil, fmt.Errorf("http %d", resp.StatusCode)
+	}
+	return io.ReadAll(resp.Body)
+}
+
+// getBlock 拉取指定高度区块，含重试 + 退避。返回 nil 表示区块不存在。
+func (c *TronGridClient) getBlock(ctx context.Context, num int64) (*Block, error) {
+	var lastErr error
+	for attempt := 0; attempt < retryMax; attempt++ {
+		body, err := c.post(ctx, "/wallet/getblockbynum",
+			map[string]int64{"num": num})
+		if err == nil {
+			var blk Block
+			if jerr := json.Unmarshal(body, &blk); jerr != nil {
+				return nil, jerr
+			}
+			// 空响应 / 区块不存在
+			if blk.BlockHeader.RawData.Number == 0 && len(blk.Transactions) == 0 {
+				return nil, nil
+			}
+			return &blk, nil
+		}
+		lastErr = err
+		log.Printf("get_block(%d) attempt %d failed: %v", num, attempt+1, err)
+		if attempt < retryMax-1 {
+			select {
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			case <-time.After(time.Duration(retryBackoffSec*(attempt+1)) * time.Second):
+			}
+		}
+	}
+	return nil, lastErr
+}
+
+// getNowBlockNum 取主网当前最高块号。
+func (c *TronGridClient) getNowBlockNum(ctx context.Context) (int64, error) {
+	body, err := c.post(ctx, "/wallet/getnowblock", map[string]any{})
+	if err != nil {
+		return 0, err
+	}
+	var blk Block
+	if err := json.Unmarshal(body, &blk); err != nil {
+		return 0, err
+	}
+	return blk.BlockHeader.RawData.Number, nil
+}

--- a/tools/replay/trongrid.go
+++ b/tools/replay/trongrid.go
@@ -110,16 +110,3 @@ func (c *TronGridClient) getBlock(ctx context.Context, num int64) (*Block, error
 	}
 	return nil, lastErr
 }
-
-// getNowBlockNum returns the current mainnet head block number.
-func (c *TronGridClient) getNowBlockNum(ctx context.Context) (int64, error) {
-	body, err := c.post(ctx, "/wallet/getnowblock", map[string]any{})
-	if err != nil {
-		return 0, err
-	}
-	var blk Block
-	if err := json.Unmarshal(body, &blk); err != nil {
-		return 0, err
-	}
-	return blk.BlockHeader.RawData.Number, nil
-}


### PR DESCRIPTION
Add tools/replay/, a pure-Go HTTP client that streams mainnet historical transactions from TronGrid to a private chain. Serves as an alternative to tron-docker/stress_test's embedded BroadcastNode approach for testing and stress harness workflows.

Key differences from stress_test:
- External HTTP client (no java-tron source dependency)
- Single ~8MB Go binary (vs jar + JDK)
- Streaming (no intermediate CSV)
- state.json resume on block boundary
- Pre-filter Vote/Witness/Withdraw txs that always fail on private chain (default-on, --include-all opts out)
- TPS multiplier (vs fixed tpsLimit) — auto-derived from private-vs-mainnet SR ratio

Build:
  make build-replay     # bin/replay
  make install-replay   # $(GOBIN)/replay

Releases ship replay alongside trond as a separate tarball.