### PR TITLE
docs: Phase 6 — build-pipeline quickstart + README dev-loop + AGENTS

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -301,6 +301,84 @@ trond network destroy pn --confirm pn -o json
 
 ---
 
+## Workflow 5 — Build java-tron from source
+
+Use when the user wants a custom build: a fork, an unreleased patch,
+a wired-in profiler. The build pipeline is content-addressed by
+git revision + builder image digest + gradle task + args, so
+repeated `apply` calls against an unchanged source are sub-second
+cache hits, not full recompiles.
+
+Trigger: the intent file carries a `build:` block under the node.
+`trond apply` invokes the build automatically; you rarely need to
+call `trond build` directly except for cache mgmt or pre-warming.
+
+```bash
+# 1. Validate the intent like any other.
+trond config validate my-dev.yaml -o json
+
+# 2. Preflight gains LOCAL-side `build-*` checks when build: is set:
+#    build-git, build-source-<dir>, build-docker-local (if builder=docker),
+#    build-host-jdk + build-host-gradlew-<dir> (if builder=host).
+#    Target-side checks (jdk, disk, ports) still run too.
+trond preflight --intent my-dev.yaml -o json
+
+# 3. Apply — the build kicks off automatically before the deploy step.
+#    Cold first build: 3-5 min for java-tron. Cached: ~50ms.
+trond apply --intent my-dev.yaml -o json
+# Output now carries a `build` field alongside the usual envelope:
+# {"name":"...", "result":"created",
+#  "build": {"cache_key":"abc12345-bd…+dirty-7f2a…",
+#            "source_revision":"8f4e2a3c…",
+#            "dirty": true,
+#            "artifact_path":"/home/.../FullNode.jar",
+#            "sha256":"160185…", "cache_hit": false,
+#            "duration_ms": 215000},
+#  ...}
+
+# 4. Survey what's in the cache.
+trond build list -o json
+# Output: {"count": N, "entries": [{cache_key, artifact_kind, size_bytes,
+#                                   orphaned, source_revision, ...}, ...]}
+
+# 5. Inspect a specific entry — full key OR unambiguous prefix.
+trond build inspect 8f4e2a3c -o json
+# Returns the single entry (same shape as build_list entries).
+# Errors: NOT_FOUND (no match), AMBIGUOUS_PREFIX (multi-match;
+# message lists candidates).
+
+# 6. Prune. Filters AND together; dry-run is the default — only
+#    --confirm performs deletions.
+trond build prune --older-than 168h -o json                  # dry-run
+trond build prune --older-than 168h --keep-last 3 --confirm  # delete
+trond build prune --orphan --confirm                         # GC
+```
+
+### Key invariants for agents
+
+- The build runs on the LOCAL machine even when `target.type: ssh` —
+  trond `scp`s the JAR over with an SHA256-skip fast-path. No source
+  bytes ever leave the host.
+- `build.builder: host` works without docker but pins the cache key
+  to `sha256(java -version)`, so a JDK upgrade orphans prior entries
+  (orphans are surfaced in `list --include-orphans` and cleaned by
+  `prune --orphan`).
+- The CLI rejects `--keep-last N --confirm` without an explicit
+  scoping filter (`--all`, `--orphan`, or `--older-than > 0s`).
+  This is a footgun guard: `--keep-last 1 --confirm` would wipe
+  every entry except the newest, which is rarely what the user
+  meant.
+- Build *execution* is intentionally NOT exposed via MCP — it's a
+  long-running, stderr-streaming operation. The CLI's `-o json`
+  stream is the right surface. The cache-mgmt tools (`build_list`,
+  `build_inspect`, `build_prune`) ARE exposed via MCP — see below.
+
+Full walkthrough including image artifacts, cross-arch builds, and
+the `image_strategy: jar-wrap` variant for stock java-tron:
+[`specs/002-trond-build-pipeline/quickstart.md`](specs/002-trond-build-pipeline/quickstart.md).
+
+---
+
 ## Test-harness primitives (for agents driving CI / fuzz / chaos)
 
 These exist for agents that drive trond programmatically rather than
