### PR TITLE
design: trond build pipeline (containerized Gradle for dev inner loop)

### DIFF
--- a/specs/002-trond-build-pipeline/plan.md
+++ b/specs/002-trond-build-pipeline/plan.md
@@ -69,8 +69,10 @@ the container; trond is the conductor.
                   └─► -v <source>:/src:ro
                        -v <cache>/gradle:/root/.gradle
                        -v <cache>/out:/out:rw
-                       -e GRADLE_OPTS, JAVA_OPTS, build.env.*
-                       bash -c "./gradlew <task> && cp build/libs/*.jar /out/"
+                       -e GRADLE_OPTS, JAVA_OPTS, ORG_GRADLE_PROJECT_* (allowlist only)
+                       --workdir /src
+                       ./gradlew <task> <args...>
+                       (NO `bash -c`; argv-form only — FR-022)
 
                   internal/build/cache.go
                   (content-addressed cache, manifest dir, prune logic,
@@ -112,28 +114,53 @@ opaque blobs.
 
 ```go
 type CacheKey struct {
-    SourcePath   string // canonicalized abs path (symlinks resolved)
-    GitRevision  string // resolved sha
-    PatchHash    string // sha256 of (git diff || git status --porcelain -uall) if dirty
-    JDKVersion   string
-    ArtifactKind string // "jar" | "image"
-    GradleTask   string // "shadowJar" | "dockerBuild" | custom
+    SourcePath          string // canonicalized abs path (symlinks resolved)
+    GitRevision         string // resolved sha
+    PatchHash           string // sha256(git diff || git status --porcelain -uall) if dirty
+    BuilderImageDigest  string // sha256:... of the JDK image actually used
+    JDKVersion          string
+    ArtifactKind        string // "jar" | "image"
+    GradleTask          string // "shadowJar" | "dockerBuild" | custom
+    GradleArgs          []string
 }
 
 func (k CacheKey) String() string {
+    bd := k.BuilderImageDigest[7:13] // strip "sha256:" then take 6 hex chars
+    base := fmt.Sprintf("%s-b%s", k.GitRevision, bd)
     if k.PatchHash != "" {
-        return fmt.Sprintf("%s+dirty-%s", k.GitRevision, k.PatchHash[:8])
+        return fmt.Sprintf("%s+dirty-%s", base, k.PatchHash[:8])
     }
-    return k.GitRevision
+    return base
 }
 ```
 
-**Critical**: PatchHash combines BOTH `git diff` AND `git status
---porcelain -uall`. A diff alone misses untracked files, which would
-silently cache-hit a stale artifact (the bug found in self-review, FR-002).
+**Critical**:
+- PatchHash combines BOTH `git diff` AND `git status --porcelain -uall`.
+  Diff alone misses untracked files (FR-002, regression bug found in
+  pass 1).
+- BuilderImageDigest is in the key (FR-002, found in pass 2). When a
+  trond release bumps the JDK pin, every cache entry is automatically
+  invalidated — no manual prune required.
+- GradleArgs participates (different `-Dflag` produces different bytes).
 
-Two different source paths producing the same sha hit the same cache (this
-is the intent — a build is determined by its inputs, not its location).
+Two different source paths producing the same sha hit the same cache
+(this is the intent — a build is determined by its inputs, not its
+location).
+
+### Artifact naming pattern on disk
+
+```
+~/.trond/builds/out/<git-sha>-b<digest6>[+dirty-<patchsha8>].jar
+                       ^^^^^^^   ^^^^^^^^
+                       6 hex     6 hex prefix of patch sha
+                       prefix    when working tree dirty
+                       of image
+                       sha256
+```
+
+Example: `8f4e2a-bd4e2a1+dirty-7f2a3b9c.jar` reads as
+"revision 8f4e2a, built by image digest starting d4e2a1, with dirty patch
+7f2a3b9c". Long enough for collision safety, short enough to grep.
 
 ### Concurrent build serialization (FR-015)
 
@@ -154,12 +181,18 @@ if hit := cacheLookup(key); hit != nil {
 
 ### SIGINT handling (FR-016)
 
+`signal.NotifyContext` is installed once at the `apply` (or `build`)
+entry point and threaded through every subprocess that runs after it —
+docker, git, ssh, scp. Each invocation uses `exec.CommandContext`, so
+cancellation propagates as SIGKILL to the child.
+
 ```go
 ctx, cancel := signal.NotifyContext(parent, os.Interrupt, syscall.SIGTERM)
 defer cancel()
 
+// build phase
 cmd := exec.CommandContext(ctx, "docker", "run", "--rm", "--name", containerName, ...)
-defer cleanup(containerName) // best-effort `docker kill` + `rm -rf out/<partial>`
+defer cleanup(containerName) // best-effort `docker kill` + `rm -f out/*.tmp`
 
 if err := cmd.Run(); err != nil {
     if errors.Is(ctx.Err(), context.Canceled) {
@@ -167,7 +200,47 @@ if err := cmd.Run(); err != nil {
     }
     return errResult("BUILD_FAILED", 1, err, suggestionsFromTail(cmd))
 }
+
+// transfer phase (SSH target) — same ctx, same cancellation semantics
+//   - scp writes to `<remote>.tmp`, rename only on clean exit
+//   - on ctx cancel: trond runs `ssh remote 'rm -f <remote>.tmp'` best-effort
 ```
+
+Writing output via a `.tmp` suffix and rename-on-success guarantees that
+a cancelled build/transfer leaves no half-written file pretending to be
+a finished artifact — neither locally nor on the SSH target.
+
+### Security boundary: subprocess invocation
+
+A user-controlled intent file (or a `--gradle-task` CLI flag) MUST NOT
+be able to inject shell metacharacters into the build pipeline. Two
+guardrails (FR-022):
+
+1. **Argv-only**. Every subprocess goes through `exec.Command(name,
+   args...)` with no intervening shell. No `bash -c`, no
+   `sh -c "..."`. The container's entrypoint stays `./gradlew`
+   directly.
+
+   ```go
+   // GOOD
+   cmd := exec.CommandContext(ctx, "docker", "run", "--rm",
+       "-v", srcMount, "-v", outMount, "--workdir", "/src",
+       imageRef,
+       "./gradlew", task, gradleArgs...)
+
+   // BAD — would have enabled $(...) and ; injection
+   cmd := exec.CommandContext(ctx, "bash", "-c",
+       fmt.Sprintf("docker run ... %s && cp ...", task))
+   ```
+
+2. **Token-regex validation at parse time**. `gradle_task` and each
+   `gradle_arg` MUST match `^[a-zA-Z0-9._:=/+-]+$`. Names like
+   `shadowJar`, `:dbfork:build`, `-Dorg.gradle.daemon=false`,
+   `--offline`, `-Pversion=1.2.3` all pass. Anything with whitespace,
+   semicolons, redirection, backticks, `$()`, or quotes is rejected as
+   `VALIDATION_ERROR` before docker is even invoked.
+
+The same gate guards `build.env` values (FR-019 allowlist).
 
 ### Intent integration
 
@@ -190,8 +263,13 @@ build:
   image_tag: dev:latest      # required if artifact=image
   builder: docker            # default; "host" available
   gradle_task: shadowJar     # default depends on artifact
-  env:                       # additive env passthrough (FR-019)
-    GRADLE_OPTS: "-Xmx2g"
+  gradle_args:               # extra gradle args (FR-001, FR-022)
+    - --no-daemon
+    - -Dorg.gradle.parallel=true
+  env:                       # allowlisted env only (FR-019)
+    GRADLE_OPTS: "-Xmx2g"    # GRADLE_OPTS|JAVA_OPTS|GRADLE_USER_HOME|MAVEN_OPTS|ORG_GRADLE_PROJECT_*
+  cache:
+    dirty_ttl: 7d            # FR-025; "never" allowed
 ```
 
 Note: `rebuild: always|on_change|never` is **removed** from the v1 draft.
@@ -273,31 +351,51 @@ existing `image:` path.
 **Deliverable**: `trond build --source <path> --artifact jar -o json` works
 end-to-end. No intent integration yet.
 
-- `cmd/build.go`: cobra command, flags, JSON output via `output.Result`.
+- `cmd/build.go`: cobra command, flags (`--gradle-task`, `--gradle-arg`,
+  `--builder-image-override`, etc.), JSON output via `output.Result`.
 - `internal/build/builder.go`: `Builder` interface, default impl, docker
-  and host paths inline.
-- `internal/build/cache.go`: manifest read/write, cache lookup, flock
-  serialization (FR-015).
+  and host paths inline. Argv-only subprocess invocation (FR-022).
+- `internal/build/cache.go`: manifest read/write, cache lookup that also
+  stats the artifact file (FR-020), flock serialization (FR-015),
+  builder-digest-aware key (FR-002).
 - `internal/build/source.go`: shell-out wrapper for `git rev-parse`,
   `status --porcelain -uall`, `diff`; patch hash combining both (FR-002).
-- `internal/build/validate.go`: JAR `Main-Class` check via `archive/zip`.
-- `internal/build/signal.go`: SIGINT handler (FR-016).
+- `internal/build/validate.go`: JAR `Main-Class` check via `archive/zip`,
+  argv token regex `^[a-zA-Z0-9._:=/+-]+$` for gradle task + args
+  (FR-022), env-key allowlist (FR-019).
+- `internal/build/signal.go`: SIGINT context propagation + cleanup
+  (FR-016).
+- `internal/build/audit.go`: emits the FR-023 build-event JSON into the
+  existing `internal/audit` log.
+- `internal/build/pins.go`: `go:embed builder_image_digests.json`
+  (FR-024), with `--builder-image-override` resolver. Override values
+  feed into the cache key.
 - `internal/schema/files/build.schema.json` + `schemas/output/build.schema.json`.
 - `internal/schema/embed.go`: bump SchemaVersion to 1.3.0; add entry to
   history comment.
 - `internal/schema/version_baseline.json`: regenerate via make target.
-- `builder_image_digests.json` at repo root, plus
-  `Makefile :: refresh-builder-pins` (FR-012).
+- `builder_image_digests.json` checked in at the repo root (also embedded
+  via go:embed); `Makefile :: refresh-builder-pins` regenerates it (FR-012).
 - Tests:
   - `cmd/build_test.go`: cobra wiring + JSON shape.
-  - `internal/build/builder_test.go`: unit with a fake `dockerRunner`.
+  - `internal/build/builder_test.go`: unit with a fake `dockerRunner`;
+    asserts argv form and the absence of any shell invocation.
   - `internal/build/cache_test.go`: cache hit / dirty key including
-    untracked files / prune / concurrent flock.
+    untracked files / cache miss when artifact deleted (FR-020) / cache
+    invalidation on builder-digest change / prune / concurrent flock.
   - `internal/build/source_test.go`: patch hash regression test for
     untracked file invalidation.
-  - `internal/build/signal_test.go`: SIGINT mid-build cleanup.
+  - `internal/build/signal_test.go`: SIGINT mid-build cleanup; asserts
+    `out/*.tmp` removed.
+  - `internal/build/validate_test.go`: token regex rejects `;`, ``` ` ```,
+    `$()`, whitespace, etc.; env-allowlist rejects `LD_PRELOAD`,
+    `PATH`, etc.
   - Golden test: a tiny synthetic source tree produces a deterministic
     manifest (excluding `duration_ms` and `created_at`).
+  - **Integration test (build-tag gated)**: `internal/build/integration_test.go`
+    (`//go:build integration`) runs a real `eclipse-temurin:8-jdk` against
+    a 10-line hello-world gradle project, asserts the produced JAR is
+    structurally valid. Runs in CI on the e2e job; skipped on `go test ./...`.
 
 ### Phase 2 — Intent integration (~2 days)
 
@@ -340,15 +438,24 @@ end-to-end. No intent integration yet.
 
 **Deliverable**: build locally, deploy over SSH.
 
-- `internal/target/ssh/scp.go`: add a `Sha256IfExists(remotePath)` probe,
-  a `PutFile(localPath, remotePath)` op with `-v` parsing for progress.
+- `internal/target/ssh/scp.go`: add a `Sha256IfExists(remotePath)` probe;
+  a `PutFile(ctx, localPath, remotePath)` op that:
+  - Writes to `<remotePath>.tmp` first.
+  - Pipes `-v` (or `-p` byte counts) through a parser that converts to
+    MCP `progress` notifications for transfers > 50 MB (FR-009).
+  - On ctx cancel: tries `ssh remote 'rm -f <remotePath>.tmp'`
+    best-effort, then returns `BUILD_CANCELLED` (FR-016 SSH branch).
+  - On success: atomic rename to `<remotePath>`.
 - `internal/target/ssh/preflight.go`: add `command -v scp` probe (FR-017).
 - `internal/apply/apply.go`: when target is SSH and artifact is JAR, after
   the build call `target.PutFile`. Skip if remote sha256 matches.
-- `internal/mcp`: emit progress notifications for transfers > 50 MB (FR-009).
 - `examples/dev-ssh.yaml`.
-- Tests: integration test with an SSH-target container (already used by
-  existing e2e suite). One test asserts the progress notification fires.
+- Tests:
+  - Integration test against an SSH-target container (already used by
+    existing e2e suite). Asserts the `.tmp`-then-rename pattern, the
+    progress notification firing for a synthesized large file, and the
+    `command -v scp` preflight check.
+  - SIGINT during transfer leaves no `<remotePath>.tmp` on the remote.
 
 ### Phase 5 — Build management commands & MCP (~1 day)
 
@@ -359,8 +466,10 @@ tools surfaced.
 - `internal/build/cache.go`: prune logic — LRU by `created_at`,
   cross-references `state.json::nodes[].build_revision` to refuse deletion
   of in-use builds (FR-018). Dirty-build entries (those with `+dirty-`
-  suffix) are pruned more aggressively (TTL 7 days default) since they're
-  inherently disposable.
+  suffix) are pruned more aggressively (configurable `build.cache.dirty_ttl`
+  / `--cache-dirty-ttl`, default 7 days, `never` accepted — FR-025).
+  During prune, manifest entries pointing at missing artifacts (e.g., user
+  manually deleted a JAR) are also removed (FR-020 cleanup branch).
 - MCP tools (`internal/mcp/tools_build.go`): expose `build`, `build_list`,
   `build_inspect`, `build_prune` with annotations per FR-013:
   - `build`: `idempotentHint=true`, `destructiveHint=false`
@@ -463,3 +572,30 @@ and Phase 4 (progress notifications, scp probe).
     passthrough) — all phases updated accordingly.
   - `pull_policy: never` made explicit for local-built docker images.
   - SSH progress notifications for transfers > 50 MB.
+- **2026-05-08 (self-review pass 2)**: Applied 12-item second review.
+  - **Security hardening**: dedicated "Security boundary" section; argv-
+    only subprocess invocation (no `bash -c`); FR-022 token regex on
+    gradle task + args; FR-019 narrows `build.env` to a fixed allowlist
+    (`GRADLE_OPTS|JAVA_OPTS|GRADLE_USER_HOME|MAVEN_OPTS|ORG_GRADLE_PROJECT_*`).
+  - **Cache correctness**: cache key now includes
+    `BuilderImageDigest` + `GradleArgs` (FR-002 pass 2). On-disk naming
+    `<sha>-b<digest6>[+dirty-<patchsha8>]`. Cache lookup also stats the
+    artifact (FR-020) so a manually-deleted JAR triggers a real rebuild.
+  - **Distribution**: `builder_image_digests.json` is now `go:embed`-ed
+    (FR-024); `--builder-image-override` is documented as escape hatch
+    only and participates in the cache key.
+  - **SIGINT extended to SSH** (FR-016): scp writes `.tmp` and renames;
+    cancellation tries best-effort remote cleanup.
+  - **Audit log shape**: FR-023 fixes a concrete event JSON for build
+    operations.
+  - **Source path resolution**: FR-021 distinguishes CLI (CWD) vs intent
+    (intent-file dir) relative-path resolution.
+  - **Preflight**: FR-017 builder-image probe is now offline-friendly
+    (warning on missing-and-offline, not hard fail).
+  - **New flags**: `--gradle-arg` repeatable (FR-001); cache dirty TTL
+    via `build.cache.dirty_ttl` or `--cache-dirty-ttl` (FR-025, default
+    7d, `never` accepted).
+  - **Integration test**: build-tag gated test runs real
+    `eclipse-temurin:8-jdk` against a hello-world gradle project.
+  - Phase / total estimate unchanged at ~9-10 days; pass 2 fixes are
+    additions to existing phases, not new phases.

--- a/specs/002-trond-build-pipeline/plan.md
+++ b/specs/002-trond-build-pipeline/plan.md
@@ -164,13 +164,41 @@ Example: `8f4e2a-bd4e2a1+dirty-7f2a3b9c.jar` reads as
 
 ### Concurrent build serialization (FR-015)
 
+POSIX path (Linux / macOS) uses `syscall.Flock`. Windows ships a
+no-cross-process fallback (in-process `sync.Mutex` only) — concurrent
+`trond build` from two trond processes on Windows is undefined and
+documented as such. Split via build constraints:
+
+```
+internal/build/lock_posix.go    // //go:build !windows
+internal/build/lock_windows.go  // //go:build windows
+```
+
+POSIX implementation:
+
+```go
+//go:build !windows
+
+func acquireBuildLock(cacheDir, key string) (release func(), err error) {
+    lockPath := filepath.Join(cacheDir, "locks", key+".lock")
+    f, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0o600)
+    if err != nil { return nil, err }
+    if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX); err != nil {
+        f.Close()
+        return nil, err
+    }
+    return func() {
+        syscall.Flock(int(f.Fd()), syscall.LOCK_UN)
+        f.Close()
+    }, nil
+}
+```
+
 ```go
 // before any expensive work
-lockPath := filepath.Join(cacheDir, "locks", key.String()+".lock")
-f, _ := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0o600)
-defer f.Close()
-syscall.Flock(int(f.Fd()), syscall.LOCK_EX)
-defer syscall.Flock(int(f.Fd()), syscall.LOCK_UN)
+release, err := acquireBuildLock(cacheDir, key.String())
+if err != nil { return errResult(err) }
+defer release()
 
 // re-check cache after acquiring lock
 if hit := cacheLookup(key); hit != nil {
@@ -233,14 +261,33 @@ guardrails (FR-022):
        fmt.Sprintf("docker run ... %s && cp ...", task))
    ```
 
-2. **Token-regex validation at parse time**. `gradle_task` and each
-   `gradle_arg` MUST match `^[a-zA-Z0-9._:=/+-]+$`. Names like
-   `shadowJar`, `:dbfork:build`, `-Dorg.gradle.daemon=false`,
-   `--offline`, `-Pversion=1.2.3` all pass. Anything with whitespace,
-   semicolons, redirection, backticks, `$()`, or quotes is rejected as
-   `VALIDATION_ERROR` before docker is even invoked.
+2. **`gradle_task`: char regex.** Task names are inherently regular —
+   `shadowJar`, `:dbfork:build`, `assemble`. Validated as
+   `^[a-zA-Z][a-zA-Z0-9:_-]*$`.
 
-The same gate guards `build.env` values (FR-019 allowlist).
+3. **`gradle_args`: flag-name allowlist** (not a character class).
+   The character regex from pass 2 was the wrong defense: it rejected
+   legitimate args (`--projects=a,b,c` has `,`; `-Dtitle=my title` has
+   spaces) AND let dangerous flags through (`--init-script
+   /tmp/evil.gradle` is all-ASCII-and-slashes). Since argv form already
+   blocks shell injection, the remaining concern is which gradle flags
+   are dangerous.
+
+   Allowed flags (whole arg matches):
+   - `--offline`, `--no-daemon`, `--parallel`, `--rerun-tasks`
+   - `--max-workers=<int>`
+   - `-D<key>=<val>`, `-P<key>=<val>` (value unrestricted, argv-safe)
+   - `-q`, `-i`, `-d` (log levels)
+
+   Rejected flags (allowlist miss):
+   - `--init-script`, `--include-build`, `--build-file`,
+     `--settings-file` — these redirect the build to attacker-supplied
+     logic.
+   - Anything else not listed.
+
+   Extending the allowlist is a code change, not an intent change.
+
+The same gate guards `build.env` keys (FR-019 allowlist).
 
 ### Intent integration
 
@@ -346,7 +393,7 @@ existing `image:` path.
 
 ## Phase Breakdown
 
-### Phase 1 — `trond build` standalone (~3 days)
+### Phase 1 — `trond build` standalone (~4 days)
 
 **Deliverable**: `trond build --source <path> --artifact jar -o json` works
 end-to-end. No intent integration yet.
@@ -366,10 +413,27 @@ end-to-end. No intent integration yet.
 - `internal/build/signal.go`: SIGINT context propagation + cleanup
   (FR-016).
 - `internal/build/audit.go`: emits the FR-023 build-event JSON into the
-  existing `internal/audit` log.
-- `internal/build/pins.go`: `go:embed builder_image_digests.json`
-  (FR-024), with `--builder-image-override` resolver. Override values
-  feed into the cache key.
+  existing `internal/audit` log. Append `result: "in_progress"` at
+  start; update atomically to `success` / `failed` / `cancelled` on
+  completion. Crashed builds leave forensic-visible `in_progress`
+  entries.
+- `internal/build/pins/`: package owning the embedded JSON. Layout:
+  - `internal/build/pins/builder_image_digests.json` — checked-in,
+    embedded via `//go:embed builder_image_digests.json`
+  - `internal/build/pins/pins.go` — `Resolve(jdkVersion) (ref string,
+    err error)` plus the `--builder-image-override` resolver. Override
+    values feed into the cache key (FR-024). When a pinned digest
+    resolves but `docker pull` fails (registry deleted the tag),
+    surface `BUILDER_IMAGE_UNAVAILABLE` with suggestions; do NOT fall
+    back to an unpinned tag.
+  - Repo-root `builder_image_digests.json` becomes a generated symlink
+    (Makefile target) for editor convenience and the
+    `refresh-builder-pins` script's output target.
+- `internal/build/lock_posix.go` + `internal/build/lock_windows.go`:
+  POSIX `flock` vs in-process mutex (FR-015 windows caveat).
+- `internal/build/imagetag.go`: Docker reference-format validator
+  (FR-005). Uses `github.com/distribution/reference` (small, stdlib-
+  free transitively) or an inline regex equivalent.
 - `internal/schema/files/build.schema.json` + `schemas/output/build.schema.json`.
 - `internal/schema/embed.go`: bump SchemaVersion to 1.3.0; add entry to
   history comment.
@@ -402,14 +466,15 @@ end-to-end. No intent integration yet.
 **Deliverable**: `trond apply --intent dev.yaml` automatically builds.
 
 - `internal/intent/schema.go`: add `Build` struct, validator rules
-  (mutual exclusion with `image:`, valid jdk versions, etc.).
+  (mutual exclusion with `image:`, valid jdk versions, image_tag
+  reference-format check via `imagetag.go`).
 - `schemas/intent.schema.json`: add the `build:` block, document mutual
   exclusion with `image:`.
 - `internal/apply/apply.go`: insert `resolveBuild()` between validate and
   render. Resolved artifact ref is held on the in-memory intent. On
-  success record `build_revision` on the state node entry (FR-018).
+  success record `build_cache_key` on the state node entry (FR-018).
 - `internal/state/state.go`: extend node entry with optional
-  `build_revision`. SchemaVersion stays 1.3.0 (still MINOR; additive).
+  `build_cache_key`. SchemaVersion stays 1.3.0 (still MINOR; additive).
 - `internal/render/`: consume the resolved ref. For `runtime: jar`, point
   the systemd unit at `<sha>.jar`. For `runtime: docker`, use the local
   image tag with `pull_policy: never` (FR-005).
@@ -464,12 +529,16 @@ tools surfaced.
 
 - `cmd/build_list.go`, `cmd/build_inspect.go`, `cmd/build_prune.go`.
 - `internal/build/cache.go`: prune logic — LRU by `created_at`,
-  cross-references `state.json::nodes[].build_revision` to refuse deletion
-  of in-use builds (FR-018). Dirty-build entries (those with `+dirty-`
-  suffix) are pruned more aggressively (configurable `build.cache.dirty_ttl`
-  / `--cache-dirty-ttl`, default 7 days, `never` accepted — FR-025).
-  During prune, manifest entries pointing at missing artifacts (e.g., user
-  manually deleted a JAR) are also removed (FR-020 cleanup branch).
+  cross-references `state.json::nodes[].build_cache_key` to refuse
+  deletion of in-use builds (FR-018). For `--artifact image` entries,
+  prune runs `docker image rm <image_id>` (not `docker untag`) so
+  layer storage is released; docker's refcounting protects layers
+  shared with other tags. Dirty-build entries (those with `+dirty-`
+  suffix) are pruned more aggressively (configurable
+  `build.cache.dirty_ttl` / `--cache-dirty-ttl`, default 7 days,
+  `never` accepted — FR-025). During prune, manifest entries pointing
+  at missing artifacts (e.g., user manually deleted a JAR) are also
+  removed (FR-020 cleanup branch).
 - MCP tools (`internal/mcp/tools_build.go`): expose `build`, `build_list`,
   `build_inspect`, `build_prune` with annotations per FR-013:
   - `build`: `idempotentHint=true`, `destructiveHint=false`
@@ -486,10 +555,14 @@ tools surfaced.
 
 ## Total estimate
 
-~9-10 working days from MVP (Phase 1+2) to fully closed loop (Phase 1-6).
-Revised up from the v1 draft's 7-8 days after the self-review added
-non-trivial work to Phase 1 (signal handling, flock, patch hash bug fix)
-and Phase 4 (progress notifications, scp probe).
+~11-12 working days from MVP (Phase 1+2) to fully closed loop (Phase
+1-6). Revised up from:
+- v1 draft 7-8d (initial scope)
+- pass 1 (+2d): signal handling, flock, patch-hash bug fix → 9-10d
+- pass 3 (+2d): Windows split + flag allowlist + image_tag validator +
+  pins package + audit lifecycle → 11-12d
+
+Phase 1 alone is now ~4 working days (was 2 in v1, 3 in pass 1).
 
 ## Risks and mitigations
 
@@ -530,9 +603,11 @@ and Phase 4 (progress notifications, scp probe).
 ## Schema impact
 
 - SchemaVersion: 1.2.0 → **1.3.0** (MINOR: adds new `build` schema +
-  extends state node entry with optional `build_revision`; no breaking
+  extends state node entry with optional `build_cache_key`; no breaking
   changes to existing schemas).
 - New file: `schemas/output/build.schema.json`.
+- Modified: `schemas/state.schema.json` (additive: new optional
+  `build_cache_key` field on each node entry).
 - Modified: `schemas/intent.schema.json` (additive: new optional `build:`
   block).
 - Modified: `schemas/state.schema.json` (additive: optional
@@ -550,8 +625,6 @@ and Phase 4 (progress notifications, scp probe).
 3. Whether to expose a `--builder ssh:<host>` (build on a remote build
    server) in the future. Hook is there in the `Builder` interface; no
    implementation in v1.
-4. Should `build.env` allow arbitrary keys, or whitelist? v1: arbitrary.
-   If supply-chain concerns arise, narrow later.
 
 ## CHANGELOG
 
@@ -572,6 +645,26 @@ and Phase 4 (progress notifications, scp probe).
     passthrough) — all phases updated accordingly.
   - `pull_policy: never` made explicit for local-built docker images.
   - SSH progress notifications for transfers > 50 MB.
+- **2026-05-08 (self-review pass 3)**: Applied 10-item third review.
+  - Windows port: split `internal/build/lock_{posix,windows}.go` so
+    `syscall.Flock` doesn't break windows/amd64 builds.
+  - Defense correction: `gradle_args` validation is now a flag-name
+    allowlist (was a char regex). New "Security boundary" subsection
+    enumerates accepted and rejected flags with rationale.
+  - `internal/build/pins/` package owns the embedded JSON; the root
+    file is a Makefile-generated symlink for ergonomics.
+  - New `internal/build/imagetag.go` validates `build.image_tag`
+    against Docker reference format.
+  - State node field renamed `build_revision` → `build_cache_key` (the
+    value is a cache key, not just a sha).
+  - Phase 5 prune for image artifacts uses `docker image rm` (not
+    `docker untag`) so layer storage is actually freed.
+  - Audit-log lifecycle is now two-phase: `in_progress` at start,
+    atomic update to terminal on completion. Crashed builds leave
+    forensic-visible entries.
+  - Pin-unreachable behavior specified: error, not silent fallback.
+  - Phase 1 estimate 3d → 4d; total 9-10d → 11-12d.
+  - Open question #4 (`build.env` allowlist) removed — resolved in pass 2.
 - **2026-05-08 (self-review pass 2)**: Applied 12-item second review.
   - **Security hardening**: dedicated "Security boundary" section; argv-
     only subprocess invocation (no `bash -c`); FR-022 token regex on

--- a/specs/002-trond-build-pipeline/plan.md
+++ b/specs/002-trond-build-pipeline/plan.md
@@ -1,0 +1,301 @@
+# Implementation Plan: trond Build Pipeline
+
+**Branch**: `feat/build-pipeline` | **Date**: 2026-05-08 | **Spec**: [spec.md](spec.md)
+
+## Summary
+
+Add a `trond build` command and an apply-side `build:` intent block that
+together let developers iterate on java-tron source code without context-
+switching out to Gradle. The build itself happens in a Docker container
+running a pinned `eclipse-temurin` image. trond orchestrates: source mount,
+gradle invocation, output capture, content-addressed caching, and (for
+SSH targets) artifact transfer.
+
+trond ships no JDK, no Gradle, no Java compiler. The build environment is
+the container; trond is the conductor.
+
+## Technical Context
+
+**Language/Version**: Go 1.25+
+**New Dependencies** (kept minimal):
+- `github.com/go-git/go-git/v5` — resolve `HEAD` / branch / tag → sha,
+  detect dirty working tree, compute patch hash. Already considered for
+  internal/state but not yet pulled in.
+- `archive/zip` (stdlib) — read JAR manifest to validate `Main-Class`.
+- `crypto/sha256` (stdlib) — content hashing.
+
+**Existing trond packages reused**:
+- `internal/paths` — for `${TROND_STATE_DIR}/builds/`
+- `internal/output` — for the structured error envelope
+- `internal/state` — to record built artifacts (no new file required;
+  reuse audit log)
+- `internal/mcp` — to expose tools
+- `internal/target/ssh` — for the scp transfer path in US-4
+
+**No removed dependencies**.
+
+## Architecture
+
+```
+                          trond CLI
+                              │
+        ┌─────────────────────┼─────────────────────┐
+        │                     │                     │
+   cmd/build.go         cmd/apply.go          internal/mcp
+   (standalone)         (resolves build:)     (tool: build)
+        │                     │                     │
+        └──────── calls ──────┴──────── calls ──────┘
+                              │
+                  internal/build/builder.go
+                  (Builder interface)
+                  ┌───────────┴────────────┐
+                  │                        │
+       internal/build/docker.go   internal/build/host.go
+       (containerized)            (--builder host)
+                  │
+                  └─► docker run eclipse-temurin:8-jdk-jammy@sha256:...
+                       -v <source>:/src:ro
+                       -v <cache>/gradle:/root/.gradle
+                       -v <cache>/out:/out:rw
+                       bash -c "./gradlew shadowJar && cp build/libs/*.jar /out/"
+
+                  internal/build/cache.go
+                  (content-addressed cache, manifest dir, prune logic)
+
+                  internal/build/validate.go
+                  (JAR Main-Class check, image inspect)
+```
+
+### Directory layout on disk
+
+```
+${TROND_STATE_DIR}/builds/
+├── gradle/                 # ~/.gradle persisted across builds
+├── out/                    # produced JARs
+│   ├── abc123.jar
+│   └── abc123+dirty-7f2a.jar
+├── images/                 # local image registry (sha → tag map)
+│   └── abc123.json
+└── manifest/               # one JSON per build, source of truth
+    ├── abc123.json
+    └── abc123+dirty-7f2a.json
+```
+
+The `manifest/` directory is the cache key index. `cache.go` reads only
+manifests (small JSON files); the artifacts under `out/` and `images/` are
+opaque blobs.
+
+### Cache key derivation
+
+```go
+type CacheKey struct {
+    SourcePath   string // canonicalized abs path
+    GitRevision  string // resolved sha
+    PatchHash    string // sha256 of git diff if dirty, else ""
+    JDKVersion   string
+    ArtifactKind string // "jar" | "image"
+}
+
+func (k CacheKey) String() string {
+    if k.PatchHash != "" {
+        return fmt.Sprintf("%s+dirty-%s", k.GitRevision, k.PatchHash[:8])
+    }
+    return k.GitRevision
+}
+```
+
+Two different source paths producing the same sha hit the same cache (this
+is the intent — a build is determined by its inputs, not its location).
+
+### Intent integration
+
+The intent schema gains a `build:` block, mutually exclusive with `image:`.
+
+```yaml
+name: dev-fullnode
+network: nile
+node:
+  type: fullnode
+  runtime: jar               # or docker
+target:
+  type: local
+
+build:
+  source: /Users/me/java-tron
+  revision: HEAD             # or branch / tag / sha
+  jdk: "8"                   # default
+  artifact: jar              # or image
+  image_tag: dev:latest      # required if artifact=image
+  builder: docker            # default; "host" available
+  rebuild: on_change         # always | on_change | never
+```
+
+Render pipeline change: if `build:` is present, render runs the build first,
+then substitutes the produced artifact ref (JAR path or image tag) into the
+runtime config. Render is otherwise unchanged.
+
+### Apply pipeline change
+
+```
+preflight → validate intent → [NEW: resolve build] → render → diff → apply
+```
+
+`resolve build` is a no-op if the intent has no `build:` block (backwards-
+compatible). Otherwise it calls the builder, then mutates the in-memory
+intent to substitute the resolved artifact ref. The original intent file is
+not touched.
+
+### SSH transfer path (US-4)
+
+When `target.type == ssh` and `build.artifact == jar`:
+
+```
+local build → ~/.trond/builds/out/<sha>.jar
+       │
+       ▼ scp (skip if remote file already matches sha256)
+remote:/opt/trond/deployments/<node>/java-tron.jar
+       │
+       ▼ systemd unit references /opt/trond/deployments/<node>/java-tron.jar
+       │
+       ▼ systemctl start
+```
+
+When `artifact == image` and target is SSH: out of scope for v1. Document
+that and require `target.type: local` for image artifacts. Users wanting
+remote image deploys should push to a registry and reference via the
+existing `image:` path.
+
+## Phase Breakdown
+
+### Phase 1 — `trond build` standalone (~2 days)
+
+**Deliverable**: `trond build --source <path> --artifact jar -o json` works
+end-to-end. No intent integration yet.
+
+- `cmd/build.go`: cobra command, flags, JSON output via `output.Result`.
+- `internal/build/builder.go`: `Builder` interface, default impl.
+- `internal/build/docker.go`: containerized builder using `os/exec` against
+  the docker CLI (no docker SDK — match the rest of trond).
+- `internal/build/cache.go`: manifest read/write, cache lookup.
+- `internal/build/source.go`: go-git wrapper, revision resolution, dirty
+  detection.
+- `internal/build/validate.go`: JAR `Main-Class` check via `archive/zip`.
+- `internal/schema/files/build.schema.json` + `schemas/output/build.schema.json`.
+- `internal/schema/embed.go`: bump SchemaVersion to 1.3.0; add entry to
+  history comment.
+- `internal/schema/version_baseline.json`: regenerate via make target.
+- Tests:
+  - `cmd/build_test.go`: cobra wiring + JSON shape.
+  - `internal/build/builder_test.go`: unit with a fake `dockerRunner`.
+  - `internal/build/cache_test.go`: cache hit / dirty key / prune.
+  - Golden test: a tiny synthetic source tree produces a deterministic
+    manifest (excluding timestamps and durations).
+
+### Phase 2 — Intent integration (~2 days)
+
+**Deliverable**: `trond apply --intent dev.yaml` automatically builds.
+
+- `internal/intent/schema.go`: add `Build` struct, validator rules.
+- `schemas/intent.schema.json`: add the `build:` block, document mutual
+  exclusion with `image:`.
+- `internal/apply/apply.go`: insert `resolveBuild()` between validate and
+  render. Resolved artifact ref is held on the in-memory intent.
+- `internal/render/`: consume the resolved ref. For `runtime: jar`, point
+  the systemd unit at `<sha>.jar`. For `runtime: docker`, use the local
+  image tag instead of pulling from a registry.
+- `internal/output`: add the `build` block to the apply result JSON.
+- Tests:
+  - `cmd/apply_build_test.go`: intent with `build:` resolves and applies
+    against a stub builder.
+  - `examples/dev-local.yaml`: a working example intent.
+
+### Phase 3 — Image artifact (~1 day)
+
+**Deliverable**: `--artifact image` and `runtime: docker` work together.
+
+- Recognize `image` artifact in `docker.go`; invoke `./gradlew :dockerBuild`
+  (or `:docker`, depending on tron-docker's task name; needs verification).
+- Local image-tag book-keeping: write a `images/<sha>.json` mapping
+  `image_id → tag`; remove tag on `prune`.
+- `internal/render/docker.go`: when artifact is `image`, use the tag
+  directly; skip the `image_pull_policy: always` we otherwise set.
+- Tests: round-trip with a minimal Dockerfile-only source tree (a stub
+  that doesn't need the full java-tron build).
+
+### Phase 4 — SSH target transfer (~1-2 days)
+
+**Deliverable**: build locally, deploy over SSH.
+
+- `internal/target/ssh/scp.go`: add a `Sha256IfExists(remotePath)` probe
+  and a `PutFile(localPath, remotePath)` op.
+- `internal/apply/apply.go`: when target is SSH and artifact is JAR, after
+  the build call `target.PutFile`. Skip if remote sha256 matches.
+- `examples/dev-ssh.yaml`.
+- Tests: integration test with an SSH-target container (already used by
+  existing e2e suite).
+
+### Phase 5 — Build management commands (~1 day)
+
+**Deliverable**: `trond build list / inspect <sha> / prune --keep N`.
+
+- `cmd/build_list.go`, `cmd/build_inspect.go`, `cmd/build_prune.go`.
+- `internal/build/cache.go`: prune logic (LRU by `created_at`, never delete
+  the build referenced by any currently-running node).
+- MCP tools (`internal/mcp/tools_build.go`): expose `build`, `build_list`,
+  `build_inspect`, `build_prune` with the same shape as the existing tool
+  registrations. `build` carries `destructiveHint=false` (it writes only
+  to the cache), `build_prune` carries `destructiveHint=true`.
+
+### Phase 6 — Docs & quickstart (~0.5 day)
+
+- `specs/002-trond-build-pipeline/quickstart.md` — copy/pasteable dev-loop
+  walkthrough.
+- README.md `## Dev loop` section linking to quickstart.
+- AGENTS.md: add `build` to the read-write tool list, document the
+  build-then-apply workflow.
+
+## Total estimate
+
+~7-8 working days from MVP (Phase 1+2) to fully closed loop (Phase 1-6).
+
+## Risks and mitigations
+
+- **Risk**: tron-docker's gradle task layout changes (`shadowJar` vs
+  `bootJar` vs `dockerBuild`).
+  **Mitigation**: keep the gradle task name configurable via the intent's
+  `build.gradle_task` field, with a sensible default. Detect the task list
+  with `./gradlew tasks --quiet` on first run and cache.
+
+- **Risk**: builder image pin becomes a security-update blocker.
+  **Mitigation**: trond release process includes a `make refresh-builder-pins`
+  target that re-resolves Eclipse Temurin tags to current digests.
+
+- **Risk**: the cache directory grows unbounded.
+  **Mitigation**: `trond build prune --keep N` is in Phase 5. Documented
+  in the quickstart. Add a soft-warn when cache > 5 GB.
+
+- **Risk**: gradle caches inside the container conflict with host gradle
+  (when developer also uses `./gradlew` outside trond).
+  **Mitigation**: trond mounts a separate `<cache>/gradle` directory rather
+  than the host's `~/.gradle`. The container's caches are isolated from
+  host. Document this.
+
+## Schema impact
+
+- SchemaVersion: 1.2.0 → **1.3.0** (MINOR: adds new `build` schema, no
+  change to existing schemas).
+- New file: `schemas/output/build.schema.json`.
+- Modified: `schemas/intent.schema.json` (additive: new optional `build:`
+  block).
+- `internal/schema/version_baseline.json`: regenerate.
+
+## Open questions (to resolve during implementation)
+
+1. Exact gradle task name in current tron-docker: `:shadowJar` or
+   `:bootJar`? Verify by inspecting `tools/toolkit/build.gradle`.
+2. Should `build.jdk: "8"` be a string or a number in the schema?
+   Recommend string to match Maven coords style (`"1.8"` vs `"8"` is also
+   ambiguous — pick `"8"`, `"11"`, `"17"`, `"21"`).
+3. Whether to expose a `--builder ssh:<host>` (build on a remote build
+   server) in the future. Hook is there in the `Builder` interface; no
+   implementation in v1.

--- a/specs/002-trond-build-pipeline/plan.md
+++ b/specs/002-trond-build-pipeline/plan.md
@@ -1,6 +1,7 @@
 # Implementation Plan: trond Build Pipeline
 
 **Branch**: `feat/build-pipeline` | **Date**: 2026-05-08 | **Spec**: [spec.md](spec.md)
+**Last revised**: 2026-05-08 (self-review pass)
 
 ## Summary
 
@@ -17,22 +18,31 @@ the container; trond is the conductor.
 ## Technical Context
 
 **Language/Version**: Go 1.25+
-**New Dependencies** (kept minimal):
-- `github.com/go-git/go-git/v5` — resolve `HEAD` / branch / tag → sha,
-  detect dirty working tree, compute patch hash. Already considered for
-  internal/state but not yet pulled in.
-- `archive/zip` (stdlib) — read JAR manifest to validate `Main-Class`.
-- `crypto/sha256` (stdlib) — content hashing.
+
+**New dependencies**: **None.** All external interactions go through
+`os/exec`, matching the rest of trond:
+
+- `git`: shell out via `exec.CommandContext(ctx, "git", ...)` — `rev-parse`,
+  `status --porcelain -uall`, `diff`. Avoids ~30 MB `go-git/v5` impact on
+  binary size; consistent with how trond already drives `docker` and `scp`.
+- `docker`: existing pattern.
+- `scp` / `ssh`: existing `internal/target/ssh`.
 
 **Existing trond packages reused**:
 - `internal/paths` — for `${TROND_STATE_DIR}/builds/`
 - `internal/output` — for the structured error envelope
-- `internal/state` — to record built artifacts (no new file required;
-  reuse audit log)
-- `internal/mcp` — to expose tools
-- `internal/target/ssh` — for the scp transfer path in US-4
+- `internal/state` — extends node entry with optional `build_revision`
+- `internal/mcp` — to expose tools (`build`, `build_list`, `build_inspect`,
+  `build_prune`)
+- `internal/target/ssh` — for the scp transfer path in US-4 and the
+  `scp` preflight probe (FR-017)
+- `internal/audit` — to record build events
 
-**No removed dependencies**.
+**Stdlib only**:
+- `archive/zip` — read JAR manifest to validate `Main-Class`.
+- `crypto/sha256` — content hashing and patch hashing.
+- `os/signal` — SIGINT handling (FR-016).
+- `syscall.Flock` — concurrent build serialization (FR-015).
 
 ## Architecture
 
@@ -47,38 +57,51 @@ the container; trond is the conductor.
         └──────── calls ──────┴──────── calls ──────┘
                               │
                   internal/build/builder.go
-                  (Builder interface)
-                  ┌───────────┴────────────┐
-                  │                        │
-       internal/build/docker.go   internal/build/host.go
-       (containerized)            (--builder host)
+                  (Builder interface + docker/host impls in one file)
+                              │
+                  ┌───────────┼───────────┐
+                  │           │           │
+                  ▼           ▼           ▼
+              docker run    ./gradlew    cache hit
+              eclipse-      (host         (manifest
+              temurin       builder)      lookup)
                   │
-                  └─► docker run eclipse-temurin:8-jdk-jammy@sha256:...
-                       -v <source>:/src:ro
+                  └─► -v <source>:/src:ro
                        -v <cache>/gradle:/root/.gradle
                        -v <cache>/out:/out:rw
-                       bash -c "./gradlew shadowJar && cp build/libs/*.jar /out/"
+                       -e GRADLE_OPTS, JAVA_OPTS, build.env.*
+                       bash -c "./gradlew <task> && cp build/libs/*.jar /out/"
 
                   internal/build/cache.go
-                  (content-addressed cache, manifest dir, prune logic)
+                  (content-addressed cache, manifest dir, prune logic,
+                   flock-based concurrent-build serialization)
 
                   internal/build/validate.go
                   (JAR Main-Class check, image inspect)
+
+                  internal/build/source.go
+                  (shells out to git: rev-parse, status, diff, patch hash)
 ```
+
+Note: dropped the separate `host.go` file from the v1 draft — host builder
+is a single function with a switch in `builder.go`. Avoids over-stratifying
+~30 lines of logic.
 
 ### Directory layout on disk
 
 ```
 ${TROND_STATE_DIR}/builds/
-├── gradle/                 # ~/.gradle persisted across builds
-├── out/                    # produced JARs
+├── gradle/                 # gradle deps cache, persisted across builds
+├── out/                    # produced JARs (named by cache key)
 │   ├── abc123.jar
 │   └── abc123+dirty-7f2a.jar
 ├── images/                 # local image registry (sha → tag map)
 │   └── abc123.json
-└── manifest/               # one JSON per build, source of truth
-    ├── abc123.json
-    └── abc123+dirty-7f2a.json
+├── manifest/               # one JSON per build, source of truth
+│   ├── abc123.json
+│   └── abc123+dirty-7f2a.json
+└── locks/                  # flock per cache key (FR-015)
+    └── abc123.lock
 ```
 
 The `manifest/` directory is the cache key index. `cache.go` reads only
@@ -89,11 +112,12 @@ opaque blobs.
 
 ```go
 type CacheKey struct {
-    SourcePath   string // canonicalized abs path
+    SourcePath   string // canonicalized abs path (symlinks resolved)
     GitRevision  string // resolved sha
-    PatchHash    string // sha256 of git diff if dirty, else ""
+    PatchHash    string // sha256 of (git diff || git status --porcelain -uall) if dirty
     JDKVersion   string
     ArtifactKind string // "jar" | "image"
+    GradleTask   string // "shadowJar" | "dockerBuild" | custom
 }
 
 func (k CacheKey) String() string {
@@ -104,8 +128,46 @@ func (k CacheKey) String() string {
 }
 ```
 
+**Critical**: PatchHash combines BOTH `git diff` AND `git status
+--porcelain -uall`. A diff alone misses untracked files, which would
+silently cache-hit a stale artifact (the bug found in self-review, FR-002).
+
 Two different source paths producing the same sha hit the same cache (this
 is the intent — a build is determined by its inputs, not its location).
+
+### Concurrent build serialization (FR-015)
+
+```go
+// before any expensive work
+lockPath := filepath.Join(cacheDir, "locks", key.String()+".lock")
+f, _ := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0o600)
+defer f.Close()
+syscall.Flock(int(f.Fd()), syscall.LOCK_EX)
+defer syscall.Flock(int(f.Fd()), syscall.LOCK_UN)
+
+// re-check cache after acquiring lock
+if hit := cacheLookup(key); hit != nil {
+    return hit, nil   // first caller finished while we waited
+}
+// otherwise do the build
+```
+
+### SIGINT handling (FR-016)
+
+```go
+ctx, cancel := signal.NotifyContext(parent, os.Interrupt, syscall.SIGTERM)
+defer cancel()
+
+cmd := exec.CommandContext(ctx, "docker", "run", "--rm", "--name", containerName, ...)
+defer cleanup(containerName) // best-effort `docker kill` + `rm -rf out/<partial>`
+
+if err := cmd.Run(); err != nil {
+    if errors.Is(ctx.Err(), context.Canceled) {
+        return errResult("BUILD_CANCELLED", 130, err, suggestions...)
+    }
+    return errResult("BUILD_FAILED", 1, err, suggestionsFromTail(cmd))
+}
+```
 
 ### Intent integration
 
@@ -127,12 +189,31 @@ build:
   artifact: jar              # or image
   image_tag: dev:latest      # required if artifact=image
   builder: docker            # default; "host" available
-  rebuild: on_change         # always | on_change | never
+  gradle_task: shadowJar     # default depends on artifact
+  env:                       # additive env passthrough (FR-019)
+    GRADLE_OPTS: "-Xmx2g"
 ```
+
+Note: `rebuild: always|on_change|never` is **removed** from the v1 draft.
+The cache key derivation already handles every legitimate case (dirty tree
+forces a new key; clean tree hits cache).
 
 Render pipeline change: if `build:` is present, render runs the build first,
 then substitutes the produced artifact ref (JAR path or image tag) into the
 runtime config. Render is otherwise unchanged.
+
+### Pull policy for local images (US-3 acceptance #2, FR-005)
+
+When `artifact: image` is consumed by `runtime: docker`, the rendered
+service block MUST carry `pull_policy: never` (Compose 3.9+) so compose
+does not attempt to pull the locally-built tag:
+
+```yaml
+services:
+  java-tron:
+    image: trond-build:abc123
+    pull_policy: never
+```
 
 ### Apply pipeline change
 
@@ -143,7 +224,22 @@ preflight → validate intent → [NEW: resolve build] → render → diff → a
 `resolve build` is a no-op if the intent has no `build:` block (backwards-
 compatible). Otherwise it calls the builder, then mutates the in-memory
 intent to substitute the resolved artifact ref. The original intent file is
-not touched.
+not touched. On success, apply records `build_revision = <key.String()>` on
+the state node entry (FR-018), enabling `build prune` to skip in-use builds.
+
+### Preflight integration (FR-017)
+
+When intent has `build:`:
+
+```go
+// internal/preflight/build.go (new file)
+- check source path exists + `git status` works
+- if builder == docker: check docker daemon reachable + builder image cached or pullable
+- if builder == host:   check `./gradlew --version` works
+- if target == ssh:     ssh probe `command -v scp` on remote
+```
+
+Surfaces as preflight checks with the existing pass/warning/fail shape.
 
 ### SSH transfer path (US-4)
 
@@ -160,6 +256,11 @@ remote:/opt/trond/deployments/<node>/java-tron.jar
        ▼ systemctl start
 ```
 
+Transfers > 50 MB emit MCP progress notifications (FR-009) using the same
+mechanism `snapshot download` uses. The scp invocation pipes its `-v`
+output through a parser that converts byte counts to MCP `progress`
+messages.
+
 When `artifact == image` and target is SSH: out of scope for v1. Document
 that and require `target.type: local` for image artifacts. Users wanting
 remote image deploys should push to a registry and reference via the
@@ -167,84 +268,104 @@ existing `image:` path.
 
 ## Phase Breakdown
 
-### Phase 1 — `trond build` standalone (~2 days)
+### Phase 1 — `trond build` standalone (~3 days)
 
 **Deliverable**: `trond build --source <path> --artifact jar -o json` works
 end-to-end. No intent integration yet.
 
 - `cmd/build.go`: cobra command, flags, JSON output via `output.Result`.
-- `internal/build/builder.go`: `Builder` interface, default impl.
-- `internal/build/docker.go`: containerized builder using `os/exec` against
-  the docker CLI (no docker SDK — match the rest of trond).
-- `internal/build/cache.go`: manifest read/write, cache lookup.
-- `internal/build/source.go`: go-git wrapper, revision resolution, dirty
-  detection.
+- `internal/build/builder.go`: `Builder` interface, default impl, docker
+  and host paths inline.
+- `internal/build/cache.go`: manifest read/write, cache lookup, flock
+  serialization (FR-015).
+- `internal/build/source.go`: shell-out wrapper for `git rev-parse`,
+  `status --porcelain -uall`, `diff`; patch hash combining both (FR-002).
 - `internal/build/validate.go`: JAR `Main-Class` check via `archive/zip`.
+- `internal/build/signal.go`: SIGINT handler (FR-016).
 - `internal/schema/files/build.schema.json` + `schemas/output/build.schema.json`.
 - `internal/schema/embed.go`: bump SchemaVersion to 1.3.0; add entry to
   history comment.
 - `internal/schema/version_baseline.json`: regenerate via make target.
+- `builder_image_digests.json` at repo root, plus
+  `Makefile :: refresh-builder-pins` (FR-012).
 - Tests:
   - `cmd/build_test.go`: cobra wiring + JSON shape.
   - `internal/build/builder_test.go`: unit with a fake `dockerRunner`.
-  - `internal/build/cache_test.go`: cache hit / dirty key / prune.
+  - `internal/build/cache_test.go`: cache hit / dirty key including
+    untracked files / prune / concurrent flock.
+  - `internal/build/source_test.go`: patch hash regression test for
+    untracked file invalidation.
+  - `internal/build/signal_test.go`: SIGINT mid-build cleanup.
   - Golden test: a tiny synthetic source tree produces a deterministic
-    manifest (excluding timestamps and durations).
+    manifest (excluding `duration_ms` and `created_at`).
 
 ### Phase 2 — Intent integration (~2 days)
 
 **Deliverable**: `trond apply --intent dev.yaml` automatically builds.
 
-- `internal/intent/schema.go`: add `Build` struct, validator rules.
+- `internal/intent/schema.go`: add `Build` struct, validator rules
+  (mutual exclusion with `image:`, valid jdk versions, etc.).
 - `schemas/intent.schema.json`: add the `build:` block, document mutual
   exclusion with `image:`.
 - `internal/apply/apply.go`: insert `resolveBuild()` between validate and
-  render. Resolved artifact ref is held on the in-memory intent.
+  render. Resolved artifact ref is held on the in-memory intent. On
+  success record `build_revision` on the state node entry (FR-018).
+- `internal/state/state.go`: extend node entry with optional
+  `build_revision`. SchemaVersion stays 1.3.0 (still MINOR; additive).
 - `internal/render/`: consume the resolved ref. For `runtime: jar`, point
   the systemd unit at `<sha>.jar`. For `runtime: docker`, use the local
-  image tag instead of pulling from a registry.
+  image tag with `pull_policy: never` (FR-005).
 - `internal/output`: add the `build` block to the apply result JSON.
+- `internal/preflight/build.go`: build-related preflight checks (FR-017).
 - Tests:
   - `cmd/apply_build_test.go`: intent with `build:` resolves and applies
     against a stub builder.
+  - `cmd/preflight_build_test.go`: each FR-017 check surfaces correctly.
   - `examples/dev-local.yaml`: a working example intent.
 
 ### Phase 3 — Image artifact (~1 day)
 
 **Deliverable**: `--artifact image` and `runtime: docker` work together.
 
-- Recognize `image` artifact in `docker.go`; invoke `./gradlew :dockerBuild`
-  (or `:docker`, depending on tron-docker's task name; needs verification).
+- Recognize `image` artifact in `builder.go`; invoke `./gradlew :dockerBuild`
+  (or whatever `build.gradle_task` overrides to).
 - Local image-tag book-keeping: write a `images/<sha>.json` mapping
   `image_id → tag`; remove tag on `prune`.
 - `internal/render/docker.go`: when artifact is `image`, use the tag
-  directly; skip the `image_pull_policy: always` we otherwise set.
+  directly with `pull_policy: never`.
 - Tests: round-trip with a minimal Dockerfile-only source tree (a stub
   that doesn't need the full java-tron build).
 
-### Phase 4 — SSH target transfer (~1-2 days)
+### Phase 4 — SSH target transfer (~2 days)
 
 **Deliverable**: build locally, deploy over SSH.
 
-- `internal/target/ssh/scp.go`: add a `Sha256IfExists(remotePath)` probe
-  and a `PutFile(localPath, remotePath)` op.
+- `internal/target/ssh/scp.go`: add a `Sha256IfExists(remotePath)` probe,
+  a `PutFile(localPath, remotePath)` op with `-v` parsing for progress.
+- `internal/target/ssh/preflight.go`: add `command -v scp` probe (FR-017).
 - `internal/apply/apply.go`: when target is SSH and artifact is JAR, after
   the build call `target.PutFile`. Skip if remote sha256 matches.
+- `internal/mcp`: emit progress notifications for transfers > 50 MB (FR-009).
 - `examples/dev-ssh.yaml`.
 - Tests: integration test with an SSH-target container (already used by
-  existing e2e suite).
+  existing e2e suite). One test asserts the progress notification fires.
 
-### Phase 5 — Build management commands (~1 day)
+### Phase 5 — Build management commands & MCP (~1 day)
 
-**Deliverable**: `trond build list / inspect <sha> / prune --keep N`.
+**Deliverable**: `trond build list / inspect <sha> / prune --keep N` + MCP
+tools surfaced.
 
 - `cmd/build_list.go`, `cmd/build_inspect.go`, `cmd/build_prune.go`.
-- `internal/build/cache.go`: prune logic (LRU by `created_at`, never delete
-  the build referenced by any currently-running node).
+- `internal/build/cache.go`: prune logic — LRU by `created_at`,
+  cross-references `state.json::nodes[].build_revision` to refuse deletion
+  of in-use builds (FR-018). Dirty-build entries (those with `+dirty-`
+  suffix) are pruned more aggressively (TTL 7 days default) since they're
+  inherently disposable.
 - MCP tools (`internal/mcp/tools_build.go`): expose `build`, `build_list`,
-  `build_inspect`, `build_prune` with the same shape as the existing tool
-  registrations. `build` carries `destructiveHint=false` (it writes only
-  to the cache), `build_prune` carries `destructiveHint=true`.
+  `build_inspect`, `build_prune` with annotations per FR-013:
+  - `build`: `idempotentHint=true`, `destructiveHint=false`
+  - `build_list`, `build_inspect`: `readOnlyHint=true`
+  - `build_prune`: `destructiveHint=true`
 
 ### Phase 6 — Docs & quickstart (~0.5 day)
 
@@ -256,23 +377,28 @@ end-to-end. No intent integration yet.
 
 ## Total estimate
 
-~7-8 working days from MVP (Phase 1+2) to fully closed loop (Phase 1-6).
+~9-10 working days from MVP (Phase 1+2) to fully closed loop (Phase 1-6).
+Revised up from the v1 draft's 7-8 days after the self-review added
+non-trivial work to Phase 1 (signal handling, flock, patch hash bug fix)
+and Phase 4 (progress notifications, scp probe).
 
 ## Risks and mitigations
 
 - **Risk**: tron-docker's gradle task layout changes (`shadowJar` vs
   `bootJar` vs `dockerBuild`).
-  **Mitigation**: keep the gradle task name configurable via the intent's
-  `build.gradle_task` field, with a sensible default. Detect the task list
-  with `./gradlew tasks --quiet` on first run and cache.
+  **Mitigation**: `build.gradle_task` field in intent + `--gradle-task`
+  CLI flag (FR-001). Sensible default per artifact kind.
 
 - **Risk**: builder image pin becomes a security-update blocker.
-  **Mitigation**: trond release process includes a `make refresh-builder-pins`
-  target that re-resolves Eclipse Temurin tags to current digests.
+  **Mitigation**: `make refresh-builder-pins` regenerates digests; CI runs
+  it weekly and opens a PR if drift is detected. Users in a bind can pass
+  `--builder-image-override <ref>` (escape hatch, not promoted in docs).
 
-- **Risk**: the cache directory grows unbounded.
-  **Mitigation**: `trond build prune --keep N` is in Phase 5. Documented
-  in the quickstart. Add a soft-warn when cache > 5 GB.
+- **Risk**: the cache directory grows unbounded (a working dev produces a
+  dirty build every few minutes).
+  **Mitigation**: `prune` exists in Phase 5. Dirty-build entries have a
+  default 7-day TTL (more aggressive than clean-build LRU). Soft-warn when
+  cache > 5 GB at the start of any `build`.
 
 - **Risk**: gradle caches inside the container conflict with host gradle
   (when developer also uses `./gradlew` outside trond).
@@ -280,22 +406,60 @@ end-to-end. No intent integration yet.
   than the host's `~/.gradle`. The container's caches are isolated from
   host. Document this.
 
+- **Risk**: Patch hash misses some signal that changes the build output
+  (e.g., file mode changes, submodule state).
+  **Mitigation**: `git status --porcelain -uall` covers untracked files,
+  modified mode bits, and submodule state. Stays a strict subset of "what
+  gradle actually depends on", but it's the strictest off-the-shelf
+  hash we can get without parsing build.gradle.
+
+- **Risk**: SSH transfer over a slow link with no progress feedback feels
+  hung.
+  **Mitigation**: MCP progress notifications for > 50 MB (FR-009). In
+  `-o text` mode the same parser drives a tty progress bar.
+
 ## Schema impact
 
-- SchemaVersion: 1.2.0 → **1.3.0** (MINOR: adds new `build` schema, no
-  change to existing schemas).
+- SchemaVersion: 1.2.0 → **1.3.0** (MINOR: adds new `build` schema +
+  extends state node entry with optional `build_revision`; no breaking
+  changes to existing schemas).
 - New file: `schemas/output/build.schema.json`.
 - Modified: `schemas/intent.schema.json` (additive: new optional `build:`
   block).
+- Modified: `schemas/state.schema.json` (additive: optional
+  `build_revision` field).
 - `internal/schema/version_baseline.json`: regenerate.
 
 ## Open questions (to resolve during implementation)
 
 1. Exact gradle task name in current tron-docker: `:shadowJar` or
-   `:bootJar`? Verify by inspecting `tools/toolkit/build.gradle`.
-2. Should `build.jdk: "8"` be a string or a number in the schema?
-   Recommend string to match Maven coords style (`"1.8"` vs `"8"` is also
-   ambiguous — pick `"8"`, `"11"`, `"17"`, `"21"`).
+   `:bootJar`? Verify by inspecting `tools/toolkit/build.gradle` and
+   `tools/dbfork/build.gradle`. The `build.gradle_task` field neutralizes
+   this concern; the question is what default to ship.
+2. `build.jdk` schema type: string (`"8"`, `"11"`, `"17"`, `"21"`).
+   Confirmed — string. Number is ambiguous (`8` vs `1.8`).
 3. Whether to expose a `--builder ssh:<host>` (build on a remote build
    server) in the future. Hook is there in the `Builder` interface; no
    implementation in v1.
+4. Should `build.env` allow arbitrary keys, or whitelist? v1: arbitrary.
+   If supply-chain concerns arise, narrow later.
+
+## CHANGELOG
+
+- **2026-05-08**: Initial draft.
+- **2026-05-08 (self-review)**: Applied 17-item review.
+  - Removed `go-git/v5` dependency; everything shells out via os/exec.
+  - Phase 1 estimate 2 days → 3 days (added signal handling, flock,
+    patch hash bug fix).
+  - Total estimate 7-8 → 9-10 days.
+  - Removed separate `host.go` file from architecture; folded into
+    `builder.go`.
+  - Architecture diagram redrawn to show new components: flock,
+    SIGINT handler, env passthrough, preflight integration.
+  - Cache key now explicitly combines git-diff AND git-status (untracked
+    files invalidate cache).
+  - Added FR-015 (concurrent lock), FR-016 (SIGINT), FR-017
+    (preflight), FR-018 (prune state cross-ref), FR-019 (env
+    passthrough) — all phases updated accordingly.
+  - `pull_policy: never` made explicit for local-built docker images.
+  - SSH progress notifications for transfers > 50 MB.

--- a/specs/002-trond-build-pipeline/spec.md
+++ b/specs/002-trond-build-pipeline/spec.md
@@ -2,6 +2,7 @@
 
 **Feature Branch**: `feat/build-pipeline`
 **Created**: 2026-05-08
+**Last revised**: 2026-05-08 (self-review pass — see CHANGELOG below)
 **Status**: Draft
 **Input**: User description: "Add a `trond build` capability that produces deployable
 java-tron artifacts (JAR or Docker image) from a source tree, integrated with
@@ -43,6 +44,19 @@ SBOM-attached, multi-arch matrix). That stays in tron-docker's CI. trond's
 - Q: Is `trond build` a standalone command or only an apply-side phase? →
   A: Both. Standalone for CI / debugging; apply-side for the integrated loop.
 
+### Session 2026-05-08 (self-review pass)
+
+- Q: Should `build.rebuild` field exist (`always | on_change | never`)? →
+  A: **Removed.** Semantics overlapped confusingly with revision = HEAD +
+  dirty detection. The cache-key derivation already handles the legitimate
+  cases; an explicit field added zero value.
+- Q: Patch hash for dirty trees: just `git diff`? → A: **No.** `git diff`
+  misses untracked files, which would silently cache-hit a stale artifact.
+  Patch hash MUST combine `git diff` and `git status --porcelain -uall`
+  (so a brand-new `.java` file invalidates the cache).
+- Q: Configurable gradle task name? → A: Yes, as `build.gradle_task` field
+  with sensible defaults (`shadowJar` for jar, `dockerBuild` for image).
+
 ## User Scenarios & Testing
 
 ### User Story 1 — Build a JAR from local source (Priority: P1)
@@ -75,10 +89,12 @@ Delivers a JAR file under `~/.trond/builds/out/` and a JSON manifest under
    re-runs the same command, **Then** trond returns the cached manifest with
    `cache_hit: true` and `duration_ms < 200`. The on-disk JAR is byte-identical.
 
-3. **Given** uncommitted edits in the working tree, **When** the developer
-   runs the same command, **Then** trond computes a patch hash, names the
-   artifact `abc123+dirty-<patchsha>.jar`, and treats it as a distinct cache
-   entry.
+3. **Given** uncommitted edits in the working tree **and** an untracked new
+   file, **When** the developer runs the same command, **Then** trond
+   computes a patch hash that combines `git diff` and `git status --porcelain
+   -uall`, names the artifact `abc123+dirty-<patchsha>.jar`, and treats it as
+   a distinct cache entry. Adding an untracked file MUST change the patch
+   hash (regression guard against the v1 design bug found in self-review).
 
 4. **Given** the build fails (compile error in user's code), **When** the
    command runs, **Then** trond surfaces a structured error envelope
@@ -89,6 +105,17 @@ Delivers a JAR file under `~/.trond/builds/out/` and a JSON manifest under
    invokes `trond build` without `--builder host`, **Then** trond exits with
    `error_code: "TARGET_UNREACHABLE"`, exit code 3, and a suggestion to start
    Docker or pass `--builder host`.
+
+6. **Given** the user sends SIGINT during a running build, **When** trond
+   receives the signal, **Then** trond kills the build container, removes
+   any partial output from `out/`, leaves no manifest entry for the aborted
+   build, and exits with `error_code: "BUILD_CANCELLED"`, exit code 130
+   (standard for SIGINT).
+
+7. **Given** two concurrent `trond build` invocations against the same
+   source + revision, **When** they race, **Then** the second caller
+   acquires a per-key file lock, waits for the first to complete, and
+   returns a cache hit (no duplicate build).
 
 ### User Story 2 — Build and deploy in one command (Priority: P1)
 
@@ -122,6 +149,11 @@ Delivers a running node whose runtime points at the just-built artifact.
    `apply` reaches the runtime step, **Then** trond fails with `error_code:
    "INVALID_ARTIFACT"`, NOT with a runtime crash inside the container.
 
+4. **Given** `runtime: docker` with `artifact: image`, **When** trond renders
+   the compose file, **Then** the service has `pull_policy: never` set, so
+   compose does not attempt to pull the locally-built tag from a remote
+   registry.
+
 ### User Story 3 — Build a Docker image, not a JAR (Priority: P2)
 
 The same developer wants a runnable Docker image rather than a JAR (so the
@@ -141,8 +173,8 @@ trond build --source ./java-tron --artifact image --tag trond-dev:abc123 -o json
    the image ID (sha256 digest).
 
 2. **Given** the artifact is `image`, **When** `apply` runs, **Then** the
-   rendered docker-compose references the local image tag directly (no
-   registry pull).
+   rendered docker-compose references the local image tag directly with
+   `pull_policy: never`.
 
 ### User Story 4 — Deploy over SSH using a locally built JAR (Priority: P2)
 
@@ -165,6 +197,16 @@ where the intent has both a `build:` block AND `target.type: ssh`.
    a prior run), **When** `apply` runs, **Then** trond skips the transfer
    step and goes directly to the start phase.
 
+3. **Given** a slow link and a large fat JAR (~200 MB), **When** the
+   transfer starts, **Then** trond emits MCP progress notifications (same
+   mechanism `snapshot download` uses) so a connected agent surfaces a
+   live progress bar to the user.
+
+4. **Given** the SSH target host lacks `scp` (some hardened distros), **When**
+   preflight runs, **Then** trond reports a clear `error_code:
+   "TARGET_MISSING_TOOL"` with a suggestion to install openssh-clients on
+   the remote.
+
 ### User Story 5 — Use host gradle (no container) (Priority: P3)
 
 A developer with a configured local Gradle daemon wants to skip the container
@@ -184,13 +226,18 @@ for max-iteration speed.
   to write to `~/.gradle/caches` — trond redirects this via mount.
 - **Out-of-disk during a build**: detected by gradle's own error; trond
   surfaces with a disk-space suggestion.
-- **Concurrent `trond build` calls on the same revision**: use a file lock on
-  the cache directory; second caller waits or returns cache hit.
+- **Concurrent `trond build` calls on the same revision**: per-key
+  `flock`-based serialization (FR-015); second caller waits then returns cache
+  hit.
 - **Builder image not present and offline**: surface clear network-error
   message, suggest `--builder host` fallback.
 - **Revision is `HEAD` but git working tree is not a git repo**: error
   `error_code: "INVALID_SOURCE"` with suggestion to either commit or pass an
   explicit `--source-id <name>`.
+- **Source path is a symlink**: resolve it before mounting; Docker's mount
+  resolves symlinks at mount-time, so trond canonicalizes the path first.
+- **Untracked file added between builds**: the patch hash MUST include
+  untracked files (FR-002 explicit), preventing stale cache hits.
 
 ## Requirements
 
@@ -198,24 +245,32 @@ for max-iteration speed.
 
 - **FR-001**: trond MUST expose a `trond build` cobra command accepting at
   minimum `--source <path>`, `--artifact <jar|image>`, `--revision <rev>`,
-  `--jdk <version>`, `--builder <docker|host>`, `--tag <tag>` (for image).
-- **FR-002**: The build cache MUST be content-addressed by source git
-  revision. Repeated builds at the same revision MUST be no-ops at the cache
-  hit path.
+  `--jdk <version>`, `--builder <docker|host>`, `--tag <tag>` (for image),
+  `--gradle-task <name>` (override default).
+- **FR-002**: The build cache MUST be content-addressed. The cache key for
+  clean working trees is the resolved git sha. For dirty working trees, the
+  key MUST incorporate a patch hash computed over the combined output of
+  `git diff` AND `git status --porcelain -uall` (so untracked files
+  invalidate cache).
 - **FR-003**: Build outputs MUST live under `${TROND_STATE_DIR}/builds/`
   (default `~/.trond/builds/`) and respect `--state-dir` / `TROND_STATE_DIR`.
 - **FR-004**: Each completed build MUST produce a JSON manifest matching
   `schemas/output/build.schema.json`.
 - **FR-005**: The intent.yaml schema MUST accept a `build:` block that is
-  mutually exclusive with `image:` and references source + revision.
+  mutually exclusive with `image:` and references source + revision. When
+  `runtime: docker` + `artifact: image`, the rendered compose service MUST
+  carry `pull_policy: never`.
 - **FR-006**: `trond apply` MUST resolve a `build:` block by invoking the
   build pipeline before the render/deploy phases.
 - **FR-007**: A build failure MUST set exit code 1 and `error_code:
-  "BUILD_FAILED"`, with the gradle stderr tail in the message.
+  "BUILD_FAILED"`, with the gradle stderr tail (last ~50 lines) in the
+  message. Output of a successful build MUST be silent on stdout in `-o
+  json` mode; verbose mode streams gradle output to stderr.
 - **FR-008**: The default builder MUST be `docker`. The host builder MUST be
   available as a flag override.
 - **FR-009**: When the target is SSH, trond MUST build locally and transfer
-  the JAR via scp. Source code MUST NOT be shipped to the remote.
+  the JAR via scp. Source code MUST NOT be shipped to the remote. Transfers
+  > 50 MB MUST emit MCP progress notifications.
 - **FR-010**: Builds MUST be discoverable: `trond build list`, `trond build
   prune --keep N`, `trond build inspect <sha>`.
 - **FR-011**: trond MUST validate the produced artifact is structurally valid
@@ -223,22 +278,53 @@ for max-iteration speed.
   ENTRYPOINT) before declaring success.
 - **FR-012**: The pinned builder image MUST be reproducible: trond ships a
   `builder_image_digests.json` mapping `jdk_version → sha256:...`. Upgrading
-  the pin is a trond release change, not a runtime change.
+  the pin is a trond release change, not a runtime change. A `make
+  refresh-builder-pins` target MUST regenerate the file from current Temurin
+  tags so digest drift is a one-command bump.
 - **FR-013**: All build-related operations MUST be exposed through MCP as
-  tools so AI agents can drive the dev loop.
+  tools so AI agents can drive the dev loop. Tool annotations:
+  - `build`: `idempotentHint=true`, `destructiveHint=false`
+  - `build_list`, `build_inspect`: `readOnlyHint=true`
+  - `build_prune`: `destructiveHint=true`
 - **FR-014**: The audit log MUST record each build invocation (revision,
   duration, result) alongside the existing apply/upgrade events.
+- **FR-015**: Concurrent `trond build` invocations against the same cache
+  key MUST serialize via a per-key `flock` on
+  `${TROND_STATE_DIR}/builds/locks/<key>.lock`. The waiting caller MUST
+  return a cache hit after the first completes (not duplicate work).
+- **FR-016**: `trond build` MUST handle SIGINT by terminating the build
+  container, removing partial output, omitting the manifest entry, and
+  exiting 130 with `error_code: "BUILD_CANCELLED"`.
+- **FR-017**: `trond preflight --intent <yaml>` MUST, when the intent
+  contains a `build:` block, additionally verify: (a) source path exists and
+  is a git repo, (b) docker is reachable (or host gradle exists with
+  `--builder host`), (c) the builder image is in the local cache or can be
+  pulled, (d) for SSH targets, scp is present on the remote.
+- **FR-018**: `trond build prune` MUST cross-reference `state.json` and
+  refuse to delete any build whose sha equals the `build_revision` field
+  of a currently-managed node. The state schema gains an optional
+  `build_revision` field on each node entry (additive, MINOR bump).
+- **FR-019**: The build environment MUST forward `GRADLE_OPTS` and
+  `JAVA_OPTS` from the trond invocation environment into the build
+  container. Additional pass-through can be requested via the intent's
+  `build.env: { KEY: VALUE }` map (v1 scope: any KEY allowed).
 
 ### Key Entities
 
 - **Build**: A content-addressed compilation of a java-tron source tree.
   Properties: source_revision (git sha), patch_hash (if dirty), jdk_version,
   artifact_kind (jar|image), artifact_ref (path or image tag),
-  sha256/image_id, duration_ms, builder (docker|host), created_at.
-- **Source**: A reference to a java-tron checkout. Properties: path,
-  revision_spec (HEAD|branch|tag|sha), resolved_revision, dirty_state.
+  sha256/image_id, duration_ms, builder (docker|host), gradle_task,
+  created_at.
+- **Source**: A reference to a java-tron checkout. Properties: path
+  (canonicalized), revision_spec (HEAD|branch|tag|sha), resolved_revision,
+  dirty_state (boolean), patch_hash (when dirty_state).
 - **Builder Image Pin**: A frozen mapping `jdk_version → image@sha256:...`
-  bundled with each trond release.
+  bundled with each trond release. Refresh path: `make
+  refresh-builder-pins`.
+- **State node entry** (existing, extended): adds optional
+  `build_revision: string` field, populated by apply when the deploy
+  consumed a `build:` block.
 
 ### Success Criteria
 
@@ -250,8 +336,8 @@ for max-iteration speed.
 - **SC-003**: A build can be triggered by an AI agent through MCP (the
   `build` tool) and the agent can chain build → apply → status in one
   conversation.
-- **SC-004**: The first 10 trond users to try the dev-loop quickstart (USX-1
-  / USX-2) complete it without manual intervention on the build step.
+- **SC-004**: The first 10 trond users to try the dev-loop quickstart (US-1
+  / US-2) complete it without manual intervention on the build step.
 
 ## Out of Scope (For This Feature)
 
@@ -264,9 +350,26 @@ for max-iteration speed.
 - Cross-source builds (combine multiple repos into one artifact).
 - Remote-host builds (build *on* the SSH target). Out of scope per
   clarification.
+- Image artifact + SSH target combined. Use registry push for that case
+  (existing `image:` path).
 
 ## Dependencies
 
 - This feature does NOT depend on the toolkit wrapper or analyze layer.
 - The shadow-fork feature DOES depend on a working build pipeline (it needs
   to produce a forked-state JAR/image).
+
+## CHANGELOG
+
+- **2026-05-08**: Initial draft.
+- **2026-05-08 (self-review)**: Applied 17-item review. Material changes:
+  - Removed ambiguous `build.rebuild: always|on_change|never` field.
+  - FR-002 patch hash now MUST include untracked files (regression bug fix
+    in design).
+  - FR-005 makes `pull_policy: never` explicit for local-built images.
+  - FR-015 (concurrent lock), FR-016 (SIGINT), FR-017 (preflight), FR-018
+    (prune cross-ref state), FR-019 (env passthrough) all newly added.
+  - US-1 gained acceptance scenarios 6-7 (SIGINT, concurrent).
+  - US-2 gained scenario 4 (pull_policy: never).
+  - US-4 gained scenarios 3-4 (progress, scp probe).
+  - FR-013 MCP tool annotations now explicit.

--- a/specs/002-trond-build-pipeline/spec.md
+++ b/specs/002-trond-build-pipeline/spec.md
@@ -57,6 +57,35 @@ SBOM-attached, multi-arch matrix). That stays in tron-docker's CI. trond's
 - Q: Configurable gradle task name? → A: Yes, as `build.gradle_task` field
   with sensible defaults (`shadowJar` for jar, `dockerBuild` for image).
 
+### Session 2026-05-08 (review pass 2)
+
+- Q: How to pass gradle_task / gradle_args without shell injection? →
+  A: Never invoke `bash -c`. Pass gradle task and args as separate
+  `exec.Command` argv; validate each token against
+  `^[a-zA-Z0-9._:=/+-]+$` at parse time and reject otherwise.
+- Q: Should the cache key incorporate the builder image digest? → A: Yes.
+  Cache key becomes `<git-sha>-b<digest-prefix>` so a pin bump silently
+  invalidates stale artifacts. Same for `+dirty-` variants.
+- Q: `build.env` arbitrary keys? → A: **No.** v1 is an allowlist: env
+  passthrough is restricted to `GRADLE_OPTS`, `JAVA_OPTS`,
+  `GRADLE_USER_HOME`, `MAVEN_OPTS`, and any var matching
+  `ORG_GRADLE_PROJECT_*`. Extending the list is a code change, not an
+  intent change.
+- Q: How is `builder_image_digests.json` distributed? → A: Embedded into
+  the trond binary via `go:embed`. Pin bumps ship with releases. A
+  `--builder-image-override <ref@sha256:...>` escape hatch exists for
+  emergencies but is not documented in the dev-loop quickstart.
+- Q: Source path relative to what? → A: CLI `--source ./path` resolves
+  relative to CWD. `build.source: ./path` in intent resolves relative
+  to the intent file's directory (matches docker-compose `build.context`).
+- Q: Should cache hit verify the artifact file exists on disk? → A: Yes.
+  Manifest existence is necessary but not sufficient; cache lookup MUST
+  stat the artifact and treat a missing file as a miss.
+- Q: Should SIGINT cancel scp transfers too? → A: Yes. The whole apply
+  flow runs under the same signal-aware context. scp writes to a
+  `.tmp` suffix and renames on success so a cancelled transfer leaves
+  no half-written artifact on the remote.
+
 ## User Scenarios & Testing
 
 ### User Story 1 — Build a JAR from local source (Priority: P1)
@@ -246,12 +275,15 @@ for max-iteration speed.
 - **FR-001**: trond MUST expose a `trond build` cobra command accepting at
   minimum `--source <path>`, `--artifact <jar|image>`, `--revision <rev>`,
   `--jdk <version>`, `--builder <docker|host>`, `--tag <tag>` (for image),
-  `--gradle-task <name>` (override default).
-- **FR-002**: The build cache MUST be content-addressed. The cache key for
-  clean working trees is the resolved git sha. For dirty working trees, the
-  key MUST incorporate a patch hash computed over the combined output of
-  `git diff` AND `git status --porcelain -uall` (so untracked files
-  invalidate cache).
+  `--gradle-task <name>` (override default), `--gradle-arg <flag>`
+  (repeatable; e.g. `--gradle-arg=--offline`).
+- **FR-002**: The build cache MUST be content-addressed. The cache key
+  MUST combine: resolved git sha, builder image digest prefix (so a pin
+  bump silently invalidates stale artifacts), jdk version, artifact kind,
+  gradle task name, and, for dirty working trees, a patch hash computed
+  over the COMBINED output of `git diff` AND `git status --porcelain
+  -uall` (so untracked files invalidate cache). On-disk naming:
+  `<git-sha>-b<digest6>[+dirty-<patchsha8>].(jar|imgmeta)`.
 - **FR-003**: Build outputs MUST live under `${TROND_STATE_DIR}/builds/`
   (default `~/.trond/builds/`) and respect `--state-dir` / `TROND_STATE_DIR`.
 - **FR-004**: Each completed build MUST produce a JSON manifest matching
@@ -292,30 +324,66 @@ for max-iteration speed.
   key MUST serialize via a per-key `flock` on
   `${TROND_STATE_DIR}/builds/locks/<key>.lock`. The waiting caller MUST
   return a cache hit after the first completes (not duplicate work).
-- **FR-016**: `trond build` MUST handle SIGINT by terminating the build
-  container, removing partial output, omitting the manifest entry, and
-  exiting 130 with `error_code: "BUILD_CANCELLED"`.
+- **FR-016**: `trond build` AND the build phase of `trond apply` MUST run
+  under a signal-aware context. SIGINT MUST terminate the build container
+  AND any in-flight scp transfer, remove partial output (`out/*.tmp`,
+  remote `*.tmp` files), omit the manifest entry, and exit 130 with
+  `error_code: "BUILD_CANCELLED"`.
 - **FR-017**: `trond preflight --intent <yaml>` MUST, when the intent
-  contains a `build:` block, additionally verify: (a) source path exists and
-  is a git repo, (b) docker is reachable (or host gradle exists with
-  `--builder host`), (c) the builder image is in the local cache or can be
-  pulled, (d) for SSH targets, scp is present on the remote.
+  contains a `build:` block, additionally verify: (a) source path exists
+  and is a git repo, (b) docker is reachable (or host gradle exists with
+  `--builder host`), (c) the builder image is in the local cache (a
+  network-reachable warm-pull check runs only when the image is missing;
+  offline hosts get a warning, not an error), (d) for SSH targets, scp
+  is present on the remote.
 - **FR-018**: `trond build prune` MUST cross-reference `state.json` and
-  refuse to delete any build whose sha equals the `build_revision` field
+  refuse to delete any build whose key equals the `build_revision` field
   of a currently-managed node. The state schema gains an optional
   `build_revision` field on each node entry (additive, MINOR bump).
-- **FR-019**: The build environment MUST forward `GRADLE_OPTS` and
-  `JAVA_OPTS` from the trond invocation environment into the build
-  container. Additional pass-through can be requested via the intent's
-  `build.env: { KEY: VALUE }` map (v1 scope: any KEY allowed).
+- **FR-019**: The build environment MUST forward env vars to the build
+  container ONLY from a fixed allowlist: `GRADLE_OPTS`, `JAVA_OPTS`,
+  `GRADLE_USER_HOME`, `MAVEN_OPTS`, and any var matching the
+  `ORG_GRADLE_PROJECT_*` prefix. Intent-side `build.env: { KEY: VALUE }`
+  is also restricted to this allowlist; unknown keys MUST fail validation
+  with `VALIDATION_ERROR`. Extending the allowlist is a trond code
+  change, not an intent change.
+- **FR-020**: Cache lookup MUST stat the manifest's referenced artifact
+  (jar file or local image tag) and treat a missing artifact as a cache
+  miss. Manifests pointing at missing artifacts MUST be removed during
+  the next prune.
+- **FR-021**: Source path resolution: `--source ./path` on the CLI
+  resolves relative to CWD; `build.source: ./path` in intent.yaml
+  resolves relative to the intent file's parent directory (matching
+  docker-compose's `build.context` convention).
+- **FR-022**: All gradle invocations MUST use a no-shell argv form
+  (`exec.Command("docker", "run", ..., image, "./gradlew", task,
+  args...)` — never `bash -c "..."`). The gradle task name and each
+  gradle arg MUST match `^[a-zA-Z0-9._:=/+-]+$`; non-matching values
+  MUST be rejected at parse time with `VALIDATION_ERROR`.
+- **FR-023**: Each build event in the audit log MUST conform to:
+  `{timestamp, command: "build", result: "success"|"failed"|"cancelled",
+  build: {source_revision, dirty: bool, jdk_version, artifact_kind,
+  builder, duration_ms, error_code: string|null}}`. Schema is shared
+  with the existing audit-log shape.
+- **FR-024**: `builder_image_digests.json` MUST be embedded into the
+  trond binary via `go:embed`. Runtime override via
+  `--builder-image-override <ref@sha256:...>` is allowed but is an
+  escape hatch (not promoted in the dev-loop quickstart). Override values
+  participate in the cache key (FR-002) so they don't pollute pinned
+  caches.
+- **FR-025**: The dirty-build cache TTL MUST be user-configurable via
+  `build.cache.dirty_ttl` in intent (or `--cache-dirty-ttl` on `build
+  prune`). Default 7 days. Accepted: any Go `time.ParseDuration` value
+  plus the literal `never`.
 
 ### Key Entities
 
 - **Build**: A content-addressed compilation of a java-tron source tree.
-  Properties: source_revision (git sha), patch_hash (if dirty), jdk_version,
+  Properties: source_revision (git sha), patch_hash (if dirty),
+  builder_image_digest (which JDK image produced this), jdk_version,
   artifact_kind (jar|image), artifact_ref (path or image tag),
   sha256/image_id, duration_ms, builder (docker|host), gradle_task,
-  created_at.
+  gradle_args, created_at.
 - **Source**: A reference to a java-tron checkout. Properties: path
   (canonicalized), revision_spec (HEAD|branch|tag|sha), resolved_revision,
   dirty_state (boolean), patch_hash (when dirty_state).
@@ -362,14 +430,39 @@ for max-iteration speed.
 ## CHANGELOG
 
 - **2026-05-08**: Initial draft.
-- **2026-05-08 (self-review)**: Applied 17-item review. Material changes:
+- **2026-05-08 (self-review pass 1)**: Applied 17-item review. Material
+  changes:
   - Removed ambiguous `build.rebuild: always|on_change|never` field.
-  - FR-002 patch hash now MUST include untracked files (regression bug fix
-    in design).
+  - FR-002 patch hash now MUST include untracked files (regression bug
+    fix in design).
   - FR-005 makes `pull_policy: never` explicit for local-built images.
-  - FR-015 (concurrent lock), FR-016 (SIGINT), FR-017 (preflight), FR-018
-    (prune cross-ref state), FR-019 (env passthrough) all newly added.
+  - FR-015 (concurrent lock), FR-016 (SIGINT), FR-017 (preflight),
+    FR-018 (prune cross-ref state), FR-019 (env passthrough) all newly
+    added.
   - US-1 gained acceptance scenarios 6-7 (SIGINT, concurrent).
   - US-2 gained scenario 4 (pull_policy: never).
   - US-4 gained scenarios 3-4 (progress, scp probe).
   - FR-013 MCP tool annotations now explicit.
+- **2026-05-08 (self-review pass 2)**: Applied 12-item second review.
+  Material changes:
+  - **Security**: FR-022 forbids shell-mediated gradle invocations
+    (closes command-injection via `gradle_task` / `gradle_args`); FR-019
+    narrows `build.env` from "any KEY" to a fixed allowlist (closes
+    `LD_PRELOAD`-style hijacks). Token regex added to `--gradle-task`
+    and `--gradle-arg`.
+  - **Correctness**: FR-002 cache key now includes builder image digest
+    (pin bump invalidates stale artifacts); FR-020 makes cache hit also
+    verify artifact file exists on disk.
+  - **Distribution**: FR-024 makes the pin file `go:embed`-ed so the
+    binary is the source of truth, with `--builder-image-override` as
+    documented escape hatch.
+  - **UX**: FR-021 disambiguates `source:` relative path resolution
+    (CLI = CWD, intent = intent-file dir).
+  - **Robustness**: FR-016 extends SIGINT handling to scp; uses
+    `.tmp` + rename so remote never sees half-written JARs.
+    FR-017 builder-image preflight is offline-friendly (warning on
+    missing-and-offline, not hard fail).
+  - **Audit/observability**: FR-023 fixes the audit-log build event
+    JSON shape so tooling can rely on it.
+  - **Configurability**: FR-001 grows `--gradle-arg <flag>` repeatable;
+    FR-025 makes dirty-cache TTL user-tunable (default 7d).

--- a/specs/002-trond-build-pipeline/spec.md
+++ b/specs/002-trond-build-pipeline/spec.md
@@ -86,6 +86,45 @@ SBOM-attached, multi-arch matrix). That stays in tron-docker's CI. trond's
   `.tmp` suffix and renames on success so a cancelled transfer leaves
   no half-written artifact on the remote.
 
+### Session 2026-05-08 (review pass 3)
+
+- Q: `gradle_args` validation by character class? → A: **No.** Character
+  regex was both too tight (rejects `,` in `--projects=a,b,c`, spaces in
+  `-Dtitle=my title`) and too loose (allows `--init-script
+  /tmp/evil.gradle`, which is the actual threat). Switched to a
+  **flag-name allowlist**: `--offline`, `--no-daemon`, `--parallel`,
+  `--max-workers=N`, `--rerun-tasks`, `-D<key>=<val>`, `-P<key>=<val>`,
+  `-q`/`-i`/`-d`. The value portion is unrestricted (argv form is
+  already shell-safe). `gradle_task` continues to use a tight char
+  regex (`^[a-zA-Z][a-zA-Z0-9:_-]*$`) since task names are inherently
+  regular.
+- Q: Windows support for concurrent-build serialization? → A: trond
+  publishes a windows/amd64 binary, but `syscall.Flock` is POSIX-only.
+  Implementation split via `//go:build !windows` — Windows uses an
+  in-process mutex only (no cross-process protection). FR-015 caveat
+  records this. Doc says: concurrent `trond build` from two trond
+  processes is undefined on Windows.
+- Q: `image_tag` format validation? → A: Validated against Docker
+  reference format. `image_tag: /etc/passwd` and similar must be
+  rejected with `VALIDATION_ERROR` at intent parse time.
+- Q: `state.json` field naming — `build_revision` or `build_cache_key`?
+  → A: **`build_cache_key`.** The stored value is the full cache key
+  (`<sha>-b<digest>[+dirty-<patch>]`), not just a git revision. Renaming
+  pre-implementation so we don't ship the misleading name.
+- Q: What if a pinned builder image digest becomes unreachable? → A:
+  Fail loudly. `error_code: "BUILDER_IMAGE_UNAVAILABLE"`, suggestions
+  point at `--builder-image-override` and "upgrade trond." Do NOT
+  silently fall back to unpinned tags — that defeats reproducibility.
+- Q: Does `build prune` clean up docker image layer disk usage? → A:
+  Yes. For `--artifact image`, prune runs `docker image rm <id>` (not
+  just `docker untag`). Layers shared with other images stay because
+  docker handles refcounting.
+- Q: Audit log atomicity around long-running builds? → A: Append a
+  `result: "in_progress"` event at build start; update atomically to
+  the terminal state on completion. A crash mid-build leaves an
+  `in_progress` entry visible via `trond events`, surfacing the
+  forensic signal.
+
 ## User Scenarios & Testing
 
 ### User Story 1 — Build a JAR from local source (Priority: P1)
@@ -291,7 +330,10 @@ for max-iteration speed.
 - **FR-005**: The intent.yaml schema MUST accept a `build:` block that is
   mutually exclusive with `image:` and references source + revision. When
   `runtime: docker` + `artifact: image`, the rendered compose service MUST
-  carry `pull_policy: never`.
+  carry `pull_policy: never`. `build.image_tag` MUST match Docker's
+  reference format (validated via `github.com/distribution/reference` or
+  equivalent regex); paths, whitespace, and uppercase are rejected with
+  `VALIDATION_ERROR`.
 - **FR-006**: `trond apply` MUST resolve a `build:` block by invoking the
   build pipeline before the render/deploy phases.
 - **FR-007**: A build failure MUST set exit code 1 and `error_code:
@@ -324,6 +366,9 @@ for max-iteration speed.
   key MUST serialize via a per-key `flock` on
   `${TROND_STATE_DIR}/builds/locks/<key>.lock`. The waiting caller MUST
   return a cache hit after the first completes (not duplicate work).
+  On Windows (no POSIX `flock`), the implementation falls back to an
+  in-process mutex only; cross-process serialization is undefined and
+  documented as such. Goal: don't break the Windows build.
 - **FR-016**: `trond build` AND the build phase of `trond apply` MUST run
   under a signal-aware context. SIGINT MUST terminate the build container
   AND any in-flight scp transfer, remove partial output (`out/*.tmp`,
@@ -337,9 +382,13 @@ for max-iteration speed.
   offline hosts get a warning, not an error), (d) for SSH targets, scp
   is present on the remote.
 - **FR-018**: `trond build prune` MUST cross-reference `state.json` and
-  refuse to delete any build whose key equals the `build_revision` field
-  of a currently-managed node. The state schema gains an optional
-  `build_revision` field on each node entry (additive, MINOR bump).
+  refuse to delete any build whose cache key equals the
+  `build_cache_key` field of a currently-managed node. The state schema
+  gains an optional `build_cache_key` field on each node entry
+  (additive, MINOR bump). For `--artifact image` entries, prune MUST
+  call `docker image rm <image_id>` (not just `docker untag`) so layer
+  storage is actually released; docker's refcounting protects layers
+  shared with other tags.
 - **FR-019**: The build environment MUST forward env vars to the build
   container ONLY from a fixed allowlist: `GRADLE_OPTS`, `JAVA_OPTS`,
   `GRADLE_USER_HOME`, `MAVEN_OPTS`, and any var matching the
@@ -357,20 +406,40 @@ for max-iteration speed.
   docker-compose's `build.context` convention).
 - **FR-022**: All gradle invocations MUST use a no-shell argv form
   (`exec.Command("docker", "run", ..., image, "./gradlew", task,
-  args...)` — never `bash -c "..."`). The gradle task name and each
-  gradle arg MUST match `^[a-zA-Z0-9._:=/+-]+$`; non-matching values
-  MUST be rejected at parse time with `VALIDATION_ERROR`.
+  args...)` — never `bash -c "..."`). Validation:
+  - `gradle_task` MUST match `^[a-zA-Z][a-zA-Z0-9:_-]*$` (task names
+    are inherently regular). Examples accepted: `shadowJar`,
+    `:dbfork:build`. Rejected: anything with whitespace, `;`, `$()`,
+    or path separators.
+  - `gradle_args` is restricted by a **flag-name allowlist**, not a
+    character class. Accepted: `--offline`, `--no-daemon`, `--parallel`,
+    `--max-workers=<int>`, `--rerun-tasks`, `-D<key>=<val>`,
+    `-P<key>=<val>`, `-q` / `-i` / `-d`. The value portion of `-D`/`-P`
+    is unrestricted (argv form is already shell-safe). Any other
+    flag, including `--init-script`, `--include-build`, `--build-file`,
+    `--settings-file`, is rejected with `VALIDATION_ERROR` because they
+    can redirect the build to attacker-supplied logic.
 - **FR-023**: Each build event in the audit log MUST conform to:
-  `{timestamp, command: "build", result: "success"|"failed"|"cancelled",
-  build: {source_revision, dirty: bool, jdk_version, artifact_kind,
-  builder, duration_ms, error_code: string|null}}`. Schema is shared
-  with the existing audit-log shape.
+  `{timestamp, command: "build", result:
+  "in_progress"|"success"|"failed"|"cancelled", build:
+  {source_revision, dirty: bool, jdk_version, artifact_kind, builder,
+  duration_ms, error_code: string|null}}`. Lifecycle: append a
+  `result: "in_progress"` event at build start, then update atomically
+  to the terminal result on completion. A trond process crash mid-build
+  leaves an `in_progress` entry visible via `trond events`, surfacing
+  the forensic signal. Schema is shared with the existing audit-log
+  shape.
 - **FR-024**: `builder_image_digests.json` MUST be embedded into the
   trond binary via `go:embed`. Runtime override via
   `--builder-image-override <ref@sha256:...>` is allowed but is an
   escape hatch (not promoted in the dev-loop quickstart). Override values
   participate in the cache key (FR-002) so they don't pollute pinned
-  caches.
+  caches. When the pinned digest is unreachable (image removed from
+  registry, network outage of the registry itself), trond MUST exit
+  with `error_code: "BUILDER_IMAGE_UNAVAILABLE"`, `exit_code: 3`, and
+  surface suggestions covering both `--builder-image-override <ref>`
+  and "upgrade trond." trond MUST NOT silently fall back to an
+  unpinned tag — that defeats reproducibility.
 - **FR-025**: The dirty-build cache TTL MUST be user-configurable via
   `build.cache.dirty_ttl` in intent (or `--cache-dirty-ttl` on `build
   prune`). Default 7 days. Accepted: any Go `time.ParseDuration` value
@@ -391,8 +460,9 @@ for max-iteration speed.
   bundled with each trond release. Refresh path: `make
   refresh-builder-pins`.
 - **State node entry** (existing, extended): adds optional
-  `build_revision: string` field, populated by apply when the deploy
-  consumed a `build:` block.
+  `build_cache_key: string` field (full cache key, not just git sha),
+  populated by apply when the deploy consumed a `build:` block. Used by
+  `build prune` to refuse deletion of in-use builds.
 
 ### Success Criteria
 
@@ -443,6 +513,28 @@ for max-iteration speed.
   - US-2 gained scenario 4 (pull_policy: never).
   - US-4 gained scenarios 3-4 (progress, scp probe).
   - FR-013 MCP tool annotations now explicit.
+- **2026-05-08 (self-review pass 3)**: Applied 10-item third review.
+  - **Portability bug**: FR-015 now documents Windows fallback for
+    `flock` (in-process mutex only; cross-process serialization
+    undefined). Prevents windows/amd64 build break.
+  - **Defense correction**: FR-022 swaps the `gradle_args` char-regex
+    for a flag-name allowlist (`--init-script /tmp/evil.gradle` was
+    passing the old regex while legitimate `--projects=a,b,c` was
+    failing it). `gradle_task` keeps its tight char-regex since task
+    names are inherently regular.
+  - **Input validation**: FR-005 grows an `image_tag` reference-format
+    check (rejects `image_tag: /etc/passwd` etc.).
+  - **State naming**: `build_revision` field renamed to
+    `build_cache_key` — the stored value is the cache key
+    (`<sha>-b<digest>[+dirty-<patch>]`), not just a git sha.
+  - **Resilience**: FR-024 specifies behavior when a pinned digest
+    becomes unreachable — explicit error, no silent fallback to
+    unpinned tags.
+  - **Resource cleanup**: FR-018 prune now calls `docker image rm`
+    (not `docker untag`) so image layer storage is actually freed.
+  - **Audit lifecycle**: FR-023 introduces `result: "in_progress"`
+    appended at build start, atomically updated on completion. A
+    crashed build leaves an inspectable forensic entry.
 - **2026-05-08 (self-review pass 2)**: Applied 12-item second review.
   Material changes:
   - **Security**: FR-022 forbids shell-mediated gradle invocations

--- a/specs/002-trond-build-pipeline/spec.md
+++ b/specs/002-trond-build-pipeline/spec.md
@@ -1,0 +1,272 @@
+# Feature Specification: trond Build Pipeline
+
+**Feature Branch**: `feat/build-pipeline`
+**Created**: 2026-05-08
+**Status**: Draft
+**Input**: User description: "Add a `trond build` capability that produces deployable
+java-tron artifacts (JAR or Docker image) from a source tree, integrated with
+`trond apply` so a developer can iterate on java-tron code and redeploy with a
+single command."
+
+## Background
+
+trond today consumes pre-built java-tron artifacts: an official Docker image
+(`tronprotocol/java-tron:<tag>`) or a pre-built JAR. The "edit java-tron code,
+test the change on a node" loop is unsupported — operators must context-switch
+to tron-docker / java-tron's Gradle toolchain to produce a custom artifact,
+then hand-stitch the result back into a trond intent.
+
+This feature closes that loop. trond gains a `build` verb that orchestrates a
+containerized Gradle invocation and an `apply`-side hook that resolves a
+`build:` block in intent.yaml automatically.
+
+## Non-Goals
+
+trond will NOT implement Java compilation, dependency resolution, or the Gradle
+DSL itself. The Java toolchain runs unchanged inside a container that trond
+manages; trond is an orchestrator, not a re-implementation.
+
+trond will NOT replace tron-docker's release-grade image build (signed,
+SBOM-attached, multi-arch matrix). That stays in tron-docker's CI. trond's
+`build` targets the development inner loop.
+
+## Clarifications
+
+### Session 2026-05-08
+
+- Q: Should the builder image be reproducible or follow upstream? → A: Pin a
+  specific sha256 digest per JDK version. Bump the pin in a trond release.
+- Q: Keep a `--builder host` escape hatch for developers with local gradle? →
+  A: Yes — same flags, skips the container path. Low maintenance cost.
+- Q: How should SSH targets handle the build step? → A: Build locally, scp the
+  resulting JAR to the remote target, start the node there. Don't ship source.
+- Q: Is `trond build` a standalone command or only an apply-side phase? →
+  A: Both. Standalone for CI / debugging; apply-side for the integrated loop.
+
+## User Scenarios & Testing
+
+### User Story 1 — Build a JAR from local source (Priority: P1)
+
+A java-tron developer has cloned the source, modified a few files, and wants a
+fat JAR they can hand to `trond apply` or run separately. They invoke
+`trond build` against the source directory and receive a JSON response
+containing the artifact path, source revision, and content hash.
+
+**Why this priority**: This is the foundation. Until a single artifact can be
+produced repeatably from a source tree, nothing else in this feature works.
+
+**Independent Test**:
+```bash
+trond build --source ./java-tron --artifact jar -o json
+```
+Delivers a JAR file under `~/.trond/builds/out/` and a JSON manifest under
+`~/.trond/builds/manifest/`.
+
+**Acceptance Scenarios**:
+
+1. **Given** a clean java-tron working tree at revision `abc123`, **When** the
+   developer runs `trond build --source ./java-tron --artifact jar -o json`,
+   **Then** trond pulls the pinned `eclipse-temurin:8-jdk` image (first run
+   only), runs `./gradlew shadowJar` inside it, and emits
+   `{"source_revision":"abc123", "artifact_path":"~/.trond/builds/out/abc123.jar",
+   "sha256":"...", "duration_ms":..., "cache_hit": false}`.
+
+2. **Given** the same revision built once already, **When** the developer
+   re-runs the same command, **Then** trond returns the cached manifest with
+   `cache_hit: true` and `duration_ms < 200`. The on-disk JAR is byte-identical.
+
+3. **Given** uncommitted edits in the working tree, **When** the developer
+   runs the same command, **Then** trond computes a patch hash, names the
+   artifact `abc123+dirty-<patchsha>.jar`, and treats it as a distinct cache
+   entry.
+
+4. **Given** the build fails (compile error in user's code), **When** the
+   command runs, **Then** trond surfaces a structured error envelope
+   (`error_code: "BUILD_FAILED"`, message containing gradle's tail output,
+   `suggestions` pointing at common causes) and exits 1.
+
+5. **Given** Docker is not running on the host, **When** the developer
+   invokes `trond build` without `--builder host`, **Then** trond exits with
+   `error_code: "TARGET_UNREACHABLE"`, exit code 3, and a suggestion to start
+   Docker or pass `--builder host`.
+
+### User Story 2 — Build and deploy in one command (Priority: P1)
+
+A developer has an intent file that references a `build:` block instead of a
+prebuilt image. They run `trond apply --intent dev.yaml`. trond resolves the
+build first, then deploys a node against the freshly produced artifact.
+
+**Why this priority**: This is the dev loop trond is being extended for. Story
+1 alone leaves the build/deploy boundary manual.
+
+**Independent Test**:
+```bash
+trond apply --intent examples/dev-local.yaml --auto-approve --wait -o json
+```
+Delivers a running node whose runtime points at the just-built artifact.
+
+**Acceptance Scenarios**:
+
+1. **Given** an intent with `build.source: ./java-tron, build.revision: HEAD,
+   build.artifact: jar`, **When** `apply` runs and the revision has not been
+   built before, **Then** trond invokes the build pipeline, then proceeds to
+   `apply`. The JSON output contains both a `build` block and the usual `apply`
+   fields.
+
+2. **Given** the intent points at a build that's already cached, **When**
+   `apply` runs and the node is already deployed at that same revision,
+   **Then** the result is `no_change` and total duration is < 5 seconds.
+
+3. **Given** the build succeeds but the resulting JAR is not a valid
+   java-tron fat JAR (no `org.tron.program.FullNode` main class), **When**
+   `apply` reaches the runtime step, **Then** trond fails with `error_code:
+   "INVALID_ARTIFACT"`, NOT with a runtime crash inside the container.
+
+### User Story 3 — Build a Docker image, not a JAR (Priority: P2)
+
+The same developer wants a runnable Docker image rather than a JAR (so the
+node uses the docker runtime). They set `build.artifact: image` and a
+`build.image_tag` in their intent.
+
+**Independent Test**:
+```bash
+trond build --source ./java-tron --artifact image --tag trond-dev:abc123 -o json
+```
+
+**Acceptance Scenarios**:
+
+1. **Given** a tron-docker-shaped source tree (gradle target `dockerBuild`),
+   **When** the build runs, **Then** trond invokes the gradle docker plugin
+   and produces a local image tagged `trond-dev:abc123`. The manifest records
+   the image ID (sha256 digest).
+
+2. **Given** the artifact is `image`, **When** `apply` runs, **Then** the
+   rendered docker-compose references the local image tag directly (no
+   registry pull).
+
+### User Story 4 — Deploy over SSH using a locally built JAR (Priority: P2)
+
+A developer builds on their laptop and deploys to a remote Linux VM via SSH.
+
+**Independent Test**:
+```bash
+trond apply --intent examples/dev-ssh.yaml -o json
+```
+where the intent has both a `build:` block AND `target.type: ssh`.
+
+**Acceptance Scenarios**:
+
+1. **Given** a successful local build of `<sha>.jar`, **When** `apply` runs
+   against an SSH target, **Then** trond scp's the JAR to the remote host's
+   deployment directory, configures the systemd unit to point at it, and
+   starts the service. No source is shipped to the remote.
+
+2. **Given** the remote target already has the same `<sha>.jar` on disk (from
+   a prior run), **When** `apply` runs, **Then** trond skips the transfer
+   step and goes directly to the start phase.
+
+### User Story 5 — Use host gradle (no container) (Priority: P3)
+
+A developer with a configured local Gradle daemon wants to skip the container
+for max-iteration speed.
+
+**Acceptance Scenarios**:
+
+1. **Given** `--builder host` is passed (CLI) or `build.builder: host` is set
+   (intent), **When** the build runs, **Then** trond invokes `./gradlew` from
+   the source directory directly. JDK + Gradle version mismatches surface as
+   `BUILD_FAILED` with `suggestions` pointing at the required versions.
+
+### Edge Cases
+
+- **Source tree on a separate filesystem with weird permissions**: trond
+  mounts read-only so the build can't corrupt source. Gradle wrapper attempts
+  to write to `~/.gradle/caches` — trond redirects this via mount.
+- **Out-of-disk during a build**: detected by gradle's own error; trond
+  surfaces with a disk-space suggestion.
+- **Concurrent `trond build` calls on the same revision**: use a file lock on
+  the cache directory; second caller waits or returns cache hit.
+- **Builder image not present and offline**: surface clear network-error
+  message, suggest `--builder host` fallback.
+- **Revision is `HEAD` but git working tree is not a git repo**: error
+  `error_code: "INVALID_SOURCE"` with suggestion to either commit or pass an
+  explicit `--source-id <name>`.
+
+## Requirements
+
+### Functional Requirements
+
+- **FR-001**: trond MUST expose a `trond build` cobra command accepting at
+  minimum `--source <path>`, `--artifact <jar|image>`, `--revision <rev>`,
+  `--jdk <version>`, `--builder <docker|host>`, `--tag <tag>` (for image).
+- **FR-002**: The build cache MUST be content-addressed by source git
+  revision. Repeated builds at the same revision MUST be no-ops at the cache
+  hit path.
+- **FR-003**: Build outputs MUST live under `${TROND_STATE_DIR}/builds/`
+  (default `~/.trond/builds/`) and respect `--state-dir` / `TROND_STATE_DIR`.
+- **FR-004**: Each completed build MUST produce a JSON manifest matching
+  `schemas/output/build.schema.json`.
+- **FR-005**: The intent.yaml schema MUST accept a `build:` block that is
+  mutually exclusive with `image:` and references source + revision.
+- **FR-006**: `trond apply` MUST resolve a `build:` block by invoking the
+  build pipeline before the render/deploy phases.
+- **FR-007**: A build failure MUST set exit code 1 and `error_code:
+  "BUILD_FAILED"`, with the gradle stderr tail in the message.
+- **FR-008**: The default builder MUST be `docker`. The host builder MUST be
+  available as a flag override.
+- **FR-009**: When the target is SSH, trond MUST build locally and transfer
+  the JAR via scp. Source code MUST NOT be shipped to the remote.
+- **FR-010**: Builds MUST be discoverable: `trond build list`, `trond build
+  prune --keep N`, `trond build inspect <sha>`.
+- **FR-011**: trond MUST validate the produced artifact is structurally valid
+  (JAR contains `org.tron.program.FullNode` main class, or image has runnable
+  ENTRYPOINT) before declaring success.
+- **FR-012**: The pinned builder image MUST be reproducible: trond ships a
+  `builder_image_digests.json` mapping `jdk_version → sha256:...`. Upgrading
+  the pin is a trond release change, not a runtime change.
+- **FR-013**: All build-related operations MUST be exposed through MCP as
+  tools so AI agents can drive the dev loop.
+- **FR-014**: The audit log MUST record each build invocation (revision,
+  duration, result) alongside the existing apply/upgrade events.
+
+### Key Entities
+
+- **Build**: A content-addressed compilation of a java-tron source tree.
+  Properties: source_revision (git sha), patch_hash (if dirty), jdk_version,
+  artifact_kind (jar|image), artifact_ref (path or image tag),
+  sha256/image_id, duration_ms, builder (docker|host), created_at.
+- **Source**: A reference to a java-tron checkout. Properties: path,
+  revision_spec (HEAD|branch|tag|sha), resolved_revision, dirty_state.
+- **Builder Image Pin**: A frozen mapping `jdk_version → image@sha256:...`
+  bundled with each trond release.
+
+### Success Criteria
+
+- **SC-001**: A developer with java-tron source on their laptop can run
+  `trond apply --intent dev.yaml` and reach a running node in < 5 minutes for
+  a cold build, < 1 minute for a cached build.
+- **SC-002**: Re-running `trond apply` against an unchanged source tree
+  results in `no_change` and exits within 2 seconds.
+- **SC-003**: A build can be triggered by an AI agent through MCP (the
+  `build` tool) and the agent can chain build → apply → status in one
+  conversation.
+- **SC-004**: The first 10 trond users to try the dev-loop quickstart (USX-1
+  / USX-2) complete it without manual intervention on the build step.
+
+## Out of Scope (For This Feature)
+
+- Multi-arch image build matrix (`linux/amd64,linux/arm64`). Recorded in
+  follow-up. The Phase 4 design notes the buildx hook point.
+- Build provenance signing (cosign-signed artifacts at build time). The
+  release pipeline in tron-docker already does this; trond's dev builds are
+  intentionally unsigned.
+- Builds against branches of dependencies (e.g., custom protobuf-java).
+- Cross-source builds (combine multiple repos into one artifact).
+- Remote-host builds (build *on* the SSH target). Out of scope per
+  clarification.
+
+## Dependencies
+
+- This feature does NOT depend on the toolkit wrapper or analyze layer.
+- The shadow-fork feature DOES depend on a working build pipeline (it needs
+  to produce a forked-state JAR/image).


### PR DESCRIPTION
**Status**: Draft for design review only — no code yet.

## Summary

Proposes a \`trond build\` capability that closes the "edit java-tron source →
test on a node" loop. Build runs in a pinned eclipse-temurin container that
trond orchestrates; trond ships no JDK, no Gradle, no Java compiler.

Spec: [specs/002-trond-build-pipeline/spec.md](specs/002-trond-build-pipeline/spec.md)
Plan: [specs/002-trond-build-pipeline/plan.md](specs/002-trond-build-pipeline/plan.md)

## Key design decisions

- **Containerized builder** by default; \`--builder host\` escape hatch kept for devs with local Gradle.
- **Content-addressed cache** keyed by \`<git-sha>\` (or \`<git-sha>+dirty-<patch-sha>\` for uncommitted edits). Reruns at the same revision are no-ops.
- **Builder image pinned by sha256 digest** per JDK version, bumped per trond release.
- **SSH targets**: build locally, scp the JAR; never ship source to remote. \`artifact: image\` over SSH is out of scope for v1 (push to registry instead).
- **Intent integration**: new \`build:\` block in intent.yaml, mutually exclusive with \`image:\`. \`trond apply\` resolves it transparently.
- **Schema bump**: 1.2.0 → 1.3.0 (MINOR — additive build.schema.json).

## What this PR contains

Two markdown design docs only:
- \`spec.md\` — 5 user stories (P1 build standalone, P1 build+apply, P2 image artifact, P2 SSH transfer, P3 host builder), 14 functional requirements, 4 success criteria, edge cases, OOS.
- \`plan.md\` — architecture diagram, cache-key design, 6-phase implementation breakdown (~7-8 working days), risks, schema impact, open questions.

## What this PR does NOT contain

- Code. Phase 1 implementation starts once the design is reviewed.

## Review goals

- Is the build/deploy split (orchestrate, don't reimplement) the right boundary?
- Are the 5 user stories covering the dev workflows you have in mind?
- Are the 3 open questions in plan.md the right ones to defer?

## Test plan (for the future implementation, not this PR)

- [ ] Phase 1: \`trond build --source <path> --artifact jar\` produces a deterministic manifest; cache hit returns < 200ms.
- [ ] Phase 2: \`trond apply\` with a \`build:\` block round-trips end-to-end.
- [ ] Phase 4: SSH target gets the JAR via scp; rerun skips transfer if remote sha256 matches.
- [ ] Phase 5: \`trond build list/prune\` integrates with MCP tools.