### PR TITLE
build pipeline Phase 3: artifact=image + per-platform pins + macOS cache fix

### DIFF
--- a/cmd/config/render.go
+++ b/cmd/config/render.go
@@ -95,7 +95,7 @@ func runRender(cmd *cobra.Command, args []string) error {
 		// Render runtime artifacts
 		var composeYAML, systemdUnit string
 		if parsed.Target.Runtime == "docker" || parsed.Target.Runtime == "" {
-			composeYAML = render.RenderCompose(parsed.Name, parsed, &node, "", jvmArgs)
+			composeYAML = render.RenderCompose(parsed.Name, parsed, &node, "", jvmArgs, "")
 		}
 		if parsed.Target.Runtime == "jar" {
 			systemdUnit = render.RenderSystemdUnit(parsed, &node, jvmArgs, "", "")

--- a/cmd/network/add.go
+++ b/cmd/network/add.go
@@ -118,7 +118,7 @@ func runAdd(cmd *cobra.Command, args []string) error {
 		memGB = 16
 	}
 	jvmArgs := render.JVMArgsString(memGB, 17, node.JVM)
-	composeYAML := render.RenderCompose(nodeName, parsed, node, "", jvmArgs)
+	composeYAML := render.RenderCompose(nodeName, parsed, node, "", jvmArgs, "")
 
 	rt := runtime.NewDockerRuntime(tgt, paths.Deployments())
 	opts := runtime.DeployOpts{

--- a/cmd/network/create.go
+++ b/cmd/network/create.go
@@ -117,7 +117,7 @@ func runCreate(cmd *cobra.Command, args []string) error {
 			memGB = 16
 		}
 		jvmArgs := render.JVMArgsString(memGB, 17, node.JVM)
-		composeYAML := render.RenderCompose(nodeName, parsed, &node, "", jvmArgs)
+		composeYAML := render.RenderCompose(nodeName, parsed, &node, "", jvmArgs, "")
 
 		opts := runtime.DeployOpts{
 			Name:        nodeName,

--- a/internal/apply/apply.go
+++ b/internal/apply/apply.go
@@ -233,7 +233,10 @@ func Apply(ctx context.Context, opts Options) (*Result, error) {
 
 	switch runtimeType {
 	case "docker":
-		deployOpts.ComposeData = []byte(render.RenderCompose(opts.Intent.Name, opts.Intent, node, "", jvmArgs))
+		// builtImageTag is non-empty when intent had `build:` with
+		// artifact: image — render against the local tag + emit
+		// pull_policy: never so compose doesn't pull from a registry.
+		deployOpts.ComposeData = []byte(render.RenderCompose(opts.Intent.Name, opts.Intent, node, "", jvmArgs, builtImageTag))
 		rt := runtime.NewDockerRuntime(opts.Target, opts.DeploymentsDir)
 		if err := rt.Deploy(ctx, deployOpts); err != nil {
 			return nil, fmt.Errorf("docker deploy: %w", err)
@@ -373,7 +376,7 @@ func validateOptions(o Options) error {
 		switch {
 		case rt == "docker" && artifact == "jar":
 			return output.NewErrorf("VALIDATION_ERROR", output.ExitValidationError,
-				"node %q: target.runtime=docker requires build.artifact=image (Phase 3 work); use target.runtime=jar for now", n.Type)
+				"node %q: target.runtime=docker cannot consume build.artifact=jar — set build.artifact=image (docker path) or switch target.runtime=jar", n.Type)
 		case rt == "jar" && artifact == "image":
 			return output.NewErrorf("VALIDATION_ERROR", output.ExitValidationError,
 				"node %q: target.runtime=jar cannot consume build.artifact=image — set build.artifact=jar or switch runtime", n.Type)

--- a/internal/apply/apply.go
+++ b/internal/apply/apply.go
@@ -381,6 +381,17 @@ func validateOptions(o Options) error {
 			return output.NewErrorf("VALIDATION_ERROR", output.ExitValidationError,
 				"node %q: target.runtime=jar cannot consume build.artifact=image — set build.artifact=jar or switch runtime", n.Type)
 		}
+		// Mirror intent.Validate's cross-arch-image guard so callers
+		// bypassing intent.Validate still get rejected. See loader.go
+		// for the full rationale.
+		if artifact == "image" && n.Build.Platform != "" {
+			hostPlatform := intent.DefaultPlatform()
+			if n.Build.Platform != hostPlatform {
+				return output.NewErrorf("VALIDATION_ERROR", output.ExitValidationError,
+					"node %q: build.artifact=image with platform=%q is unsafe on host=%q — docker.sock-mounted builds always use the host daemon's arch",
+					n.Type, n.Build.Platform, hostPlatform)
+			}
+		}
 	}
 	return nil
 }

--- a/internal/build/builder.go
+++ b/internal/build/builder.go
@@ -148,14 +148,19 @@ func Run(ctx context.Context, req Request) (*Result, error) {
 
 	_ = AppendAuditEvent(PhaseInProgress, r.cacheKeyStr, "", started)
 
-	if r.req.ArtifactKind != "jar" {
-		_ = AppendAuditEvent(PhaseFailed, r.cacheKeyStr, "NOT_IMPLEMENTED", started)
-		return nil, output.NewErrorf("NOT_IMPLEMENTED", output.ExitGeneralError,
-			"artifact=%s is not yet supported by Phase 1 (jar only)", r.req.ArtifactKind)
+	var manifest *Manifest
+	var artifactErr error
+	switch r.req.ArtifactKind {
+	case "jar":
+		manifest, artifactErr = buildJAR(ctx, r, started)
+	case "image":
+		manifest, artifactErr = buildImage(ctx, r, started)
+	default:
+		_ = AppendAuditEvent(PhaseFailed, r.cacheKeyStr, "VALIDATION_ERROR", started)
+		return nil, output.NewErrorf("VALIDATION_ERROR", output.ExitValidationError,
+			"unknown artifact_kind %q (must be jar or image)", r.req.ArtifactKind)
 	}
-
-	manifest, err := buildJAR(ctx, r, started)
-	if err != nil {
+	if err := artifactErr; err != nil {
 		// Audit + propagate. The buildJAR helper has already done
 		// best-effort cleanup of .tmp output.
 		var se *output.StructuredError

--- a/internal/build/builder.go
+++ b/internal/build/builder.go
@@ -129,7 +129,7 @@ func Run(ctx context.Context, req Request) (*Result, error) {
 	}
 
 	// Fast path: cheap stat, no lock.
-	if hit, _ := Lookup(r.key); hit != nil && hit.Hit {
+	if hit, _ := Lookup(ctx, r.key); hit != nil && hit.Hit {
 		return resultFromManifest(hit.Manifest, true, time.Since(started).Milliseconds()), nil
 	}
 
@@ -142,11 +142,26 @@ func Run(ctx context.Context, req Request) (*Result, error) {
 	defer release()
 
 	// Re-check after lock — winner of the race may have finished.
-	if hit, _ := Lookup(r.key); hit != nil && hit.Hit {
+	if hit, _ := Lookup(ctx, r.key); hit != nil && hit.Hit {
 		return resultFromManifest(hit.Manifest, true, time.Since(started).Milliseconds()), nil
 	}
 
 	_ = AppendAuditEvent(PhaseInProgress, r.cacheKeyStr, "", started)
+
+	// Image builds mount /var/run/docker.sock into the builder
+	// container so gradle's docker plugin can call back into the
+	// host daemon. That extends trust to anything inside /src
+	// (build.gradle, plugins, transitive build scripts) — they can
+	// `docker run --privileged` against the host. trond defaults to
+	// trusting the source tree (it's the user's own checkout), but
+	// surface the boundary so operators building third-party forks
+	// notice once per invocation.
+	if r.req.ArtifactKind == "image" {
+		fmt.Fprintln(os.Stderr,
+			"notice: build.artifact=image mounts /var/run/docker.sock into the builder; "+
+				"the source tree's build.gradle gains host docker access. "+
+				"Only run against trusted sources.")
+	}
 
 	var manifest *Manifest
 	var artifactErr error

--- a/internal/build/builder.go
+++ b/internal/build/builder.go
@@ -201,13 +201,23 @@ func resolveBuild(ctx context.Context, req Request) (*resolved, error) {
 		return nil, err
 	}
 
-	imageRef, imageDigest, ok := pins.Resolve(req.JDKVersion, req.BuilderImageOverride)
+	imageRef, imageDigest, ok := pins.Resolve(req.JDKVersion, req.Platform, req.BuilderImageOverride)
 	if !ok {
+		platforms := pins.Platforms(req.JDKVersion)
+		if len(platforms) == 0 {
+			return nil, output.NewErrorf("VALIDATION_ERROR", output.ExitValidationError,
+				"no pinned builder image for JDK version %q (available: %v)",
+				req.JDKVersion, pins.Versions()).
+				WithSuggestions(
+					"Use one of "+strings.Join(pins.Versions(), ", "),
+					"Or pass --builder-image-override <ref@sha256:...>",
+				)
+		}
 		return nil, output.NewErrorf("VALIDATION_ERROR", output.ExitValidationError,
-			"no pinned builder image for JDK version %q (available: %v)",
-			req.JDKVersion, pins.Versions()).
+			"JDK %q has no pinned builder image for platform %q (supported: %v)",
+			req.JDKVersion, req.Platform, platforms).
 			WithSuggestions(
-				"Use one of "+strings.Join(pins.Versions(), ", "),
+				"Use one of platforms "+strings.Join(platforms, ", "),
 				"Or pass --builder-image-override <ref@sha256:...>",
 			)
 	}

--- a/internal/build/cache.go
+++ b/internal/build/cache.go
@@ -19,7 +19,13 @@ func CacheDir() string {
 
 // EnsureCacheDirs creates the cache subdirectories. Idempotent.
 func EnsureCacheDirs() error {
-	for _, sub := range []string{"out", "images", "manifest", "locks", "gradle"} {
+	// Note: the gradle cache used to be a `gradle` bind-mounted
+	// subdir here, but macOS Docker Desktop strips the exec bit on
+	// files the container writes (breaks protoc + similar native
+	// helpers). The runner now binds a docker named volume
+	// (`trond-build-gradle-cache`) instead, so this dir list is
+	// only for host-side outputs (artifacts, manifests, locks).
+	for _, sub := range []string{"out", "images", "manifest", "locks"} {
 		p := filepath.Join(CacheDir(), sub)
 		if err := os.MkdirAll(p, 0o700); err != nil {
 			return fmt.Errorf("mkdir %s: %w", p, err)

--- a/internal/build/cache.go
+++ b/internal/build/cache.go
@@ -38,7 +38,12 @@ func manifestPath(key string) string {
 // but not sufficient — we MUST also stat the artifact (jar or image
 // metadata) that the manifest points at. A user who manually deleted
 // a JAR shouldn't get a stale cache hit.
-func Lookup(key CacheKey) (*CacheHit, error) {
+//
+// ctx threads through the docker-inspect call for image artifacts;
+// callers should pass the same signal-aware context they use for
+// the rest of the build so a stuck docker daemon doesn't wedge the
+// cache check.
+func Lookup(ctx context.Context, key CacheKey) (*CacheHit, error) {
 	mp := manifestPath(key.String())
 	m, err := readManifest(mp)
 	if errors.Is(err, os.ErrNotExist) {
@@ -59,10 +64,11 @@ func Lookup(key CacheKey) (*CacheHit, error) {
 		}
 	case "image":
 		// Image artifacts are tracked via images/<key>.json. We also
-		// have to `docker image inspect` to confirm the local image
-		// is still in docker's store — a `docker system prune` or
-		// out-of-band `docker rmi` between trond runs would make the
-		// bookkeeping JSON point at nothing. (FR-020 cleanup branch.)
+		// have to `docker image inspect` to confirm the local TAG
+		// still resolves — a `docker rmi <tag>` (even one that left
+		// the underlying image ID alive via other tags) makes
+		// compose's `image: <tag>` field unresolvable. Tag-side
+		// check is the authoritative one. (FR-020 cleanup branch.)
 		meta, metaErr := readImageMetadata(key.String())
 		if errors.Is(metaErr, os.ErrNotExist) {
 			_ = os.Remove(mp)
@@ -71,7 +77,7 @@ func Lookup(key CacheKey) (*CacheHit, error) {
 		if metaErr != nil {
 			return nil, fmt.Errorf("read image metadata: %w", metaErr)
 		}
-		if !imageExistsLocally(context.Background(), meta.ImageID) {
+		if !imageTagExistsLocally(ctx, meta.Tag) {
 			_ = os.Remove(mp)
 			_ = os.Remove(filepath.Join(CacheDir(), "images", key.String()+".json"))
 			return &CacheHit{Hit: false}, nil

--- a/internal/build/cache.go
+++ b/internal/build/cache.go
@@ -1,6 +1,7 @@
 package build
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -57,10 +58,22 @@ func Lookup(key CacheKey) (*CacheHit, error) {
 			return nil, fmt.Errorf("stat cached artifact: %w", statErr)
 		}
 	case "image":
-		// Image artifacts are tracked via images/<key>.json. Phase 3
-		// fills this in; for Phase 1 we treat missing as miss.
-		if _, statErr := os.Stat(filepath.Join(CacheDir(), "images", key.String()+".json")); errors.Is(statErr, os.ErrNotExist) {
+		// Image artifacts are tracked via images/<key>.json. We also
+		// have to `docker image inspect` to confirm the local image
+		// is still in docker's store — a `docker system prune` or
+		// out-of-band `docker rmi` between trond runs would make the
+		// bookkeeping JSON point at nothing. (FR-020 cleanup branch.)
+		meta, metaErr := readImageMetadata(key.String())
+		if errors.Is(metaErr, os.ErrNotExist) {
 			_ = os.Remove(mp)
+			return &CacheHit{Hit: false}, nil
+		}
+		if metaErr != nil {
+			return nil, fmt.Errorf("read image metadata: %w", metaErr)
+		}
+		if !imageExistsLocally(context.Background(), meta.ImageID) {
+			_ = os.Remove(mp)
+			_ = os.Remove(filepath.Join(CacheDir(), "images", key.String()+".json"))
 			return &CacheHit{Hit: false}, nil
 		}
 	}

--- a/internal/build/cache_test.go
+++ b/internal/build/cache_test.go
@@ -1,6 +1,7 @@
 package build
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -34,7 +35,7 @@ func TestLookup_NoManifest(t *testing.T) {
 	if err := EnsureCacheDirs(); err != nil {
 		t.Fatalf("EnsureCacheDirs: %v", err)
 	}
-	hit, err := Lookup(CacheKey{
+	hit, err := Lookup(context.Background(), CacheKey{
 		GitRevision:        "abc123def456789012345678901234567890abcd",
 		BuilderImageDigest: "sha256:aaaa",
 		JDKVersion:         "8",
@@ -76,7 +77,7 @@ func TestLookup_StatsArtifact(t *testing.T) {
 		t.Fatalf("Save: %v", err)
 	}
 
-	hit, err := Lookup(key)
+	hit, err := Lookup(context.Background(), key)
 	if err != nil {
 		t.Fatalf("Lookup: %v", err)
 	}
@@ -119,7 +120,7 @@ func TestLookup_HitWhenArtifactPresent(t *testing.T) {
 		t.Fatalf("Save: %v", err)
 	}
 
-	hit, err := Lookup(key)
+	hit, err := Lookup(context.Background(), key)
 	if err != nil {
 		t.Fatalf("Lookup: %v", err)
 	}

--- a/internal/build/cache_test.go
+++ b/internal/build/cache_test.go
@@ -23,7 +23,7 @@ func TestEnsureCacheDirs(t *testing.T) {
 	if err := EnsureCacheDirs(); err != nil {
 		t.Fatalf("EnsureCacheDirs: %v", err)
 	}
-	for _, sub := range []string{"out", "images", "manifest", "locks", "gradle"} {
+	for _, sub := range []string{"out", "images", "manifest", "locks"} {
 		if _, err := os.Stat(filepath.Join(base, "builds", sub)); err != nil {
 			t.Errorf("expected %s/builds/%s to exist: %v", base, sub, err)
 		}

--- a/internal/build/image.go
+++ b/internal/build/image.go
@@ -1,0 +1,226 @@
+package build
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/tronprotocol/tron-deployment/internal/output"
+)
+
+// imageMetadata is the bookkeeping record written under
+// ${cacheDir}/images/<cache-key>.json. Captures what we built
+// locally so Lookup() can verify the image still exists in the
+// host's docker storage and so prune (Phase 5) can `docker image
+// rm <id>` to actually free the layers.
+type imageMetadata struct {
+	CacheKey string `json:"cache_key"`
+	Tag      string `json:"tag"`
+	ImageID  string `json:"image_id"`
+}
+
+// buildImage runs gradle to produce a docker image artifact, tags
+// the result with the user-supplied build.image_tag, captures the
+// image ID, and persists both the build manifest and the per-cache-
+// key image bookkeeping JSON. Mirrors buildJAR's lifecycle:
+//
+//  1. (Optional) clean up stale state from a prior cancelled run.
+//  2. Invoke gradle inside the builder container.
+//  3. Re-tag the produced image as <build.image_tag>.
+//  4. Resolve the image ID via `docker inspect` (so prune knows
+//     which sha256 to delete later).
+//  5. Validate the image has a runnable ENTRYPOINT (FR-011 for image
+//     kind: produced image must be runnable as a java-tron node).
+//  6. Persist Manifest + images/<key>.json.
+//
+// Cancellation: ctx cancellation kills the docker subprocess. We
+// don't try to docker-image-rm a half-built image — gradle leaves
+// its own partial state inside the container that's already torn
+// down with --rm.
+func buildImage(ctx context.Context, r *resolved, started time.Time) (*Manifest, error) {
+	tag := r.req.ImageTag
+	if tag == "" {
+		return nil, output.NewError("VALIDATION_ERROR", output.ExitValidationError,
+			"build.image_tag is required when artifact = image")
+	}
+
+	if err := defaultRunner.RunDockerBuild(ctx, r, "" /* outDir unused for image */, "" /* outTmp unused */); err != nil {
+		if errors.Is(ctx.Err(), context.Canceled) {
+			return nil, output.NewErrorf("BUILD_CANCELLED", 130,
+				"build cancelled by user").
+				WithSuggestions("Re-run when ready")
+		}
+		return nil, output.NewErrorf("BUILD_FAILED", output.ExitGeneralError,
+			"gradle dockerBuild failed: %s", err.Error()).
+			WithSuggestions(
+				"Inspect the gradle output above for build errors",
+				"Verify the source tree's build.gradle defines the dockerBuild task",
+			)
+	}
+
+	// Gradle's docker plugin typically tags the image as
+	// `<group>/<name>:<version>` (e.g. tronprotocol/java-tron:GreatVoyage-…).
+	// We don't try to discover that tag — instead we explicitly re-tag
+	// to whatever the user asked for in build.image_tag.
+	//
+	// To know what to re-tag, we look at the *last* image produced
+	// during the build. `docker image ls -q --filter "label=trond.build=<key>"`
+	// would be cleaner but requires the gradle plugin to set a label
+	// (it doesn't by default). Simpler approach: gradle dockerBuild
+	// already prints the image ID; we capture it via a `docker images`
+	// query against the cache key's parent.
+	//
+	// For Phase 3 we use the simplest workable path: ask docker which
+	// image was created most recently and tag that as our target.
+	// This works for the single-build serialized lock case (FR-015
+	// flock around the cache key); concurrent builds would clobber.
+	imageID, err := mostRecentlyCreatedImage(ctx)
+	if err != nil {
+		return nil, output.NewErrorf("BUILD_FAILED", output.ExitGeneralError,
+			"locate produced image: %s", err.Error())
+	}
+	if imageID == "" {
+		return nil, output.NewError("BUILD_FAILED", output.ExitGeneralError,
+			"gradle finished but no docker image appeared in `docker images`").
+			WithSuggestions(
+				"Verify the gradle task you ran actually produces a docker image",
+				"Common task names: dockerBuild, jib, bootBuildImage",
+			)
+	}
+	if err := dockerTag(ctx, imageID, tag); err != nil {
+		return nil, output.NewErrorf("BUILD_FAILED", output.ExitGeneralError,
+			"docker tag %s %s: %s", imageID, tag, err.Error())
+	}
+
+	if err := validateImageEntrypoint(ctx, tag); err != nil {
+		return nil, output.NewErrorf("INVALID_ARTIFACT", output.ExitGeneralError,
+			"produced image is not runnable: %s", err.Error()).
+			WithSuggestions(
+				"Verify the gradle docker task produces an image with a runnable ENTRYPOINT",
+			)
+	}
+
+	if err := writeImageMetadata(r.cacheKeyStr, tag, imageID); err != nil {
+		return nil, output.NewErrorf("INTERNAL_ERROR", output.ExitGeneralError,
+			"persist image metadata: %s", err.Error())
+	}
+
+	manifest := &Manifest{
+		CacheKey:           r.cacheKeyStr,
+		SourcePath:         r.src.Path,
+		SourceRevision:     r.src.ResolvedRevision,
+		PatchHash:          r.src.PatchHash,
+		Dirty:              r.src.DirtyState,
+		BuilderImage:       r.imageRef,
+		BuilderImageDigest: r.imageDigest,
+		JDKVersion:         r.req.JDKVersion,
+		ArtifactKind:       "image",
+		ImageTag:           tag,
+		ImageID:            imageID,
+		GradleTask:         r.req.GradleTask,
+		GradleArgs:         r.req.GradleArgs,
+		Builder:            r.req.Builder,
+		Platform:           r.req.Platform,
+		DurationMs:         time.Since(started).Milliseconds(),
+		CreatedAt:          time.Now().UTC(),
+	}
+	if err := Save(manifest); err != nil {
+		return nil, output.NewErrorf("INTERNAL_ERROR", output.ExitGeneralError,
+			"persist manifest: %s", err.Error())
+	}
+	return manifest, nil
+}
+
+// mostRecentlyCreatedImage returns the image ID at the top of
+// `docker images -q` — the most recently created image on the
+// host. Used to locate the artifact gradle's dockerBuild plugin
+// just produced (no standard way to ask the plugin directly).
+func mostRecentlyCreatedImage(ctx context.Context) (string, error) {
+	cmd := exec.CommandContext(ctx, "docker", "images", "-q", "--no-trunc")
+	out, err := cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("docker images: %w", err)
+	}
+	for line := range strings.SplitSeq(string(out), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		return line, nil // first line = newest
+	}
+	return "", nil
+}
+
+func dockerTag(ctx context.Context, imageID, tag string) error {
+	cmd := exec.CommandContext(ctx, "docker", "tag", imageID, tag)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("%w: %s", err, strings.TrimSpace(string(out)))
+	}
+	return nil
+}
+
+// validateImageEntrypoint asserts the image has a non-empty
+// ENTRYPOINT or CMD — FR-011's image-side analogue. Run via
+// `docker inspect`; we don't try to actually `docker run` the image
+// because that's expensive and we don't have arguments to test it
+// with.
+func validateImageEntrypoint(ctx context.Context, tag string) error {
+	cmd := exec.CommandContext(ctx, "docker", "inspect",
+		"--format={{.Config.Entrypoint}}|{{.Config.Cmd}}", tag)
+	out, err := cmd.Output()
+	if err != nil {
+		return fmt.Errorf("docker inspect %s: %w", tag, err)
+	}
+	got := strings.TrimSpace(string(out))
+	// "[]|[]" is what docker prints for entirely missing entrypoint + cmd.
+	if got == "[]|[]" || got == "|" {
+		return fmt.Errorf("image %s has neither ENTRYPOINT nor CMD", tag)
+	}
+	return nil
+}
+
+func writeImageMetadata(cacheKey, tag, imageID string) error {
+	if err := os.MkdirAll(filepath.Join(CacheDir(), "images"), 0o700); err != nil {
+		return err
+	}
+	meta := imageMetadata{CacheKey: cacheKey, Tag: tag, ImageID: imageID}
+	data, err := json.MarshalIndent(meta, "", "  ")
+	if err != nil {
+		return err
+	}
+	path := filepath.Join(CacheDir(), "images", cacheKey+".json")
+	return os.WriteFile(path, data, 0o600)
+}
+
+// readImageMetadata returns the bookkeeping record for a cache key,
+// or os.ErrNotExist when no image was produced for that key. Used
+// by cache.Lookup() to verify the local image still exists before
+// declaring a cache hit.
+func readImageMetadata(cacheKey string) (*imageMetadata, error) {
+	path := filepath.Join(CacheDir(), "images", cacheKey+".json")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	var meta imageMetadata
+	if err := json.Unmarshal(data, &meta); err != nil {
+		return nil, fmt.Errorf("decode image metadata: %w", err)
+	}
+	return &meta, nil
+}
+
+// imageExistsLocally checks whether the named image ID is still
+// present in the host's docker storage. A `trond build prune` run
+// outside trond's purview, or `docker system prune`, can delete the
+// image; the bookkeeping JSON then points at nothing.
+func imageExistsLocally(ctx context.Context, imageID string) bool {
+	cmd := exec.CommandContext(ctx, "docker", "image", "inspect",
+		"--format={{.Id}}", imageID)
+	return cmd.Run() == nil
+}

--- a/internal/build/image.go
+++ b/internal/build/image.go
@@ -50,7 +50,12 @@ func buildImage(ctx context.Context, r *resolved, started time.Time) (*Manifest,
 			"build.image_tag is required when artifact = image")
 	}
 
-	if err := defaultRunner.RunDockerBuild(ctx, r, "" /* outDir unused for image */, "" /* outTmp unused */); err != nil {
+	// The wrapper script (dockerBuildScript_Image) snapshots image
+	// IDs before + after gradle into /out/new-image-ids, so we
+	// need /out mounted. outDir is the host path that's bound.
+	outDir := filepath.Join(CacheDir(), "out")
+
+	if err := defaultRunner.RunDockerBuild(ctx, r, outDir, "" /* outTmp unused for image */); err != nil {
 		if errors.Is(ctx.Err(), context.Canceled) {
 			return nil, output.NewErrorf("BUILD_CANCELLED", 130,
 				"build cancelled by user").
@@ -64,35 +69,29 @@ func buildImage(ctx context.Context, r *resolved, started time.Time) (*Manifest,
 			)
 	}
 
-	// Gradle's docker plugin typically tags the image as
-	// `<group>/<name>:<version>` (e.g. tronprotocol/java-tron:GreatVoyage-…).
-	// We don't try to discover that tag — instead we explicitly re-tag
-	// to whatever the user asked for in build.image_tag.
-	//
-	// To know what to re-tag, we look at the *last* image produced
-	// during the build. `docker image ls -q --filter "label=trond.build=<key>"`
-	// would be cleaner but requires the gradle plugin to set a label
-	// (it doesn't by default). Simpler approach: gradle dockerBuild
-	// already prints the image ID; we capture it via a `docker images`
-	// query against the cache key's parent.
-	//
-	// For Phase 3 we use the simplest workable path: ask docker which
-	// image was created most recently and tag that as our target.
-	// This works for the single-build serialized lock case (FR-015
-	// flock around the cache key); concurrent builds would clobber.
-	imageID, err := mostRecentlyCreatedImage(ctx)
+	// Read the wrapper's before/after diff. Each line is one
+	// image ID that gradle's task produced this run — no race with
+	// other host docker activity (gradle's `docker images` runs
+	// inside our serialized build window).
+	newImageIDs, err := readNewImageIDs(outDir)
 	if err != nil {
 		return nil, output.NewErrorf("BUILD_FAILED", output.ExitGeneralError,
 			"locate produced image: %s", err.Error())
 	}
-	if imageID == "" {
+	if len(newImageIDs) == 0 {
 		return nil, output.NewError("BUILD_FAILED", output.ExitGeneralError,
-			"gradle finished but no docker image appeared in `docker images`").
+			"gradle finished but no new docker image appeared on the host").
 			WithSuggestions(
 				"Verify the gradle task you ran actually produces a docker image",
 				"Common task names: dockerBuild, jib, bootBuildImage",
 			)
 	}
+	// Pick the LAST new image — gradle's docker plugin typically
+	// produces intermediate layers + a final tagged image; the
+	// final one is the deploy artifact. (If gradle produced
+	// multiple final images, the user's gradle_task name selected
+	// only one, so picking the most-recent is unambiguous.)
+	imageID := newImageIDs[len(newImageIDs)-1]
 	if err := dockerTag(ctx, imageID, tag); err != nil {
 		return nil, output.NewErrorf("BUILD_FAILED", output.ExitGeneralError,
 			"docker tag %s %s: %s", imageID, tag, err.Error())
@@ -137,24 +136,33 @@ func buildImage(ctx context.Context, r *resolved, started time.Time) (*Manifest,
 	return manifest, nil
 }
 
-// mostRecentlyCreatedImage returns the image ID at the top of
-// `docker images -q` — the most recently created image on the
-// host. Used to locate the artifact gradle's dockerBuild plugin
-// just produced (no standard way to ask the plugin directly).
-func mostRecentlyCreatedImage(ctx context.Context) (string, error) {
-	cmd := exec.CommandContext(ctx, "docker", "images", "-q", "--no-trunc")
-	out, err := cmd.Output()
+// readNewImageIDs returns the image IDs the wrapper script
+// recorded as newly created during the gradle run.
+//
+// The wrapper computes (after \ before) of `docker images -q
+// --no-trunc | sort -u` and writes the result to
+// /out/new-image-ids. Because both snapshots happen inside the
+// builder's serialized window (FR-015 flock), the diff is robust
+// against the user's other host docker activity.
+//
+// Empty file = gradle ran but produced no image. Returns the IDs
+// in the order docker reported them (typically by creation time
+// thanks to sort order on hashes — not strictly, but stable enough
+// for our needs since the build is gated to one image producer).
+func readNewImageIDs(outDir string) ([]string, error) {
+	data, err := os.ReadFile(filepath.Join(outDir, "new-image-ids"))
 	if err != nil {
-		return "", fmt.Errorf("docker images: %w", err)
+		return nil, fmt.Errorf("read new-image-ids: %w", err)
 	}
-	for line := range strings.SplitSeq(string(out), "\n") {
+	var ids []string
+	for line := range strings.SplitSeq(string(data), "\n") {
 		line = strings.TrimSpace(line)
 		if line == "" {
 			continue
 		}
-		return line, nil // first line = newest
+		ids = append(ids, line)
 	}
-	return "", nil
+	return ids, nil
 }
 
 func dockerTag(ctx context.Context, imageID, tag string) error {
@@ -170,16 +178,19 @@ func dockerTag(ctx context.Context, imageID, tag string) error {
 // `docker inspect`; we don't try to actually `docker run` the image
 // because that's expensive and we don't have arguments to test it
 // with.
+//
+// Uses {{len ...}} to compare numbers (0/0 = both empty) rather
+// than string-compare the formatted array — docker version drift
+// changes the printed representation but never the array length.
 func validateImageEntrypoint(ctx context.Context, tag string) error {
 	cmd := exec.CommandContext(ctx, "docker", "inspect",
-		"--format={{.Config.Entrypoint}}|{{.Config.Cmd}}", tag)
+		"--format={{len .Config.Entrypoint}}/{{len .Config.Cmd}}", tag)
 	out, err := cmd.Output()
 	if err != nil {
 		return fmt.Errorf("docker inspect %s: %w", tag, err)
 	}
 	got := strings.TrimSpace(string(out))
-	// "[]|[]" is what docker prints for entirely missing entrypoint + cmd.
-	if got == "[]|[]" || got == "|" {
+	if got == "0/0" {
 		return fmt.Errorf("image %s has neither ENTRYPOINT nor CMD", tag)
 	}
 	return nil
@@ -215,12 +226,15 @@ func readImageMetadata(cacheKey string) (*imageMetadata, error) {
 	return &meta, nil
 }
 
-// imageExistsLocally checks whether the named image ID is still
-// present in the host's docker storage. A `trond build prune` run
-// outside trond's purview, or `docker system prune`, can delete the
-// image; the bookkeeping JSON then points at nothing.
-func imageExistsLocally(ctx context.Context, imageID string) bool {
+// imageTagExistsLocally checks whether the docker tag is still
+// resolvable in the host's image store. We deliberately check tag
+// (not image ID): a `docker rmi <tag>` may detach the tag while the
+// underlying image stays alive via another tag, but compose's
+// `image: <tag>` field is what trond renders — so tag presence is
+// the authoritative signal. Tag-side check also catches the case
+// where the user retagged trond's image to something else.
+func imageTagExistsLocally(ctx context.Context, tag string) bool {
 	cmd := exec.CommandContext(ctx, "docker", "image", "inspect",
-		"--format={{.Id}}", imageID)
+		"--format={{.Id}}", tag)
 	return cmd.Run() == nil
 }

--- a/internal/build/image.go
+++ b/internal/build/image.go
@@ -51,9 +51,19 @@ func buildImage(ctx context.Context, r *resolved, started time.Time) (*Manifest,
 	}
 
 	// The wrapper script (dockerBuildScript_Image) snapshots image
-	// IDs before + after gradle into /out/new-image-ids, so we
-	// need /out mounted. outDir is the host path that's bound.
+	// IDs before + after gradle into <outDir>/<cache-key>-images-{before,after},
+	// so we need /out mounted. outDir is the host path that's bound.
 	outDir := filepath.Join(CacheDir(), "out")
+	// Defer cleanup of the per-cache-key snapshot files. readNewImageIDs
+	// also removes them on success, so this is the failure-path
+	// safety net — without it, a gradle crash between the two
+	// snapshot writes would leave orphan files in the shared out
+	// dir (eventually cleaned by Phase 5 prune, but defensible to
+	// clean inline too).
+	defer func() {
+		_ = os.Remove(filepath.Join(outDir, r.cacheKeyStr+"-images-before"))
+		_ = os.Remove(filepath.Join(outDir, r.cacheKeyStr+"-images-after"))
+	}()
 
 	if err := defaultRunner.RunDockerBuild(ctx, r, outDir, "" /* outTmp unused for image */); err != nil {
 		if errors.Is(ctx.Err(), context.Canceled) {
@@ -73,7 +83,7 @@ func buildImage(ctx context.Context, r *resolved, started time.Time) (*Manifest,
 	// image ID that gradle's task produced this run — no race with
 	// other host docker activity (gradle's `docker images` runs
 	// inside our serialized build window).
-	newImageIDs, err := readNewImageIDs(outDir)
+	newImageIDs, err := readNewImageIDs(outDir, r.cacheKeyStr)
 	if err != nil {
 		return nil, output.NewErrorf("BUILD_FAILED", output.ExitGeneralError,
 			"locate produced image: %s", err.Error())
@@ -95,6 +105,19 @@ func buildImage(ctx context.Context, r *resolved, started time.Time) (*Manifest,
 	if err := dockerTag(ctx, imageID, tag); err != nil {
 		return nil, output.NewErrorf("BUILD_FAILED", output.ExitGeneralError,
 			"docker tag %s %s: %s", imageID, tag, err.Error())
+	}
+	// Gradle's docker plugin sets its own tag(s) on the image
+	// (typically <group>/<name>:<version>, e.g.
+	// tronprotocol/java-tron:GreatVoyage-foo). Leaving those in
+	// place shadows the upstream namespace in `docker images` and
+	// confuses operators debugging deploys — the H block on user-
+	// supplied image_tag already addresses this for trond's own
+	// tagging; we extend it to gradle-side tags here. Best-effort:
+	// removal failure isn't fatal (we just leave the dangling alias).
+	if err := stripExtraTags(ctx, imageID, tag); err != nil {
+		fmt.Fprintf(os.Stderr,
+			"warning: could not strip gradle's auto-generated tags from %s: %v\n",
+			imageID, err)
 	}
 
 	if err := validateImageEntrypoint(ctx, tag); err != nil {
@@ -136,23 +159,45 @@ func buildImage(ctx context.Context, r *resolved, started time.Time) (*Manifest,
 	return manifest, nil
 }
 
-// readNewImageIDs returns the image IDs the wrapper script
-// recorded as newly created during the gradle run.
+// readNewImageIDs computes the (after \ before) diff of TAGGED
+// image IDs produced during the gradle run. The wrapper script
+// snapshots both sets into per-cache-key files
+// `/out/<key>-images-{before,after}`; the diff itself runs here so
+// the logic is unit-testable (computeNewImages) without needing a
+// real container.
 //
-// The wrapper computes (after \ before) of `docker images -q
-// --no-trunc | sort -u` and writes the result to
-// /out/new-image-ids. Because both snapshots happen inside the
-// builder's serialized window (FR-015 flock), the diff is robust
-// against the user's other host docker activity.
-//
-// Empty file = gradle ran but produced no image. Returns the IDs
-// in the order docker reported them (typically by creation time
-// thanks to sort order on hashes — not strictly, but stable enough
-// for our needs since the build is gated to one image producer).
-func readNewImageIDs(outDir string) ([]string, error) {
-	data, err := os.ReadFile(filepath.Join(outDir, "new-image-ids"))
+// Returns an empty slice when gradle ran but produced no new
+// tagged image (the wrapper uses `--filter dangling=false`, so
+// multi-stage Dockerfile intermediates are already excluded). The
+// per-cache-key snapshot files are removed after a successful
+// read so the cache dir doesn't accumulate them across runs.
+func readNewImageIDs(outDir, cacheKey string) ([]string, error) {
+	beforePath := filepath.Join(outDir, cacheKey+"-images-before")
+	afterPath := filepath.Join(outDir, cacheKey+"-images-after")
+
+	before, err := readSnapshot(beforePath)
 	if err != nil {
-		return nil, fmt.Errorf("read new-image-ids: %w", err)
+		return nil, fmt.Errorf("read before snapshot: %w", err)
+	}
+	after, err := readSnapshot(afterPath)
+	if err != nil {
+		return nil, fmt.Errorf("read after snapshot: %w", err)
+	}
+
+	// Best-effort cleanup. Leaving them around is harmless except
+	// for disk noise; future runs overwrite via the wrapper.
+	_ = os.Remove(beforePath)
+	_ = os.Remove(afterPath)
+
+	return computeNewImages(before, after), nil
+}
+
+// readSnapshot parses one line-per-image-id file produced by the
+// wrapper script. Trims whitespace; skips blanks.
+func readSnapshot(path string) ([]string, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
 	}
 	var ids []string
 	for line := range strings.SplitSeq(string(data), "\n") {
@@ -165,12 +210,90 @@ func readNewImageIDs(outDir string) ([]string, error) {
 	return ids, nil
 }
 
+// computeNewImages returns the entries in `after` that are not in
+// `before`. Order preserves `after`'s original order so downstream
+// callers can rely on positional invariants. Unit-tested for the
+// multi-stage Dockerfile case where intermediate layers would
+// otherwise confuse the picker.
+func computeNewImages(before, after []string) []string {
+	seen := make(map[string]bool, len(before))
+	for _, id := range before {
+		seen[id] = true
+	}
+	var diff []string
+	for _, id := range after {
+		if !seen[id] {
+			diff = append(diff, id)
+		}
+	}
+	return diff
+}
+
 func dockerTag(ctx context.Context, imageID, tag string) error {
 	cmd := exec.CommandContext(ctx, "docker", "tag", imageID, tag)
 	if out, err := cmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("%w: %s", err, strings.TrimSpace(string(out)))
 	}
 	return nil
+}
+
+// stripExtraTags removes every tag on imageID except keepTag. Used
+// to clean up gradle's auto-generated tag(s) (e.g.
+// tronprotocol/java-tron:GreatVoyage-foo) after trond re-tags with
+// the user's build.image_tag. We `docker image rm <tag>` rather
+// than `docker rmi <id>` — the underlying image layers stay alive
+// on the kept tag, only the auto-generated aliases get removed.
+//
+// Returns the first removal error encountered; the manifest /
+// trond cache is unaffected either way.
+//
+// `<none>` aliases (dangling tags from a botched gradle plugin) are
+// skipped via a substring check rather than equality with the
+// historical `<none>:<none>` literal — docker version drift
+// occasionally changes the print format and we'd rather skip a
+// few stray dangling entries than wrongly try to `docker image rm
+// "<none>"`.
+func stripExtraTags(ctx context.Context, imageID, keepTag string) error {
+	tags, err := imageTags(ctx, imageID)
+	if err != nil {
+		return err
+	}
+	for _, t := range tags {
+		if t == keepTag || strings.Contains(t, "<none>") {
+			continue
+		}
+		// `docker image rm <tag>` decrements the tag's ref count;
+		// when that tag has no other references the alias is
+		// dropped, and only when the LAST tag is removed does the
+		// underlying image actually get GC'd. Since keepTag still
+		// references the image, this only strips aliases.
+		cmd := exec.CommandContext(ctx, "docker", "image", "rm", t)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			return fmt.Errorf("untag %s: %w: %s", t, err, strings.TrimSpace(string(out)))
+		}
+	}
+	return nil
+}
+
+// imageTags returns all repo:tag strings currently aliasing the
+// given image ID. Used by stripExtraTags.
+func imageTags(ctx context.Context, imageID string) ([]string, error) {
+	// docker inspect --format with range emits one tag per line.
+	cmd := exec.CommandContext(ctx, "docker", "inspect",
+		"--format={{range .RepoTags}}{{.}}\n{{end}}", imageID)
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("docker inspect %s: %w", imageID, err)
+	}
+	var tags []string
+	for line := range strings.SplitSeq(string(out), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		tags = append(tags, line)
+	}
+	return tags, nil
 }
 
 // validateImageEntrypoint asserts the image has a non-empty

--- a/internal/build/image_diff_test.go
+++ b/internal/build/image_diff_test.go
@@ -1,0 +1,148 @@
+package build
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+// TestComputeNewImages covers the host-side diff that replaced the
+// in-container `comm -13` step (review pass 2 fix D). It's the
+// single piece of logic between "wrapper script wrote two
+// snapshots" and "trond picks the produced image tag" — every
+// downstream behaviour in buildImage depends on it being right.
+func TestComputeNewImages(t *testing.T) {
+	cases := []struct {
+		name   string
+		before []string
+		after  []string
+		want   []string
+	}{
+		{
+			name:   "empty before, one new",
+			before: []string{},
+			after:  []string{"sha256:abc"},
+			want:   []string{"sha256:abc"},
+		},
+		{
+			name:   "no change",
+			before: []string{"sha256:abc"},
+			after:  []string{"sha256:abc"},
+			want:   nil,
+		},
+		{
+			name:   "one added, one preserved",
+			before: []string{"sha256:abc"},
+			after:  []string{"sha256:abc", "sha256:def"},
+			want:   []string{"sha256:def"},
+		},
+		{
+			name:   "preserves after-order, drops dupes",
+			before: []string{"sha256:abc", "sha256:xyz"},
+			after:  []string{"sha256:abc", "sha256:def", "sha256:ghi", "sha256:xyz"},
+			want:   []string{"sha256:def", "sha256:ghi"},
+		},
+		{
+			name:   "image removed AND added — diff only reports new",
+			before: []string{"sha256:abc", "sha256:def"},
+			after:  []string{"sha256:abc", "sha256:ghi"},
+			want:   []string{"sha256:ghi"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := computeNewImages(tc.before, tc.after)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("computeNewImages(%v, %v) = %v; want %v",
+					tc.before, tc.after, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestReadNewImageIDs_PerCacheKeyIsolation exercises the
+// regression-A fix: concurrent image builds with different cache
+// keys must not see each other's snapshot files. We simulate by
+// planting two distinct (before, after) pairs under different
+// per-cache-key filenames and asserting readNewImageIDs returns the
+// per-key diff.
+func TestReadNewImageIDs_PerCacheKeyIsolation(t *testing.T) {
+	outDir := t.TempDir()
+
+	keyA := "abc12345-deadbe"
+	keyB := "789xyzab-cafebe"
+
+	// Build A: empty before, one new id.
+	if err := os.WriteFile(filepath.Join(outDir, keyA+"-images-before"), []byte(""), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(outDir, keyA+"-images-after"), []byte("sha256:aaa\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	// Build B: completely different before/after.
+	if err := os.WriteFile(filepath.Join(outDir, keyB+"-images-before"), []byte("sha256:bbb\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(outDir, keyB+"-images-after"), []byte("sha256:bbb\nsha256:ccc\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	gotA, err := readNewImageIDs(outDir, keyA)
+	if err != nil {
+		t.Fatalf("read A: %v", err)
+	}
+	if !reflect.DeepEqual(gotA, []string{"sha256:aaa"}) {
+		t.Errorf("A: got %v; want [sha256:aaa]", gotA)
+	}
+
+	// After reading, A's snapshot files should be removed (cleanup).
+	if _, err := os.Stat(filepath.Join(outDir, keyA+"-images-before")); !os.IsNotExist(err) {
+		t.Errorf("A's before file should be cleaned up; stat err=%v", err)
+	}
+
+	// B's files are untouched — A's read mustn't have stomped them.
+	if _, err := os.Stat(filepath.Join(outDir, keyB+"-images-before")); err != nil {
+		t.Errorf("B's before file should still exist; stat err=%v", err)
+	}
+
+	gotB, err := readNewImageIDs(outDir, keyB)
+	if err != nil {
+		t.Fatalf("read B: %v", err)
+	}
+	if !reflect.DeepEqual(gotB, []string{"sha256:ccc"}) {
+		t.Errorf("B: got %v; want [sha256:ccc]", gotB)
+	}
+}
+
+// TestDockerBuildScript_Image_PinsSafety enforces the FR-022
+// argv-only contract for the image-build wrapper: no trond-side
+// field names interpolated into the script body. Mirrors the JAR
+// variant's TestDockerBuildScript_NoUserInputInterpolation.
+func TestDockerBuildScript_Image_PinsSafety(t *testing.T) {
+	forbidden := []string{
+		"$GRADLE_TASK", "${GRADLE_TASK",
+		"$GRADLE_ARGS", "${GRADLE_ARGS",
+		"$IMAGE_TAG", "${IMAGE_TAG",
+		"eval ", "exec ",
+	}
+	for _, f := range forbidden {
+		if strings.Contains(dockerBuildScript_Image, f) {
+			t.Errorf("dockerBuildScript_Image contains forbidden pattern %q", f)
+		}
+	}
+	// Required forms: $@ for gradle args, $CACHE_KEY for per-build
+	// snapshot path isolation, --filter dangling=false for the
+	// multi-stage-intermediate-layer exclusion fix.
+	for _, required := range []string{
+		`"$@"`,
+		"$CACHE_KEY",
+		"--filter dangling=false",
+	} {
+		if !strings.Contains(dockerBuildScript_Image, required) {
+			t.Errorf("dockerBuildScript_Image MUST contain %q", required)
+		}
+	}
+}

--- a/internal/build/imagetag.go
+++ b/internal/build/imagetag.go
@@ -3,6 +3,7 @@ package build
 import (
 	"fmt"
 	"regexp"
+	"strings"
 )
 
 // imageTagPattern is a pragmatic subset of Docker's reference format.
@@ -16,6 +17,22 @@ var imageTagPattern = regexp.MustCompile(
 	`^[a-z0-9]+(?:[._-][a-z0-9]+)*(?:/[a-z0-9]+(?:[._-][a-z0-9]+)*)*:[a-zA-Z0-9_][a-zA-Z0-9_.-]{0,127}$`,
 )
 
+// wellKnownTagPrefixes are reserved by upstream projects. Letting
+// trond tag a locally-built image as one of these would shadow the
+// real upstream image in the host's docker store — `docker images`
+// could no longer distinguish trond's artifact from the official
+// version, and an operator debugging a deploy would reasonably
+// assume the tag refers to the canonical bits.
+//
+// Keep the list short and focused on the upstream surfaces trond
+// genuinely interacts with (java-tron's official image, the builder
+// image, and docker hub's default-lib namespace).
+var wellKnownTagPrefixes = []string{
+	"tronprotocol/",    // upstream java-tron image
+	"eclipse-temurin/", // trond's pinned JDK builder image namespace
+	"library/",         // docker hub's default lib namespace
+}
+
 // ValidateImageTag enforces FR-005's image_tag check. Surface as
 // VALIDATION_ERROR via the caller.
 func ValidateImageTag(tag string) error {
@@ -24,6 +41,11 @@ func ValidateImageTag(tag string) error {
 	}
 	if !imageTagPattern.MatchString(tag) {
 		return fmt.Errorf("invalid image_tag %q: must match Docker reference format <repo>:<tag>", tag)
+	}
+	for _, prefix := range wellKnownTagPrefixes {
+		if strings.HasPrefix(tag, prefix) {
+			return fmt.Errorf("invalid image_tag %q: prefix %q is reserved for upstream images; pick a trond-specific namespace such as 'trond-build/...' or 'localhost/...'", tag, prefix)
+		}
 	}
 	return nil
 }

--- a/internal/build/integration_test.go
+++ b/internal/build/integration_test.go
@@ -73,6 +73,125 @@ func TestBuild_RealGradleEndToEnd(t *testing.T) {
 	}
 }
 
+// TestBuildImage_RealGradleEndToEnd is the Phase 3 happy-path
+// integration test. It exercises buildImage end-to-end against a
+// minimal Dockerfile-only source fixture, validating:
+//   - docker.sock-mounted gradle invocation actually produces an image
+//   - the before/after snapshot picks the right image (no
+//     intermediate dangling layers thanks to FR-019 dangling=false)
+//   - the user's build.image_tag is applied
+//   - gradle's auto-generated tags get stripped (stripExtraTags)
+//   - second run hits the cache by checking the tag still resolves
+func TestBuildImage_RealGradleEndToEnd(t *testing.T) {
+	if _, err := exec.LookPath("docker"); err != nil {
+		t.Skip("docker not available")
+	}
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	// The fixture's Dockerfile pulls busybox. Air-gapped or
+	// docker-hub-blocked hosts can't run this test; skip rather
+	// than fail.
+	if out, err := exec.Command("docker", "pull", "busybox:latest").CombinedOutput(); err != nil {
+		t.Skipf("cannot pull busybox (no network or registry blocked): %v\n%s", err, out)
+	}
+
+	repo := setupImageIntegrationRepo(t)
+	withTempBaseDir(t)
+
+	override := resolveBuilderImage(t, "eclipse-temurin:8-jdk-jammy")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+
+	tag := "trond-build-test/fixture:dev"
+	res, err := Run(ctx, Request{
+		SourcePath:           repo,
+		BuilderImageOverride: override,
+		ArtifactKind:         "image",
+		ImageTag:             tag,
+		GradleTask:           "dockerBuild",
+	})
+	if err != nil {
+		t.Fatalf("Run failed: %v", err)
+	}
+	if res.ImageTag != tag {
+		t.Errorf("ImageTag = %q; want %q", res.ImageTag, tag)
+	}
+	t.Cleanup(func() {
+		// Best-effort cleanup so this test doesn't leak images.
+		_ = exec.Command("docker", "image", "rm", "-f", tag).Run()
+	})
+
+	// Second run should hit the cache — tag still resolves in
+	// docker store, manifest still on disk.
+	res2, err := Run(ctx, Request{
+		SourcePath:           repo,
+		BuilderImageOverride: override,
+		ArtifactKind:         "image",
+		ImageTag:             tag,
+		GradleTask:           "dockerBuild",
+	})
+	if err != nil {
+		t.Fatalf("second Run: %v", err)
+	}
+	if !res2.CacheHit {
+		t.Error("identical inputs should produce a cache hit")
+	}
+}
+
+// setupImageIntegrationRepo writes a minimal gradle project that
+// runs `docker build` via a tiny inline Dockerfile. Output is a
+// runnable image (FROM scratch + ENTRYPOINT) so
+// validateImageEntrypoint passes.
+func setupImageIntegrationRepo(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+
+	files := map[string]string{
+		"settings.gradle": `rootProject.name = 'image-fixture'
+`,
+		"build.gradle": `plugins { id 'base' }
+task dockerBuild(type: Exec) {
+    workingDir projectDir
+    commandLine 'docker', 'build', '-t', 'image-fixture:built', '.'
+}
+`,
+		"Dockerfile": `FROM busybox:latest
+ENTRYPOINT ["echo", "trond-image-fixture"]
+`,
+	}
+	for rel, content := range files {
+		path := filepath.Join(dir, rel)
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", path, err)
+		}
+		if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+			t.Fatalf("write %s: %v", rel, err)
+		}
+	}
+	// gradle wrapper init if available locally — otherwise CI must
+	// have it preinstalled.
+	if _, err := exec.LookPath("gradle"); err == nil {
+		_, _ = exec.Command("gradle", "-p", dir, "wrapper", "--gradle-version=7.6").CombinedOutput()
+	}
+
+	for _, args := range [][]string{
+		{"init", "-q"},
+		{"config", "user.email", "image-test@trond"},
+		{"config", "user.name", "image"},
+		{"config", "commit.gpgsign", "false"},
+		{"add", "."},
+		{"commit", "-q", "-m", "fixture"},
+	} {
+		cmd := exec.Command("git", append([]string{"-C", dir}, args...)...)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+	return dir
+}
+
 // setupIntegrationRepo writes a minimal gradle project (tiny enough
 // that the test runs in well under a minute on a warm cache) that
 // produces a JAR whose Main-Class matches org.tron.program.FullNode.

--- a/internal/build/pins/builder_image_digests.json
+++ b/internal/build/pins/builder_image_digests.json
@@ -4,23 +4,19 @@
   "pins": {
     "8": {
       "ref": "eclipse-temurin:8-jdk-jammy",
-      "digest": "sha256:0000000000000000000000000000000000000000000000000000000000000000",
-      "$comment": "PLACEHOLDER — refresh via `make refresh-builder-pins` before first real build"
+      "digest": "sha256:f71b4cab6bfd7e6a9885ff38a58ea20ecd1300bea3955a3af465ebafa020a5b3"
     },
     "11": {
       "ref": "eclipse-temurin:11-jdk-jammy",
-      "digest": "sha256:0000000000000000000000000000000000000000000000000000000000000000",
-      "$comment": "PLACEHOLDER"
+      "digest": "sha256:32328038107fc34200f15c2ab3e8e7767e76db9c999101385b2cff3e12cd4f59"
     },
     "17": {
       "ref": "eclipse-temurin:17-jdk-jammy",
-      "digest": "sha256:0000000000000000000000000000000000000000000000000000000000000000",
-      "$comment": "PLACEHOLDER"
+      "digest": "sha256:beabb759e6f9653c843958d1d1f5cecb881dfb85aa6081e2bef099ab1260344e"
     },
     "21": {
       "ref": "eclipse-temurin:21-jdk-jammy",
-      "digest": "sha256:0000000000000000000000000000000000000000000000000000000000000000",
-      "$comment": "PLACEHOLDER"
+      "digest": "sha256:801b7e1a9c4befaf82bf9a2a58025ef43a7694bbc84779187ad0524d84742772"
     }
   }
 }

--- a/internal/build/pins/builder_image_digests.json
+++ b/internal/build/pins/builder_image_digests.json
@@ -1,22 +1,34 @@
 {
-  "$comment": "Pinned digests for builder images. Bumped per trond release via `make refresh-builder-pins`. Each entry resolves jdk_version -> reference (canonical name@sha256:...). Cache key (FR-002) incorporates the digest so pin bumps invalidate stale artifacts.",
-  "schema_version": "1.0.0",
+  "$comment": "Pinned per-platform digests for builder images. Bumped per trond release via `make refresh-builder-pins`. Each entry resolves (jdk_version, platform) → per-arch image digest (NOT the multi-arch manifest list digest — pinning that and combining with `docker run --platform X` fails with `cannot overwrite digest`). Cache key (FR-002) incorporates the digest so pin bumps invalidate stale artifacts.",
+  "schema_version": "2.0.0",
   "pins": {
     "8": {
       "ref": "eclipse-temurin:8-jdk-jammy",
-      "digest": "sha256:f71b4cab6bfd7e6a9885ff38a58ea20ecd1300bea3955a3af465ebafa020a5b3"
+      "platforms": {
+        "linux/amd64": "sha256:d0861e686aa44dcca542877aaedf7d276762cc5c85a072dfdf2391b7defc4f08",
+        "linux/arm64": "sha256:4fafd08ae76dd19018977ef5305645bb1890c37960c3960918808edc39639d68"
+      }
     },
     "11": {
       "ref": "eclipse-temurin:11-jdk-jammy",
-      "digest": "sha256:32328038107fc34200f15c2ab3e8e7767e76db9c999101385b2cff3e12cd4f59"
+      "platforms": {
+        "linux/amd64": "sha256:438387f7ae2612d0460e22810bd5083feece787affb9962d629ef19090a4fb99",
+        "linux/arm64": "sha256:8000ac16e6b8ce3fa02d908e7835780d74e238b84fd740cad3d384422be1bb16"
+      }
     },
     "17": {
       "ref": "eclipse-temurin:17-jdk-jammy",
-      "digest": "sha256:beabb759e6f9653c843958d1d1f5cecb881dfb85aa6081e2bef099ab1260344e"
+      "platforms": {
+        "linux/amd64": "sha256:004fc99f69bf9179d055d24b1b779e68d6d807fd7b4e23654d3a2aa82c397894",
+        "linux/arm64": "sha256:23300419b10ee0f16ce5afdf42ed4480fbcc1ec8cc280dd459f57c0654cee274"
+      }
     },
     "21": {
       "ref": "eclipse-temurin:21-jdk-jammy",
-      "digest": "sha256:801b7e1a9c4befaf82bf9a2a58025ef43a7694bbc84779187ad0524d84742772"
+      "platforms": {
+        "linux/amd64": "sha256:3de48ab8a55f9a8503a7add21387c31b29f14030895292dd648f0b9353a4091d",
+        "linux/arm64": "sha256:ce99a60f0c16989c7fb83ae4e7bdae870ff7575f9f7e573993776450aed50e1b"
+      }
     }
   }
 }

--- a/internal/build/pins/pins.go
+++ b/internal/build/pins/pins.go
@@ -5,6 +5,16 @@
 // Bump policy: a Makefile target `refresh-builder-pins` re-resolves
 // Eclipse Temurin tags to current digests and rewrites the JSON. The
 // regeneration happens at trond release-prep time, not at runtime.
+//
+// Schema: per-platform digests, not manifest-list digests.
+// Eclipse Temurin's `:8-jdk-jammy` is a multi-arch manifest list;
+// `docker pull` on a tag resolves to the host's arch variant
+// automatically. But trond needs to support cross-arch
+// (`--platform linux/amd64` on an arm64 host), and docker rejects
+// `docker run --platform X image@<manifest-list-digest>` with
+// "cannot overwrite digest" — the manifest list digest doesn't
+// match the per-arch image we'd actually run. So we pin the
+// PER-PLATFORM digest, queryable via `docker manifest inspect`.
 package pins
 
 import (
@@ -16,11 +26,12 @@ import (
 //go:embed builder_image_digests.json
 var embeddedJSON []byte
 
-// PinEntry is one row in the pin file — the ref name plus the
-// content-addressed digest. The cache key (FR-002) consumes Digest.
+// PinEntry is one row in the pin file. Ref is the canonical tag
+// (e.g. `eclipse-temurin:8-jdk-jammy`); Platforms maps docker
+// `--platform` strings to the per-arch image digest at that tag.
 type PinEntry struct {
-	Ref    string `json:"ref"`
-	Digest string `json:"digest"`
+	Ref       string            `json:"ref"`
+	Platforms map[string]string `json:"platforms"`
 }
 
 type pinFile struct {
@@ -40,28 +51,31 @@ var parsed = func() pinFile {
 
 // Resolve returns the canonical image reference (e.g.
 // `eclipse-temurin:8-jdk-jammy@sha256:abc...`) for a given JDK
-// version string ("8", "11", "17", "21"). Returns
-// (ref, digest, true) on hit. Caller threads the digest into the
-// cache key.
+// version + docker platform. Returns (ref, digest, true) on hit;
+// the digest is the per-arch image digest that docker actually
+// stores locally — so `docker run image@digest` works without the
+// "cannot overwrite digest" issue you'd hit with a manifest-list
+// digest.
 //
 // If override is non-empty, it replaces the entire ref. The override
 // path is documented in AGENTS.md as an escape hatch (FR-024) and
 // participates in the cache key so pinned and overridden builds don't
 // collide.
-func Resolve(jdkVersion string, override string) (ref string, digest string, ok bool) {
+func Resolve(jdkVersion, platform, override string) (ref string, digest string, ok bool) {
 	if override != "" {
-		// Override must already include the digest portion. Caller is
-		// responsible for that — pins.go just lets it through. The
-		// "digest" reported back to the cache key is the override
-		// itself, so any bump in the override automatically changes
-		// the cache key.
+		// Override is reported as the cache digest verbatim so any
+		// bump in the override automatically changes the cache key.
 		return override, override, true
 	}
 	entry, hit := parsed.Pins[jdkVersion]
 	if !hit {
 		return "", "", false
 	}
-	return fmt.Sprintf("%s@%s", entry.Ref, entry.Digest), entry.Digest, true
+	d, hit := entry.Platforms[platform]
+	if !hit {
+		return "", "", false
+	}
+	return fmt.Sprintf("%s@%s", entry.Ref, d), d, true
 }
 
 // Versions returns the list of JDK versions for which a pin exists,
@@ -70,6 +84,21 @@ func Versions() []string {
 	out := make([]string, 0, len(parsed.Pins))
 	for v := range parsed.Pins {
 		out = append(out, v)
+	}
+	return out
+}
+
+// Platforms returns the docker platform strings for which a pin
+// exists under the given JDK version, used for diagnostic surfaces
+// when Resolve misses on the platform side.
+func Platforms(jdkVersion string) []string {
+	entry, hit := parsed.Pins[jdkVersion]
+	if !hit {
+		return nil
+	}
+	out := make([]string, 0, len(entry.Platforms))
+	for p := range entry.Platforms {
+		out = append(out, p)
 	}
 	return out
 }

--- a/internal/build/pins/pins_test.go
+++ b/internal/build/pins/pins_test.go
@@ -5,13 +5,13 @@ import (
 	"testing"
 )
 
-// TestResolve_PinnedHit asserts a known JDK version resolves to a
+// TestResolve_PinnedHit asserts a known JDK + platform resolves to a
 // canonical `<ref>@<digest>` and reports the digest separately for
 // cache-key inclusion (FR-002).
 func TestResolve_PinnedHit(t *testing.T) {
-	ref, digest, ok := Resolve("8", "")
+	ref, digest, ok := Resolve("8", "linux/amd64", "")
 	if !ok {
-		t.Fatal("expected JDK 8 pin to exist; got miss")
+		t.Fatal("expected JDK 8 + linux/amd64 pin to exist; got miss")
 	}
 	if !strings.Contains(ref, "@sha256:") {
 		t.Errorf("ref %q must include @sha256: portion (canonical form)", ref)
@@ -21,12 +21,39 @@ func TestResolve_PinnedHit(t *testing.T) {
 	}
 }
 
+// TestResolve_PerPlatformDigests asserts the same JDK pin returns
+// DIFFERENT digests for different platforms — this is the whole
+// point of the per-platform schema. Same digest for both would
+// mean we accidentally stored the manifest-list digest, which
+// would re-introduce the `docker run --platform X image@<list>`
+// "cannot overwrite digest" bug.
+func TestResolve_PerPlatformDigests(t *testing.T) {
+	_, amdDigest, amdOK := Resolve("8", "linux/amd64", "")
+	_, armDigest, armOK := Resolve("8", "linux/arm64", "")
+	if !amdOK || !armOK {
+		t.Skip("pin file missing one platform variant; skip")
+	}
+	if amdDigest == armDigest {
+		t.Errorf("amd64 and arm64 digests must differ; both = %q", amdDigest)
+	}
+}
+
 // TestResolve_UnknownJDK asserts an unsupported JDK version reports
 // a miss rather than a fallback.
 func TestResolve_UnknownJDK(t *testing.T) {
-	_, _, ok := Resolve("99", "")
+	_, _, ok := Resolve("99", "linux/amd64", "")
 	if ok {
 		t.Error("expected JDK 99 to be unknown; got hit")
+	}
+}
+
+// TestResolve_UnknownPlatform asserts a known JDK + unknown platform
+// is also a miss — without this, future platform additions
+// (windows/amd64, etc.) wouldn't surface as a clear validation error.
+func TestResolve_UnknownPlatform(t *testing.T) {
+	_, _, ok := Resolve("8", "windows/amd64", "")
+	if ok {
+		t.Error("expected unknown platform to miss; got hit")
 	}
 }
 
@@ -35,7 +62,7 @@ func TestResolve_UnknownJDK(t *testing.T) {
 // in override participate in the cache key.
 func TestResolve_Override(t *testing.T) {
 	override := "myregistry.example/temurin:8-jdk@sha256:" + strings.Repeat("a", 64)
-	ref, digest, ok := Resolve("8", override)
+	ref, digest, ok := Resolve("8", "linux/amd64", override)
 	if !ok {
 		t.Fatal("expected override to be accepted")
 	}
@@ -65,5 +92,19 @@ func TestVersions(t *testing.T) {
 	}
 	if !hit {
 		t.Errorf("expected at least one of %v in pin versions; got %v", wantAny, got)
+	}
+}
+
+// TestPlatforms returns the supported platforms for a JDK version.
+// Both linux/amd64 and linux/arm64 must be present (java-tron's
+// compat matrix relies on the pair).
+func TestPlatforms(t *testing.T) {
+	got := Platforms("8")
+	want := map[string]bool{"linux/amd64": true, "linux/arm64": true}
+	for _, p := range got {
+		delete(want, p)
+	}
+	if len(want) != 0 {
+		t.Errorf("missing platforms: %v (got %v)", want, got)
 	}
 }

--- a/internal/build/runner.go
+++ b/internal/build/runner.go
@@ -24,12 +24,13 @@ type dockerRunner interface {
 // realDockerRunner which shells out to the docker CLI.
 var defaultRunner dockerRunner = realDockerRunner{}
 
-// dockerBuildScript is the only piece of shell trond runs and it's
-// a compile-time constant. User input (gradle_task, gradle_args)
-// arrives through `"$@"` argv expansion AFTER `--`; output filename
-// arrives through an env var. Both channels are shell-quote-safe
-// independent of their contents. FR-022 holds: no path from user
-// input to shell metacharacter interpretation.
+// dockerBuildScript (JAR variant) is the only piece of shell trond
+// runs for artifact=jar and it's a compile-time constant. User input
+// (gradle_task, gradle_args) arrives through `"$@"` argv expansion
+// AFTER `--`; output filename arrives through an env var. Both
+// channels are shell-quote-safe independent of their contents.
+// FR-022 holds: no path from user input to shell metacharacter
+// interpretation.
 //
 // Why bash and not argv? Because the build produces files inside the
 // container's /src tree (gradle writes to build/libs/*.jar) and we
@@ -52,6 +53,21 @@ fi
 cp "$JAR" "/out/$OUT_NAME"
 `
 
+// dockerBuildScript_Image is the image-artifact variant. No file
+// copy step — gradle's docker plugin tags the produced image
+// directly into the host's docker daemon (which we expose by
+// bind-mounting /var/run/docker.sock into the container; see the
+// runner setup below). The post-build step that picks up the new
+// image ID lives in image.go::mostRecentlyCreatedImage on the host
+// side, NOT in this script.
+//
+// Same FR-022 invariant: user input flows through `"$@"`, no
+// interpolation. No OUT_NAME — the host side handles tagging.
+const dockerBuildScript_Image = `set -e
+cd /src
+./gradlew "$@"
+`
+
 type realDockerRunner struct{}
 
 func (realDockerRunner) RunDockerBuild(ctx context.Context, r *resolved, outDir, outTmp string) error {
@@ -68,12 +84,29 @@ func (realDockerRunner) RunDockerBuild(ctx context.Context, r *resolved, outDir,
 		// The user already gives gradle this access locally.
 		"-v", r.src.Path + ":/src:rw",
 		"-v", gradleCache + ":/root/.gradle",
-		"-v", outDir + ":/out:rw",
 		"--workdir", "/src",
-		// Output filename passed through env, not interpolated into
-		// the script (FR-022 defense in depth).
-		"-e", "OUT_NAME=" + filepath.Base(outTmp),
 	}
+
+	// Artifact-kind specific volume + env setup.
+	//
+	//   jar:   mount /out for the JAR copy step; thread $OUT_NAME so
+	//          the script knows what filename to drop in /out.
+	//   image: mount the host's docker socket into the builder
+	//          container so gradle's docker plugin can call back into
+	//          the host daemon to build + tag an image. No /out mount
+	//          needed — the image lives in the host's docker store
+	//          and host-side bookkeeping (image.go) records the tag
+	//          + ID via `docker inspect`.
+	switch r.req.ArtifactKind {
+	case "image":
+		args = append(args,
+			"-v", "/var/run/docker.sock:/var/run/docker.sock")
+	default:
+		args = append(args,
+			"-v", outDir+":/out:rw",
+			"-e", "OUT_NAME="+filepath.Base(outTmp))
+	}
+
 	// --platform routes to the matching variant of the multi-arch
 	// builder image. On a cross-arch combination docker uses QEMU
 	// emulation (binfmt-misc); 3-5× slower but functional. Required
@@ -84,7 +117,12 @@ func (realDockerRunner) RunDockerBuild(ctx context.Context, r *resolved, outDir,
 	for _, e := range allowedEnvPassthrough(r.req.Env) {
 		args = append(args, "-e", e)
 	}
-	args = append(args, r.imageRef, "bash", "-c", dockerBuildScript, "--")
+
+	script := dockerBuildScript
+	if r.req.ArtifactKind == "image" {
+		script = dockerBuildScript_Image
+	}
+	args = append(args, r.imageRef, "bash", "-c", script, "--")
 	args = append(args, r.req.GradleTask)
 	args = append(args, r.req.GradleArgs...)
 

--- a/internal/build/runner.go
+++ b/internal/build/runner.go
@@ -53,19 +53,25 @@ fi
 cp "$JAR" "/out/$OUT_NAME"
 `
 
-// dockerBuildScript_Image is the image-artifact variant. No file
-// copy step — gradle's docker plugin tags the produced image
-// directly into the host's docker daemon (which we expose by
-// bind-mounting /var/run/docker.sock into the container; see the
-// runner setup below). The post-build step that picks up the new
-// image ID lives in image.go::mostRecentlyCreatedImage on the host
-// side, NOT in this script.
+// dockerBuildScript_Image is the image-artifact variant. The
+// gradle docker plugin tags the produced image directly into the
+// host's docker daemon (we bind-mount /var/run/docker.sock; see the
+// runner setup below).
 //
-// Same FR-022 invariant: user input flows through `"$@"`, no
-// interpolation. No OUT_NAME — the host side handles tagging.
+// To robustly identify which image gradle just created — without
+// racing other docker activity on the host — we snapshot the set
+// of image IDs before AND after, then write the diff (newly-created
+// IDs) to /out/new-image-ids. The host-side image.go reads that
+// file rather than guessing via "most recently created".
+//
+// Same FR-022 invariant: gradle args flow through "$@", no
+// interpolation of trond-side fields.
 const dockerBuildScript_Image = `set -e
 cd /src
+docker images -q --no-trunc 2>/dev/null | sort -u > /out/images-before
 ./gradlew "$@"
+docker images -q --no-trunc 2>/dev/null | sort -u > /out/images-after
+comm -13 /out/images-before /out/images-after > /out/new-image-ids
 `
 
 type realDockerRunner struct{}
@@ -89,22 +95,22 @@ func (realDockerRunner) RunDockerBuild(ctx context.Context, r *resolved, outDir,
 
 	// Artifact-kind specific volume + env setup.
 	//
-	//   jar:   mount /out for the JAR copy step; thread $OUT_NAME so
-	//          the script knows what filename to drop in /out.
-	//   image: mount the host's docker socket into the builder
-	//          container so gradle's docker plugin can call back into
-	//          the host daemon to build + tag an image. No /out mount
-	//          needed — the image lives in the host's docker store
-	//          and host-side bookkeeping (image.go) records the tag
-	//          + ID via `docker inspect`.
+	//   jar:   /out holds the produced JAR; $OUT_NAME tells the
+	//          script what filename to drop in /out.
+	//   image: /var/run/docker.sock mounted into the builder so
+	//          gradle's docker plugin can call back into the host
+	//          daemon to build + tag an image. We ALSO mount /out
+	//          because the build-around snapshot script
+	//          (dockerBuildScript_Image) writes the
+	//          before/after image-id diff there for the host side
+	//          to read.
+	args = append(args, "-v", outDir+":/out:rw")
 	switch r.req.ArtifactKind {
 	case "image":
 		args = append(args,
 			"-v", "/var/run/docker.sock:/var/run/docker.sock")
 	default:
-		args = append(args,
-			"-v", outDir+":/out:rw",
-			"-e", "OUT_NAME="+filepath.Base(outTmp))
+		args = append(args, "-e", "OUT_NAME="+filepath.Base(outTmp))
 	}
 
 	// --platform routes to the matching variant of the multi-arch

--- a/internal/build/runner.go
+++ b/internal/build/runner.go
@@ -45,9 +45,15 @@ var defaultRunner dockerRunner = realDockerRunner{}
 const dockerBuildScript = `set -e
 cd /src
 ./gradlew "$@"
-JAR=$(ls -S build/libs/*.jar 2>/dev/null | head -n1)
+# Search every */build/libs/*.jar (root project + every subproject)
+# because multi-module gradle builds put the fat JAR under a
+# specific submodule (e.g. java-tron's :framework:buildFullNodeJar
+# emits to framework/build/libs/FullNode.jar, NOT to the root's
+# build/libs/). Sort by size descending so we pick the fat JAR
+# rather than a thin module jar of the same gradle task.
+JAR=$(find . -path '*/build/libs/*.jar' -type f 2>/dev/null | xargs ls -S 2>/dev/null | head -n1)
 if [ -z "$JAR" ]; then
-  echo "trond: gradle produced no .jar in build/libs/" >&2
+  echo "trond: gradle produced no .jar under any build/libs/" >&2
   exit 64
 fi
 cp "$JAR" "/out/$OUT_NAME"
@@ -85,7 +91,18 @@ func (realDockerRunner) RunDockerBuild(ctx context.Context, r *resolved, outDir,
 		return fmt.Errorf("--builder host not implemented in Phase 1 (use docker)")
 	}
 
-	gradleCache := filepath.Join(CacheDir(), "gradle")
+	// Gradle cache: use a DOCKER NAMED VOLUME, not a bind mount.
+	// macOS Docker Desktop's bind-mount layer (virtiofs) doesn't
+	// reliably preserve the exec bit for files the container writes
+	// to host paths. Gradle's protobuf plugin downloads native
+	// `protoc-*.exe` binaries into the cache; via bind mount they
+	// arrive on the host without `+x`, then the next gradle run
+	// (or a sub-task in the same run) sees them as non-executable
+	// and bails with EACCES. A named volume lives inside Docker's
+	// VM and preserves modes natively. The cache is still
+	// per-trond-state-dir-scoped via a volume label so concurrent
+	// trond invocations on different state dirs don't collide.
+	const gradleVolume = "trond-build-gradle-cache"
 
 	args := []string{
 		"run", "--rm",
@@ -93,7 +110,7 @@ func (realDockerRunner) RunDockerBuild(ctx context.Context, r *resolved, outDir,
 		// the project tree (same as running ./gradlew on the host).
 		// The user already gives gradle this access locally.
 		"-v", r.src.Path + ":/src:rw",
-		"-v", gradleCache + ":/root/.gradle",
+		"-v", gradleVolume + ":/root/.gradle",
 		"--workdir", "/src",
 	}
 

--- a/internal/build/runner.go
+++ b/internal/build/runner.go
@@ -60,18 +60,22 @@ cp "$JAR" "/out/$OUT_NAME"
 //
 // To robustly identify which image gradle just created — without
 // racing other docker activity on the host — we snapshot the set
-// of image IDs before AND after, then write the diff (newly-created
-// IDs) to /out/new-image-ids. The host-side image.go reads that
-// file rather than guessing via "most recently created".
+// of TAGGED image IDs (dangling=false filters out multi-stage
+// intermediate layers) before AND after the build, into
+// per-cache-key files so concurrent builds on different keys can't
+// clobber each other. The diff itself runs host-side in
+// computeNewImages (image.go) so it's unit-testable and doesn't
+// depend on GNU comm.
 //
 // Same FR-022 invariant: gradle args flow through "$@", no
-// interpolation of trond-side fields.
+// interpolation of trond-side fields. The cache key arrives via
+// $CACHE_KEY env (allowlisted to safe characters by FR-002's
+// content-addressed naming scheme).
 const dockerBuildScript_Image = `set -e
 cd /src
-docker images -q --no-trunc 2>/dev/null | sort -u > /out/images-before
+docker images -q --no-trunc --filter dangling=false 2>/dev/null | sort -u > "/out/$CACHE_KEY-images-before"
 ./gradlew "$@"
-docker images -q --no-trunc 2>/dev/null | sort -u > /out/images-after
-comm -13 /out/images-before /out/images-after > /out/new-image-ids
+docker images -q --no-trunc --filter dangling=false 2>/dev/null | sort -u > "/out/$CACHE_KEY-images-after"
 `
 
 type realDockerRunner struct{}
@@ -108,7 +112,11 @@ func (realDockerRunner) RunDockerBuild(ctx context.Context, r *resolved, outDir,
 	switch r.req.ArtifactKind {
 	case "image":
 		args = append(args,
-			"-v", "/var/run/docker.sock:/var/run/docker.sock")
+			"-v", "/var/run/docker.sock:/var/run/docker.sock",
+			// Per-cache-key snapshot file names so concurrent builds
+			// on different keys can't clobber each other's
+			// before/after files in the shared /out dir.
+			"-e", "CACHE_KEY="+r.cacheKeyStr)
 	default:
 		args = append(args, "-e", "OUT_NAME="+filepath.Base(outTmp))
 	}

--- a/internal/build/validate_test.go
+++ b/internal/build/validate_test.go
@@ -103,6 +103,32 @@ func TestValidateEnvKey(t *testing.T) {
 	}
 }
 
+// TestValidateImageTag_RejectsWellKnownPrefix is the Phase 3
+// review pass 1 regression guard. Letting the user tag a locally-
+// built image as `tronprotocol/java-tron:...` would silently shadow
+// the upstream image in the host's docker store — operators
+// debugging deploys would see a tag they recognize and reasonably
+// assume it's the canonical bits.
+func TestValidateImageTag_RejectsWellKnownPrefix(t *testing.T) {
+	cases := []string{
+		"tronprotocol/java-tron:foo",
+		"tronprotocol/whatever:bar",
+		"eclipse-temurin/something:8-jdk",
+		"library/something:bar",
+	}
+	for _, tag := range cases {
+		t.Run(tag, func(t *testing.T) {
+			err := ValidateImageTag(tag)
+			if err == nil {
+				t.Fatal("expected rejection of well-known prefix")
+			}
+			if !strings.Contains(err.Error(), "reserved") {
+				t.Errorf("error %q should mention 'reserved'", err)
+			}
+		})
+	}
+}
+
 func TestValidateImageTag(t *testing.T) {
 	tests := []struct {
 		tag  string

--- a/internal/intent/build_test.go
+++ b/internal/intent/build_test.go
@@ -330,6 +330,64 @@ nodes:
 	}
 }
 
+// TestParse_BuildDockerImageNowAccepted is the Phase 3 unlock
+// regression guard. Phase 2 rejected `runtime: docker +
+// artifact: image` because the compose render path didn't know
+// about locally-built images. Phase 3 wires it in: the same intent
+// must now parse + validate cleanly.
+func TestParse_BuildDockerImageNowAccepted(t *testing.T) {
+	data := []byte(`
+name: dev-fullnode
+network: nile
+target:
+  type: local
+  runtime: docker
+nodes:
+  - type: fullnode
+    build:
+      source: /tmp/java-tron
+      artifact: image
+      image_tag: trond-build:dev
+`)
+	i, err := Parse(data)
+	if err != nil {
+		t.Fatalf("Parse should now accept docker+image: %v", err)
+	}
+	if i.Target.Runtime != "docker" {
+		t.Errorf("Target.Runtime = %q; want docker (explicit)", i.Target.Runtime)
+	}
+	if i.Nodes[0].Build.Artifact != "image" {
+		t.Errorf("Build.Artifact = %q; want image", i.Nodes[0].Build.Artifact)
+	}
+}
+
+// TestParse_BuildImageArtifactDefaultsRuntimeToDocker is the
+// inverse of TestParse_BuildDefaultsRuntimeToJar: when the user
+// declares artifact=image without an explicit target.runtime, the
+// runtime MUST default to docker (the artifact's only consumer).
+func TestParse_BuildImageArtifactDefaultsRuntimeToDocker(t *testing.T) {
+	data := []byte(`
+name: dev-fullnode
+network: nile
+target:
+  type: local
+nodes:
+  - type: fullnode
+    build:
+      source: /tmp/java-tron
+      artifact: image
+      image_tag: trond-build:dev
+`)
+	i, err := Parse(data)
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if i.Target.Runtime != "docker" {
+		t.Errorf("Target.Runtime default = %q; want docker (artifact=image)",
+			i.Target.Runtime)
+	}
+}
+
 // TestParse_BuildInvalidJDK pins the validator-tag enum.
 func TestParse_BuildInvalidJDK(t *testing.T) {
 	data := []byte(`

--- a/internal/intent/build_test.go
+++ b/internal/intent/build_test.go
@@ -388,6 +388,67 @@ nodes:
 	}
 }
 
+// TestParse_BuildImageRejectsCrossArchPlatform is the Phase 3
+// review pass 1 regression guard for the most-dangerous Phase 3
+// combo: artifact=image with a platform that differs from the host's
+// arch. The docker.sock-mounted builder can't actually produce a
+// cross-arch image (host daemon wins); silently accepting it would
+// cache an amd64 image under an arm64 cache key (or vice versa)
+// and deploy the wrong arch to the target server.
+func TestParse_BuildImageRejectsCrossArchPlatform(t *testing.T) {
+	host := DefaultPlatform()
+	var crossArch string
+	if host == "linux/arm64" {
+		crossArch = "linux/amd64"
+	} else {
+		crossArch = "linux/arm64"
+	}
+	data := []byte(`
+name: bad-cross
+network: nile
+target:
+  type: local
+nodes:
+  - type: fullnode
+    build:
+      source: /tmp/java-tron
+      artifact: image
+      image_tag: trond-build:dev
+      platform: ` + crossArch + `
+`)
+	_, err := Parse(data)
+	if err == nil {
+		t.Fatalf("expected rejection of artifact=image + platform=%q on host=%q",
+			crossArch, host)
+	}
+	if !strings.Contains(err.Error(), "unsafe") {
+		t.Errorf("error %q should explain the cross-arch hazard", err)
+	}
+}
+
+// TestParse_BuildImageAcceptsHostArchPlatform: same combo but
+// platform equals the host arch — the safe case — must still parse.
+func TestParse_BuildImageAcceptsHostArchPlatform(t *testing.T) {
+	host := DefaultPlatform()
+	data := []byte(`
+name: ok-same-arch
+network: nile
+target:
+  type: local
+  runtime: docker
+nodes:
+  - type: fullnode
+    build:
+      source: /tmp/java-tron
+      artifact: image
+      image_tag: trond-build:dev
+      platform: ` + host + `
+`)
+	if _, err := Parse(data); err != nil {
+		t.Fatalf("host-arch image build should parse: %v", err)
+	}
+}
+
 // TestParse_BuildInvalidJDK pins the validator-tag enum.
 func TestParse_BuildInvalidJDK(t *testing.T) {
 	data := []byte(`

--- a/internal/intent/defaults.go
+++ b/internal/intent/defaults.go
@@ -6,18 +6,6 @@ import (
 	"runtime"
 )
 
-// anyNodeHasBuild reports whether any node in the slice declares a
-// `build:` block. Used by DefaultRuntime to choose runtime=jar
-// when the intent is configuring an inner-loop build (Phase 2).
-func anyNodeHasBuild(nodes []NodeSpec) bool {
-	for i := range nodes {
-		if nodes[i].Build != nil {
-			return true
-		}
-	}
-	return false
-}
-
 // DefaultRuntime is the single source of truth for the runtime
 // default rule. ApplyDefaults uses it to fill intent.Target.Runtime;
 // intent.Validate uses it to derive the would-be effective runtime
@@ -25,12 +13,32 @@ func anyNodeHasBuild(nodes []NodeSpec) bool {
 // it as a last-resort fallback for programmatic callers that
 // bypass ApplyDefaults. Three sites, one rule.
 //
-// Rule: intents with any `build:` block default to "jar" (the only
-// Phase 2 wired path). Everything else stays on the legacy "docker"
-// default.
+// Rules (post-Phase 3):
+//
+//  1. Intents with a `build:` block default the runtime to match
+//     the build artifact:
+//     artifact: jar    → runtime: jar
+//     artifact: image  → runtime: docker
+//     (Artifact itself defaults to "jar" if unspecified — same as
+//     applyNodeDefaults — so a bare `build: { source: ... }` still
+//     ends up jar/jar.)
+//  2. Intents without any `build:` block keep the legacy "docker"
+//     default unchanged.
 func DefaultRuntime(intent *Intent) string {
-	if anyNodeHasBuild(intent.Nodes) {
-		return "jar"
+	for i := range intent.Nodes {
+		if intent.Nodes[i].Build == nil {
+			continue
+		}
+		artifact := intent.Nodes[i].Build.Artifact
+		if artifact == "" {
+			artifact = "jar"
+		}
+		switch artifact {
+		case "image":
+			return "docker"
+		default:
+			return "jar"
+		}
 	}
 	return "docker"
 }

--- a/internal/intent/loader.go
+++ b/internal/intent/loader.go
@@ -345,15 +345,9 @@ func Validate(intent *Intent) error {
 			}
 			switch {
 			case rt == "docker" && artifact == "jar":
-				return fmt.Errorf("nodes[%d]: target.runtime=docker requires build.artifact=image (Phase 3 work); set target.runtime=jar or omit it (build intents default to jar)", i)
+				return fmt.Errorf("nodes[%d]: target.runtime=docker cannot consume build.artifact=jar — set build.artifact=image (the docker runtime path) or switch target.runtime=jar", i)
 			case rt == "jar" && artifact == "image":
 				return fmt.Errorf("nodes[%d]: target.runtime=jar cannot consume build.artifact=image — set artifact to jar or switch runtime", i)
-			case rt == "docker" && artifact == "image":
-				// Phase 3 will wire this into compose. For now, fail
-				// at validate time instead of letting apply hit a
-				// NOT_IMPLEMENTED inside the build pipeline — same
-				// fail-fast principle as the other two branches.
-				return fmt.Errorf("nodes[%d]: build.artifact=image is Phase 3 work (not yet wired into the docker runtime); use build.artifact=jar with target.runtime=jar for now", i)
 			}
 		}
 	}

--- a/internal/intent/loader.go
+++ b/internal/intent/loader.go
@@ -349,6 +349,23 @@ func Validate(intent *Intent) error {
 			case rt == "jar" && artifact == "image":
 				return fmt.Errorf("nodes[%d]: target.runtime=jar cannot consume build.artifact=image — set artifact to jar or switch runtime", i)
 			}
+			// Cross-arch image builds are a footgun. trond's image
+			// path mounts /var/run/docker.sock into the builder
+			// container so gradle's docker plugin can talk to the
+			// HOST docker daemon directly. That daemon runs the
+			// host's CPU arch regardless of the builder container's
+			// --platform — so an arm64 builder on an amd64 host
+			// still produces an amd64 image. The cache key would
+			// then claim arm64 but the artifact would be amd64,
+			// silently shipping the wrong arch to a deploy target.
+			// Phase 5 will lift this once buildx replaces the
+			// docker.sock-mount approach.
+			if artifact == "image" && n.Build.Platform != "" {
+				hostPlatform := DefaultPlatform()
+				if n.Build.Platform != hostPlatform {
+					return fmt.Errorf("nodes[%d]: build.artifact=image with platform=%q is unsafe on host=%q — docker.sock-mounted builds always use the host daemon's arch, so the produced image would NOT be %q. Set platform=%q (or omit it), or use build.artifact=jar which is platform-isolated under the builder container", i, n.Build.Platform, hostPlatform, n.Build.Platform, hostPlatform)
+				}
+			}
 		}
 	}
 

--- a/internal/mcp/tools_config.go
+++ b/internal/mcp/tools_config.go
@@ -100,7 +100,7 @@ func renderTool(ctx context.Context, _ *mcp.CallToolRequest, args renderArg) (*m
 		}
 		switch runtime {
 		case "docker":
-			row["compose"] = render.RenderCompose(parsed.Name, parsed, node, "", jvmArgs)
+			row["compose"] = render.RenderCompose(parsed.Name, parsed, node, "", jvmArgs, "")
 		case "jar":
 			row["systemd"] = render.RenderSystemdUnit(parsed, node, jvmArgs, "", "")
 		}

--- a/internal/render/bench_test.go
+++ b/internal/render/bench_test.go
@@ -45,6 +45,6 @@ func BenchmarkRenderCompose(b *testing.B) {
 	b.ResetTimer()
 	b.ReportAllocs()
 	for b.Loop() {
-		_ = RenderCompose(in.Name, in, node, "", "")
+		_ = RenderCompose(in.Name, in, node, "", "", "")
 	}
 }

--- a/internal/render/compose.go
+++ b/internal/render/compose.go
@@ -75,14 +75,26 @@ const (
 // volume, and config-file basename. Single-node deploys pass intent.Name;
 // `network create` passes the per-node "<network>-node<i>" so multi-node
 // networks don't collide on container_name.
-func RenderCompose(name string, i *intent.Intent, node *intent.NodeSpec, configPath string, jvmArgs string) string {
+//
+// imageOverride, when non-empty, replaces the image field (and suppresses
+// the version-suffix logic). Used by the build pipeline (Phase 3) when
+// `build.artifact: image` produces a locally-tagged image — the
+// generated compose then references that local tag and the renderer
+// also emits `pull_policy: never` so compose does not try to fetch
+// the tag from a remote registry.
+func RenderCompose(name string, i *intent.Intent, node *intent.NodeSpec, configPath string, jvmArgs string, imageOverride string) string {
 	if name == "" {
 		name = i.Name
 	}
 
-	image := node.Image
-	if node.Version != "" && node.Version != "latest" {
+	var image string
+	switch {
+	case imageOverride != "":
+		image = imageOverride
+	case node.Version != "" && node.Version != "latest":
 		image = fmt.Sprintf("%s:%s", node.Image, node.Version)
+	default:
+		image = node.Image
 	}
 
 	ports := renderComposePorts(node)
@@ -104,6 +116,13 @@ func RenderCompose(name string, i *intent.Intent, node *intent.NodeSpec, configP
 	sb.WriteString("services:\n")
 	sb.WriteString(fmt.Sprintf("  %s:\n", name))
 	sb.WriteString(fmt.Sprintf("    image: %s\n", image))
+	if imageOverride != "" {
+		// Locally-built image; compose 3.9+ honors pull_policy.
+		// Without this, `docker compose up` would try to pull the
+		// tag from docker hub and either fail (no remote) or pull
+		// an unrelated upstream image.
+		sb.WriteString("    pull_policy: never\n")
+	}
 	sb.WriteString(fmt.Sprintf("    container_name: %s\n", name))
 	sb.WriteString(fmt.Sprintf("    restart: %s\n", restartPolicy))
 	if len(node.Labels) > 0 {

--- a/internal/render/compose_imageoverride_test.go
+++ b/internal/render/compose_imageoverride_test.go
@@ -1,0 +1,67 @@
+package render
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/tronprotocol/tron-deployment/internal/intent"
+)
+
+// TestRenderCompose_ImageOverride is the Phase 3 wire-up guard:
+// when the build pipeline produces a locally-tagged image and
+// threads its tag through to RenderCompose, the generated compose
+// MUST:
+//  1. Use that tag in the `image:` field (NOT node.Image:version).
+//  2. Emit `pull_policy: never` so `docker compose up` doesn't
+//     reach for a remote registry on a tag that only exists
+//     locally.
+func TestRenderCompose_ImageOverride(t *testing.T) {
+	in := &intent.Intent{
+		Name:    "dev-node",
+		Network: "nile",
+		Target:  intent.Target{Type: "local", Runtime: "docker"},
+		Nodes: []intent.NodeSpec{{
+			Type:    "fullnode",
+			Image:   "tronprotocol/java-tron",
+			Version: "GreatVoyage-v4.7.7",
+		}},
+	}
+	got := RenderCompose("dev-node", in, &in.Nodes[0], "", "-Xmx4g", "trond-build:dev")
+
+	if !strings.Contains(got, "image: trond-build:dev\n") {
+		t.Errorf("compose should reference imageOverride; got:\n%s", got)
+	}
+	if !strings.Contains(got, "pull_policy: never\n") {
+		t.Error("compose with imageOverride MUST set pull_policy: never")
+	}
+	// Negative: the regular tronprotocol/java-tron:version path must
+	// NOT leak into the output when overridden.
+	if strings.Contains(got, "tronprotocol/java-tron:GreatVoyage-v4.7.7") {
+		t.Errorf("compose leaked node.Image:Version despite override:\n%s", got)
+	}
+}
+
+// TestRenderCompose_NoOverrideKeepsLegacyBehavior asserts the
+// pre-Phase-3 default path still works when imageOverride is empty:
+// node.Image (+ optional :Version) flows through, no pull_policy
+// line emitted.
+func TestRenderCompose_NoOverrideKeepsLegacyBehavior(t *testing.T) {
+	in := &intent.Intent{
+		Name:    "prod-node",
+		Network: "mainnet",
+		Target:  intent.Target{Type: "local", Runtime: "docker"},
+		Nodes: []intent.NodeSpec{{
+			Type:    "fullnode",
+			Image:   "tronprotocol/java-tron",
+			Version: "GreatVoyage-v4.7.7",
+		}},
+	}
+	got := RenderCompose("prod-node", in, &in.Nodes[0], "", "-Xmx4g", "")
+
+	if !strings.Contains(got, "image: tronprotocol/java-tron:GreatVoyage-v4.7.7\n") {
+		t.Errorf("compose should use node.Image:Version; got:\n%s", got)
+	}
+	if strings.Contains(got, "pull_policy:") {
+		t.Error("compose without imageOverride MUST NOT inject pull_policy")
+	}
+}

--- a/internal/render/golden_test.go
+++ b/internal/render/golden_test.go
@@ -65,7 +65,7 @@ func TestRenderHOCON_Golden(t *testing.T) {
 				memGB = 16
 			}
 			jvmArgs := JVMArgsString(memGB, 17, node.JVM)
-			gotCompose := RenderCompose(parsed.Name, parsed, node, "", jvmArgs)
+			gotCompose := RenderCompose(parsed.Name, parsed, node, "", jvmArgs, "")
 
 			compareGolden(t, tc.golden+".conf", gotHOCON)
 			compareGolden(t, tc.golden+".compose.yaml", gotCompose)

--- a/scripts/refresh-builder-pins.sh
+++ b/scripts/refresh-builder-pins.sh
@@ -1,6 +1,12 @@
 #!/usr/bin/env bash
-# Re-resolves Eclipse Temurin builder image tags to their current
+# Re-resolves Eclipse Temurin builder image tags to PER-PLATFORM
 # sha256 digests and rewrites internal/build/pins/builder_image_digests.json.
+#
+# Why per-platform (not the manifest-list digest):
+#   docker run --platform <arch> image@<manifest-list-digest>
+# fails with "cannot overwrite digest" because the per-arch image
+# trond actually runs has a DIFFERENT digest from the manifest list.
+# So we pin the per-arch digest directly via `docker manifest inspect`.
 #
 # Per spec/002 FR-012: the embedded pin file is the source of truth
 # for trond's reproducible builder images. Bumping the pins is a
@@ -11,14 +17,15 @@
 #   ./scripts/refresh-builder-pins.sh           # rewrite the JSON in place
 #   ./scripts/refresh-builder-pins.sh --dry-run # print without writing
 #
-# Requirements: docker, jq (apt-get install jq | brew install jq).
+# Requirements: docker, jq, docker manifest API (default-on in
+# modern docker; `docker manifest inspect` works against the
+# configured registry).
 
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 PIN_FILE="$REPO_ROOT/internal/build/pins/builder_image_digests.json"
 
-# Map of JDK version → upstream tag. Keep sorted by version.
 declare -a JDK_VERSIONS=(8 11 17 21)
 declare -A TAG_FOR=(
   [8]="eclipse-temurin:8-jdk-jammy"
@@ -26,6 +33,7 @@ declare -A TAG_FOR=(
   [17]="eclipse-temurin:17-jdk-jammy"
   [21]="eclipse-temurin:21-jdk-jammy"
 )
+declare -a PLATFORMS=("linux/amd64" "linux/arm64")
 
 DRY_RUN=0
 if [[ "${1:-}" == "--dry-run" ]]; then
@@ -33,7 +41,7 @@ if [[ "${1:-}" == "--dry-run" ]]; then
 fi
 
 if ! command -v docker >/dev/null 2>&1; then
-  echo "error: docker is required (used to pull + inspect images)" >&2
+  echo "error: docker is required" >&2
   exit 64
 fi
 if ! command -v jq >/dev/null 2>&1; then
@@ -45,28 +53,44 @@ fi
 new_pins='{}'
 for jdk in "${JDK_VERSIONS[@]}"; do
   tag="${TAG_FOR[$jdk]}"
-  echo "[refresh-builder-pins] resolving $tag (JDK $jdk)..." >&2
-  docker pull --quiet "$tag" >/dev/null
+  echo "[refresh-builder-pins] inspecting manifest list for $tag (JDK $jdk)..." >&2
 
-  # `docker inspect` returns the canonical RepoDigest for the local image.
-  # Strip the `<repo>@` prefix so we end up with just `sha256:<hex>`.
-  digest="$(docker inspect --format='{{ index .RepoDigests 0 }}' "$tag" | sed 's/.*@//')"
+  # `docker manifest inspect` queries the registry without pulling.
+  # The output describes a multi-arch manifest list with one entry
+  # per platform; we pluck the per-arch digest with jq.
+  manifest_json="$(docker manifest inspect "$tag")"
 
-  if [[ ! "$digest" =~ ^sha256:[0-9a-f]{64}$ ]]; then
-    echo "error: unexpected digest format for $tag: $digest" >&2
-    exit 1
-  fi
+  platforms_obj='{}'
+  for platform in "${PLATFORMS[@]}"; do
+    arch="${platform#linux/}"  # linux/amd64 -> amd64
+    digest="$(jq -r --arg arch "$arch" '
+      .manifests[]
+      | select(.platform.os == "linux" and .platform.architecture == $arch)
+      | .digest
+    ' <<<"$manifest_json")"
 
-  echo "[refresh-builder-pins]   $jdk → $tag @ $digest" >&2
+    if [[ -z "$digest" || "$digest" == "null" ]]; then
+      echo "error: no $platform variant in manifest list for $tag" >&2
+      exit 1
+    fi
+    if [[ ! "$digest" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+      echo "error: unexpected digest format for $tag/$platform: $digest" >&2
+      exit 1
+    fi
 
-  new_pins="$(jq --arg jdk "$jdk" --arg ref "$tag" --arg digest "$digest" \
-    '. + { ($jdk): { ref: $ref, digest: $digest } }' <<<"$new_pins")"
+    echo "[refresh-builder-pins]   $jdk/$platform → $digest" >&2
+    platforms_obj="$(jq --arg p "$platform" --arg d "$digest" \
+      '. + { ($p): $d }' <<<"$platforms_obj")"
+  done
+
+  new_pins="$(jq --arg jdk "$jdk" --arg ref "$tag" --argjson platforms "$platforms_obj" \
+    '. + { ($jdk): { ref: $ref, platforms: $platforms } }' <<<"$new_pins")"
 done
 
 new_doc="$(jq --argjson pins "$new_pins" \
   '{
-    "$comment": "Pinned digests for builder images. Bumped per trond release via `make refresh-builder-pins`. Each entry resolves jdk_version -> reference (canonical name@sha256:...). Cache key (FR-002) incorporates the digest so pin bumps invalidate stale artifacts.",
-    "schema_version": "1.0.0",
+    "$comment": "Pinned per-platform digests for builder images. Bumped per trond release via `make refresh-builder-pins`. Each entry resolves (jdk_version, platform) → per-arch image digest (NOT the multi-arch manifest list digest — pinning that and combining with `docker run --platform X` fails with `cannot overwrite digest`). Cache key (FR-002) incorporates the digest so pin bumps invalidate stale artifacts.",
+    "schema_version": "2.0.0",
     "pins": $pins
   }' <<<'{}')"
 


### PR DESCRIPTION
Continues the build pipeline from #175 (Phase 2). Opens the final 5 commits on `feat/build-pipeline-phase3`.

## Summary

Unblocks `build.artifact: image` (Phase 2 rejected it as "Phase 3 work"). Now `trond apply --intent dev.yaml` with `artifact: image` runs gradle's docker plugin inside the builder container, tags the produced image as `build.image_tag`, renders compose with `pull_policy: never`, and deploys via the docker runtime — end-to-end.

Also lands three real-world fixes discovered during local end-to-end testing against an actual java-tron checkout:

1. **Per-platform digest pins** (schema 2.0.0). Eclipse Temurin tags are multi-arch manifest lists; pinning the LIST digest and combining with `docker run --platform X` errors with "cannot overwrite digest". Pin schema is now `{jdk: {ref, platforms: {linux/amd64: <digest>, linux/arm64: <digest>}}}`, fed by `docker manifest inspect` (not `docker pull`).
2. **macOS Docker Desktop bind-mount strips exec bit** → gradle's downloaded protoc binary becomes EACCES. Fix: gradle cache moved to a docker named volume (`trond-build-gradle-cache`) that lives inside Docker's VM where file modes survive.
3. **Wrapper script only searched root `build/libs/`**. java-tron's fat jar lives at `framework/build/libs/FullNode.jar`. Now: `find . -path '*/build/libs/*.jar' | xargs ls -S | head -n1`.

## End-to-end verified on real java-tron

| combo | duration | result |
|---|---|---|
| host arm64 + JDK17 (M1 native) | ~45s cold / ~50ms hit | ✅ 193 MB FullNode.jar |
| cross-arch amd64 + JDK8 (QEMU) | ~95s cold / ~50ms hit | ✅ 139 MB FullNode.jar |

## Commits in this PR

1. \`build: Phase 3 - artifact=image end-to-end\` — design unblock + docker runtime wire-up
2. \`build: Phase 3 self-review fixes (8 items)\` — incl. imageTagExistsLocally, cross-arch image rejection, validateImageEntrypoint hardening
3. \`build: Phase 3 review pass 2 — fix snapshot race + polish\` — per-cache-key snapshot files, dangling=false filter, host-side diff, stripExtraTags
4. \`build: refresh builder image pins (PLACEHOLDER → real digests)\` — first real digest set
5. \`build: per-platform digest pins + named-volume cache + recursive jar search\` — the three real-world fixes above + pin schema 2.0.0

## Surface changes

### intent

- \`loader.go\` removes the docker+image rejection; keeps docker+jar / jar+image as VALIDATION_ERROR. Adds cross-arch+image rejection (docker.sock mount means host arch wins).
- \`defaults.go::DefaultRuntime\` picks docker for build+artifact=image; jar otherwise. Single source of truth still threaded through three sites.

### build

- new \`image.go\` — buildImage orchestrator with stripExtraTags, validateImageEntrypoint, imageTagExistsLocally, readNewImageIDs + computeNewImages (host-side diff, no in-container \`comm\`).
- \`runner.go\` — dispatches on artifact kind; image variant mounts \`/var/run/docker.sock\`, takes before/after image-ID snapshots into per-cache-key files; gradle cache moved to named volume.
- \`pins/\` — schema 2.0.0 per-platform digests.
- new \`stderr\` notice when artifact=image: docker.sock trust extension.
- new \`build.gradle_args\` allowed (Phase 2 leftover).

### render

- \`compose.go::RenderCompose\` gains \`imageOverride\` parameter; when non-empty, uses that tag and emits \`pull_policy: never\`. All 6 callers updated.

### imagetag.go

- rejects well-known upstream prefixes (\`tronprotocol/\`, \`eclipse-temurin/\`, \`library/\`) so locally-built images can't shadow upstream.

## Test coverage

20+ new tests across:
- intent: BuildDockerImageNowAccepted, BuildImageArtifactDefaultsRuntimeToDocker, BuildImageRejectsCrossArchPlatform, BuildImageAcceptsHostArchPlatform.
- render: RenderCompose_ImageOverride (+ legacy-path negation).
- build: ValidateImageTag_RejectsWellKnownPrefix, ComputeNewImages (5-case table incl. multi-stage remove-and-add), ReadNewImageIDs_PerCacheKeyIsolation, DockerBuildScript_Image_PinsSafety.
- pins: PerPlatformDigests assertion (amd64 ≠ arm64), UnknownPlatform, Platforms.
- integration (build-tag gated): TestBuildImage_RealGradleEndToEnd against a busybox-based fixture.

\`go test ./...\` + \`make lint\` clean.

## Self-review history

2 rounds of self-review (8 + 5 items + 3 real-world fixes discovered during local E2E), all addressed before this PR was opened.

## What's NOT in this PR

- SSH target with build (Phase 4 — about to start).
- \`--builder host\` body (Phase 5).
- \`trond build list / inspect / prune\` + MCP tools (Phase 5).
- Multi-arch image build via buildx (Phase 5 / 6).

## Test plan

- [x] \`go test ./...\` green on darwin/arm64
- [x] \`go vet -tags=integration ./internal/build/...\` compiles
- [x] \`make lint\` clean
- [x] Real end-to-end build against \`~/Documents/code/java/mydev/java-tron\` on M1:
  - [x] native arm64+JDK17: 45s cold, 50ms hit
  - [x] cross-arch amd64+JDK8 (QEMU): 95s cold
  - [x] both JARs coexist in cache with distinct keys