@@ -401,6 +479,18 @@ topic; don't paraphrase from training data.
    Use the upcoming `snapshot prune` (or just `rm` the JSON+log pair
    when the job is `state=stopped`).
 
+9. **Don't `rm -rf ~/.trond/builds`** to clean the build cache. Use
+   `trond build prune` so the manifests, image side-files, and
+   docker-stored images all get reclaimed consistently. Manual `rm`
+   leaves dangling docker layers and orphaned manifests that confuse
+   the next `trond build list`.
+
+10. **Don't pass `--keep-last N --confirm` alone to prune**. The CLI
+    rejects it for safety: that combo deletes everything except the N
+    newest entries, which is rarely the intent. Combine with `--all`
+    (to acknowledge near-wipe) or scope with `--orphan` / `--older-than`.
+    Same guard applies to the MCP `build_prune` tool.
+
 ---
 
 ## Schema discovery
@@ -444,7 +534,7 @@ Configure once in your client. Example for Claude Desktop
 }
 ```
 
-The server registers 16 tools (read-only unless marked):
+The server registers 19 tools (read-only unless marked):
 
 - **inspection** (3): `list`, `status`, `inspect`
 - **diagnostic** (4): `doctor`, `version`, `health`, `diagnose`
@@ -453,6 +543,10 @@ The server registers 16 tools (read-only unless marked):
 - **snapshot** (4): `snapshot_sources`, `snapshot_list`, `snapshot_jobs`,
   `snapshot_download` (destructive, emits MCP progress notifications)
 - **knowledge** (2): `knowledge_list`, `knowledge_get`
+- **build** (3): `build_list`, `build_inspect`, `build_prune`
+  (destructive — dry-run by default; `confirm=true` actually deletes).
+  Build *execution* is NOT exposed via MCP; call the CLI directly
+  for that (see Workflow 5).
 
 Destructive tools carry the MCP `destructiveHint` annotation so MCP
 clients prompt the user. The server's `Instructions` field

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -479,11 +479,11 @@ topic; don't paraphrase from training data.
    Use the upcoming `snapshot prune` (or just `rm` the JSON+log pair
    when the job is `state=stopped`).
 
-9. **Don't `rm -rf ~/.trond/builds`** to clean the build cache. Use
-   `trond build prune` so the manifests, image side-files, and
-   docker-stored images all get reclaimed consistently. Manual `rm`
-   leaves dangling docker layers and orphaned manifests that confuse
-   the next `trond build list`.
+9. **Don't `rm -rf` the build cache directory** (`$TROND_STATE_DIR/builds`,
+   defaulting to `~/.trond/builds`) to clean it. Use `trond build prune`
+   so the manifests, image side-files, and docker-stored images all get
+   reclaimed consistently. Manual `rm` leaves dangling docker layers
+   and orphaned manifests that confuse the next `trond build list`.
 
 10. **Don't pass `--keep-last N --confirm` alone to prune**. The CLI
     rejects it for safety: that combo deletes everything except the N

--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ hit.
 target: { type: local, runtime: jar }
 nodes:
   - type: fullnode
-    install_path: /var/lib/trond/dev
+    install_path: /tmp/trond-dev/my-dev-node
     build:
       source: ../java-tron              # your local checkout
       gradle_task: ":framework:buildFullNodeJar"
@@ -251,7 +251,8 @@ nodes:
 
 ```bash
 trond apply --intent my-dev-node.yaml -o json
-# First run: ~5 min compile. Re-runs against the same source: ~50 ms.
+# First run: ~5-10 min compile (longer under cross-arch QEMU).
+# Re-runs against the same source: ~50 ms cache hit.
 trond build list                          # what's in the cache
 trond build prune --older-than 168h --confirm   # GC 7-day-old entries
 ```

--- a/README.md
+++ b/README.md
@@ -230,6 +230,40 @@ trond apply --intent examples/mainnet-fullnode-snapshot.yaml \
 
 Full annotated example with the storage layout: [`examples/mainnet-fullnode-snapshot.yaml`](examples/mainnet-fullnode-snapshot.yaml). Long-form rationale: `trond knowledge snapshots`.
 
+## Dev loop — build from source
+
+When you need a custom build (a fork, an unreleased patch, a wired-in
+debugger), put a `build:` block under the node and `trond apply`
+handles compile-then-deploy in one shot. Builds are content-addressed
+and cached, so re-applying an unchanged source is a sub-second cache
+hit.
+
+```yaml
+# my-dev-node.yaml
+target: { type: local, runtime: jar }
+nodes:
+  - type: fullnode
+    install_path: /var/lib/trond/dev
+    build:
+      source: ../java-tron              # your local checkout
+      gradle_task: ":framework:buildFullNodeJar"
+```
+
+```bash
+trond apply --intent my-dev-node.yaml -o json
+# First run: ~5 min compile. Re-runs against the same source: ~50 ms.
+trond build list                          # what's in the cache
+trond build prune --older-than 168h --confirm   # GC 7-day-old entries
+```
+
+Choose `--builder host` (uses your local `./gradlew`) for fastest
+iteration, or the default `--builder docker` (pinned eclipse-temurin
+image) for reproducible cross-machine builds. SSH targets build
+locally and stream the JAR over with an SHA256-skip fast-path.
+
+Full walkthrough including image artifacts, cross-arch builds,
+cache management, and MCP usage: [build pipeline quickstart](specs/002-trond-build-pipeline/quickstart.md).
+
 ## Commands
 
 ### Lifecycle
@@ -250,6 +284,15 @@ Full annotated example with the storage layout: [`examples/mainnet-fullnode-snap
 | `trond verify <node>` | Post-deploy health gate |
 | `trond preflight` | Check target readiness |
 | `trond bootstrap` | Install Docker or JDK on target |
+
+### Build (compile java-tron from source)
+
+| Command | Description |
+|---|---|
+| `trond build` | Build a JAR or docker image from a java-tron source tree (content-addressed cache) |
+| `trond build list` | List cached build artifacts |
+| `trond build inspect <key>` | Show full manifest for one cache entry (full key or unambiguous prefix) |
+| `trond build prune` | Remove cached entries per policy (`--older-than`, `--keep-last`, `--orphan`, `--all`); dry-run unless `--confirm` |
 
 ### Configuration
 

--- a/specs/002-trond-build-pipeline/quickstart.md
+++ b/specs/002-trond-build-pipeline/quickstart.md
@@ -1,0 +1,311 @@
+# trond build — quickstart
+
+Copy/pasteable dev-loop for building java-tron from source and
+deploying the result through the same `trond apply` flow you'd use
+for a pre-built image.
+
+Everything below assumes you already have `trond` installed (see
+the project [README](../../README.md)) and a `java-tron` checkout
+on disk.
+
+## TL;DR
+
+```bash
+# 1. Build a fat JAR from java-tron's master branch.
+trond build \
+  --source /path/to/java-tron \
+  --artifact jar -o json
+
+# 2. Deploy a node that consumes that JAR (intent.yaml has a build: block).
+trond apply --intent ./my-node.yaml -o json
+
+# 3. Survey the cache.
+trond build list
+trond build inspect <cache-key>
+trond build prune --older-than 168h --confirm   # 7 days
+```
+
+The build pipeline is content-addressed: same source + same builder
+image + same task + same args → same `cache_key` → instant cache hit
+on the second invocation. No artifact is ever re-built unnecessarily.
+
+## Builder choice — docker vs host
+
+trond ships two builder backends. Pick whichever fits your machine.
+
+| | `--builder docker` (default) | `--builder host` |
+|---|---|---|
+| Toolchain | Pinned `eclipse-temurin:<jdk>-jdk-jammy` image | Your local `java` + the source's `./gradlew` |
+| Reproducibility | High — same digest across machines | Only as reproducible as your host JDK |
+| Requirements | Docker daemon reachable | `java` on PATH; `./gradlew` in the source tree |
+| Cross-arch builds | `--platform linux/amd64 \| linux/arm64` via QEMU | Host arch only |
+| Cache key includes | Pinned builder image digest | sha256 of `java -version` output |
+| First-build time (java-tron) | ~5 min cold, ~50 ms cache hit | ~3 min cold, ~50 ms cache hit |
+
+You can switch builders freely — they produce distinct cache entries
+(the BuilderImageDigest differs), so a stray host build won't
+clobber your reproducible docker artifacts.
+
+## Walkthrough — local deploy with a build block
+
+### 1. Write the intent
+
+```yaml
+# my-node.yaml
+name: my-dev-fullnode
+network: nile
+target:
+  type: local
+  runtime: jar
+nodes:
+  - type: fullnode
+    install_path: /var/lib/trond/my-dev-fullnode
+    resources:
+      memory: 4G
+    build:
+      source: ../java-tron     # relative to THIS file (FR-021)
+      builder: docker          # or "host"
+      jdk: "17"                # optional; auto-detects from platform
+      gradle_task: ":framework:buildFullNodeJar"   # stock java-tron
+```
+
+Relative `build.source` paths resolve against the intent file's
+directory, mirroring `docker-compose`'s `build.context` convention.
+
+### 2. Preflight
+
+```bash
+trond preflight --intent my-node.yaml
+```
+
+You'll see two groups of checks:
+
+```
+✓ docker               Docker version 27.4.1
+✓ disk                 12GB free
+✓ memory               16GB total
+✓ port-8090            Port 8090 (http) available
+…
+✓ build-git            git version 2.43.0
+✓ build-source-java-tron  /path/to/java-tron
+✓ build-docker-local   docker server 27.4.1
+```
+
+The `build-*` checks run on the LOCAL machine (where the build will
+execute), regardless of `target.type`. SSH targets get target-side
+checks AND local-side build checks.
+
+### 3. Apply
+
+```bash
+trond apply --intent my-node.yaml -o json
+```
+
+First invocation: ~3–5 minutes for the gradle compile.
+Second invocation against an unchanged source: ~50 ms cache hit.
+
+The output's `build` field surfaces the cache state:
+
+```json
+{
+  "name": "my-dev-fullnode",
+  "result": "created",
+  "build": {
+    "cache_key": "abc12345-bdeadbef+dirty-7f2a3b9c-xa1b2c3d4",
+    "source_revision": "8f4e2a3c1234567890abcdef1234567890abcdef",
+    "dirty": true,
+    "artifact_path": "/home/you/.trond/builds/out/abc12345-….jar",
+    "sha256": "160185bf2867…",
+    "cache_hit": false,
+    "duration_ms": 215000
+  },
+  "endpoints": {"http": "http://127.0.0.1:8090", "grpc": "127.0.0.1:50051"}
+}
+```
+
+`dirty: true` means your working tree had uncommitted edits; trond
+folded a patch hash into the cache key so unrelated edits don't
+share the same artifact. `dirty: false` means the resolved revision
+matches `HEAD` exactly.
+
+## SSH target — build locally, deploy remotely
+
+trond never executes builds on the deploy target. With
+`target.type: ssh`, the build runs on your laptop and the resulting
+JAR is `scp`'d to the remote `install_path`.
+
+```yaml
+target:
+  type: ssh
+  host: 10.0.0.42
+  user: ubuntu
+  identity_file: ~/.ssh/id_ed25519
+  runtime: jar
+nodes:
+  - type: fullnode
+    install_path: /home/ubuntu/trond
+    process_manager: nohup       # or systemd if you have sudo
+    build:
+      source: ../java-tron
+      builder: host              # or docker; same cache either way
+```
+
+`trond apply` will:
+
+1. Run the build locally (or hit cache).
+2. SHA256 the remote's existing JAR, if any — skip the transfer when
+   it matches.
+3. Stream the JAR via SSH to `<install_path>/FullNode.jar.tmp`.
+4. `mv` atomically to the final path (no half-written file is ever
+   visible to the running node).
+5. Install a systemd unit / nohup launcher per `process_manager`.
+6. Start the node.
+
+The SHA256 fast-path makes subsequent applies essentially free: no
+bytes leave your laptop if the remote already holds the right JAR.
+
+## Image artifact — build a docker image, not a JAR
+
+Two strategies, picked via `build.image_strategy`:
+
+### `gradle` (default) — for source trees that ship a `dockerBuild` task
+
+```yaml
+build:
+  source: ../java-tron
+  artifact: image
+  image_tag: my-fork/java-tron:dev
+  # image_strategy: gradle   ← implicit default
+```
+
+trond invokes gradle's docker plugin inside the builder container,
+diff-snapshots `docker images` before/after, and tags the new image
+as `<image_tag>` for compose to consume.
+
+### `jar-wrap` — for stock java-tron (no `dockerBuild` task)
+
+```yaml
+build:
+  source: ../java-tron
+  artifact: image
+  image_strategy: jar-wrap
+  image_tag: my-fork/java-tron:dev
+  gradle_task: ":framework:buildFullNodeJar"   # produces the JAR
+```
+
+trond builds the fat JAR via the standard Phase 1 path, then runs
+`docker build` against an embedded Dockerfile that COPYs the JAR
+into a pinned `eclipse-temurin:<jdk>-jdk-jammy` runtime with
+`tcmalloc_minimal` preloaded (matches upstream `tron-docker`'s
+patterns).
+
+The wrapped image is cross-arch safe — `--platform linux/amd64` on
+an arm64 host produces a working amd64 image without docker.sock
+trickery (the inner JAR is JVM bytecode, the outer step is COPY-
+only).
+
+## Cache management
+
+### List
+
+```bash
+trond build list
+trond build list --filter image --sort size
+trond build list --include-orphans -o json | jq '.entries[] | select(.orphaned)'
+```
+
+Each row shows cache_key, kind, source_revision (short), size,
+created_at, and the artifact path or image tag. Newest-first by
+default; `--sort size` finds the biggest cache hogs.
+
+### Inspect
+
+```bash
+trond build inspect 260585c9397b    # unambiguous prefix is enough
+trond build inspect 260585c9397b-bd0861e68 -o json
+```
+
+Returns the full manifest plus size + orphan state. On an ambiguous
+prefix you get a `AMBIGUOUS_PREFIX` error listing the candidates.
+
+### Prune
+
+```bash
+# Dry-run (default): see the plan before doing anything destructive.
+trond build prune --older-than 168h
+
+# Actually delete (note: --confirm is REQUIRED to delete).
+trond build prune --older-than 168h --confirm
+
+# Safety-net combo: keep the 3 newest regardless of age.
+trond build prune --older-than 168h --keep-last 3 --confirm
+
+# Wipe orphans only (artifacts deleted out-of-band; manifests left behind).
+trond build prune --orphan --confirm
+
+# Nuclear option — wipe everything.
+trond build prune --all --confirm
+```
+
+Filters AND together; `--keep-last N` is a global safety net (the N
+newest entries are protected, even if the other filters would
+target them). `--keep-last N` alone with `--confirm` is rejected —
+combine with `--all` (explicit ack) or `--orphan` / `--older-than`
+to scope the deletion.
+
+For image entries, prune also runs `docker image rm --force <tag>`
+so the docker storage layer actually reclaims layers.
+
+## MCP usage
+
+The build cache tools are exposed over MCP for chat-based agents:
+
+```jsonc
+// Tool: build_list
+// Args: { "filter": "all|jar|image", "sort": "newest|oldest|size", "include_orphans": false }
+// Returns: { "count": N, "entries": [...] }
+
+// Tool: build_inspect
+// Args: { "cache_key": "<full or unambiguous prefix>" }
+// Returns: single entry (same shape as build_list entries)
+
+// Tool: build_prune                     ← carries destructiveHint
+// Args: { "all": false, "older_than": "168h", "keep_last": 3,
+//         "orphan_only": false, "confirm": false }
+// Returns: { "dry_run": bool, "plan": [...], "removed": [...], "freed_bytes": N }
+```
+
+Build *execution* (`trond build`) is intentionally NOT exposed via
+MCP — it's a long-running, stderr-streaming operation whose progress
+is best surfaced via the CLI's `-o json` stream. Agents that need
+to drive a build call the CLI binary directly.
+
+## Troubleshooting
+
+**`Java 17 is required for aarch64`** — java-tron's build.gradle
+enforces a strict platform/JDK matrix (amd64 → JDK 8, arm64 → JDK
+17). trond warns on mismatched combinations but doesn't block;
+gradle does. Either set `build.jdk` to match or accept the warning
+and let trond pick the default.
+
+**`gradle wrapper not present`** — `--builder host` requires the
+source tree to ship `./gradlew`. Run `gradle wrapper` once in your
+checkout, or switch to `--builder docker`.
+
+**`docker: cannot overwrite digest`** — cross-arch build pulled a
+multi-arch manifest list digest; the per-platform digest is what
+trond's pin schema needs. This was a real bug fixed in Phase 3;
+file an issue if you hit it on current main.
+
+**Stale cache after a JDK upgrade** — host-builder cache keys
+include the sha256 of `java -version`. After a JDK install upgrade,
+the old entries become orphaned (their digest no longer matches the
+host); `trond build prune --orphan --confirm` cleans them up.
+
+## Reference
+
+- `trond build --help` — full flag reference
+- `trond schema build -o json` — machine-readable contract
+- [spec/plan.md](./plan.md) — design rationale + non-functional
+  requirements (FR-001 through FR-024)
+- [AGENTS.md](../../AGENTS.md) — agent-facing workflows

--- a/specs/002-trond-build-pipeline/quickstart.md
+++ b/specs/002-trond-build-pipeline/quickstart.md
@@ -38,9 +38,17 @@ trond ships two builder backends. Pick whichever fits your machine.
 | Toolchain | Pinned `eclipse-temurin:<jdk>-jdk-jammy` image | Your local `java` + the source's `./gradlew` |
 | Reproducibility | High — same digest across machines | Only as reproducible as your host JDK |
 | Requirements | Docker daemon reachable | `java` on PATH; `./gradlew` in the source tree |
+| `artifact: jar` | ✓ | ✓ |
+| `artifact: image` (either strategy) | ✓ | ✓ (image step still uses host docker) |
 | Cross-arch builds | `--platform linux/amd64 \| linux/arm64` via QEMU | Host arch only |
 | Cache key includes | Pinned builder image digest | sha256 of `java -version` output |
-| First-build time (java-tron) | ~5 min cold, ~50 ms cache hit | ~3 min cold, ~50 ms cache hit |
+| First-build time (java-tron) | ~5–10 min cold (longer under QEMU), ~50 ms cache hit | ~3–8 min cold, ~50 ms cache hit |
+
+Both builders need a reachable docker daemon for image artifacts —
+the `jar-wrap` strategy runs `docker build` host-side, and the
+`gradle` strategy invokes gradle's docker plugin which talks to the
+local daemon either directly (host) or via a `docker.sock` mount
+(docker builder).
 
 You can switch builders freely — they produce distinct cache entries
 (the BuilderImageDigest differs), so a stray host build won't
@@ -59,7 +67,7 @@ target:
   runtime: jar
 nodes:
   - type: fullnode
-    install_path: /var/lib/trond/my-dev-fullnode
+    install_path: /tmp/trond-dev/my-dev-fullnode
     resources:
       memory: 4G
     build:
@@ -122,6 +130,10 @@ The output's `build` field surfaces the cache state:
   "endpoints": {"http": "http://127.0.0.1:8090", "grpc": "127.0.0.1:50051"}
 }
 ```
+
+`artifact_path` lives under `$TROND_STATE_DIR/builds/out/` (or
+`~/.trond/builds/out/` if you haven't overridden `--state-dir` /
+`$TROND_STATE_DIR`).
 
 `dirty: true` means your working tree had uncommitted edits; trond
 folded a patch hash into the cache key so unrelated edits don't
@@ -191,6 +203,7 @@ build:
   image_strategy: jar-wrap
   image_tag: my-fork/java-tron:dev
   gradle_task: ":framework:buildFullNodeJar"   # produces the JAR
+  platform: linux/amd64                        # optional; omit = host arch
 ```
 
 trond builds the fat JAR via the standard Phase 1 path, then runs
@@ -199,10 +212,11 @@ into a pinned `eclipse-temurin:<jdk>-jdk-jammy` runtime with
 `tcmalloc_minimal` preloaded (matches upstream `tron-docker`'s
 patterns).
 
-The wrapped image is cross-arch safe — `--platform linux/amd64` on
-an arm64 host produces a working amd64 image without docker.sock
-trickery (the inner JAR is JVM bytecode, the outer step is COPY-
-only).
+The wrapped image is cross-arch safe — setting `build.platform`
+(e.g. `linux/amd64` on an arm64 host) produces a working image for
+the target arch without docker.sock trickery (the inner JAR is JVM
+bytecode, the outer step is COPY-only). Omit `platform:` to get
+host arch.
 
 ## Cache management
 
@@ -306,6 +320,6 @@ host); `trond build prune --orphan --confirm` cleans them up.
 
 - `trond build --help` — full flag reference
 - `trond schema build -o json` — machine-readable contract
-- [spec/plan.md](./plan.md) — design rationale + non-functional
-  requirements (FR-001 through FR-024)
+- [spec.md](./spec.md) — functional requirements (FR-001 through FR-024)
+- [plan.md](./plan.md) — design rationale + phase-by-phase implementation plan
 - [AGENTS.md](../../AGENTS.md) — agent-facing workflows


### PR DESCRIPTION
Closes the build-pipeline epic (specs/002-trond-build-pipeline/plan.md Phase 6).

## Summary

Three docs deliverables, no code changes:

- **`specs/002-trond-build-pipeline/quickstart.md`** (new) — copy/pasteable walkthrough covering builder choice, intent shape, preflight expectations, apply envelope, SSH-target flow, image artifacts (gradle + jar-wrap strategies), cache mgmt, MCP tool reference, troubleshooting.
- **`README.md`** — new "Dev loop — build from source" section after Quickstart with a minimal example and a pointer to the quickstart; new "Build" command table.
- **`AGENTS.md`** — new "Workflow 5 — Build java-tron from source" with the agent contract; MCP tool inventory updated (16 → 19 with `build_list` / `build_inspect` / `build_prune`); anti-patterns gained #9 (don't `rm -rf ~/.trond/builds`) and #10 (don't pass `--keep-last` alone with `--confirm`).

## Test plan

- [x] `make test` — clean
- [x] `make lint` — clean
- [x] `go test -tags e2e ./cmd -run TestE2E_AgentsMD` — every command shown in AGENTS.md still resolves through cobra (catches stale command names in the new Workflow 5 section)