### PR TITLE
fix(network): join newly added node to the running mesh

### DIFF
--- a/cmd/network/add.go
+++ b/cmd/network/add.go
@@ -3,6 +3,7 @@ package network
 import (
 	"fmt"
 	"os"
+	"slices"
 	"strings"
 	"time"
 
@@ -106,6 +107,14 @@ func runAdd(cmd *cobra.Command, args []string) error {
 			c.Close()
 		}
 	}()
+
+	// Auto-attach the shared docker network so the new node can resolve
+	// sibling container names for P2P peering. Without this it lands only
+	// on its per-compose bridge and stays at 0 peers.
+	sharedNet := "trond-" + addNetworkName
+	if !slices.Contains(node.Networks, sharedNet) {
+		node.Networks = append(node.Networks, sharedNet)
+	}
 
 	templateDir := findTemplatesDir()
 	hocon, err := render.RenderHOCON(templateDir, parsed, node)

--- a/cmd/network/add.go
+++ b/cmd/network/add.go
@@ -116,6 +116,29 @@ func runAdd(cmd *cobra.Command, args []string) error {
 		node.Networks = append(node.Networks, sharedNet)
 	}
 
+	// Auto-populate active_peers from existing nodes in the network so the
+	// new node can dial into the running mesh. P2P connections are
+	// bidirectional once established, so we only update the new node —
+	// no need to reconfigure (and restart) existing siblings, they'll
+	// accept the incoming connection. Skip nodes whose P2PPort is zero
+	// (legacy state predating the field) and skip when the user
+	// explicitly supplied active_peers in the intent.
+	if node.NetworkOverrides.ActivePeers == nil {
+		var existingPeers []string
+		for _, n := range deployState.Nodes {
+			if !strings.HasPrefix(n.Name, prefix) {
+				continue
+			}
+			if n.P2PPort == 0 {
+				continue
+			}
+			existingPeers = append(existingPeers, fmt.Sprintf("%s:%d", n.Name, n.P2PPort))
+		}
+		if len(existingPeers) > 0 {
+			node.NetworkOverrides.ActivePeers = &existingPeers
+		}
+	}
+
 	templateDir := findTemplatesDir()
 	hocon, err := render.RenderHOCON(templateDir, parsed, node)
 	if err != nil {
@@ -158,6 +181,7 @@ func runAdd(cmd *cobra.Command, args []string) error {
 		LastApplied: time.Now().UTC(),
 		HTTPPort:    node.Ports.HTTP,
 		GRPCPort:    node.Ports.GRPC,
+		P2PPort:     node.Ports.P2P,
 		InstallPath: node.InstallPath,
 		Labels:      node.Labels,
 	})

--- a/cmd/network/create.go
+++ b/cmd/network/create.go
@@ -154,6 +154,7 @@ func runCreate(cmd *cobra.Command, args []string) error {
 			LastApplied: time.Now().UTC(),
 			HTTPPort:    node.Ports.HTTP,
 			GRPCPort:    node.Ports.GRPC,
+			P2PPort:     node.Ports.P2P,
 			Labels:      node.Labels,
 		}
 		store.UpsertNode(deployState, mn)

--- a/internal/state/types.go
+++ b/internal/state/types.go
@@ -22,6 +22,10 @@ type ManagedNode struct {
 	// fields — callers must fall back to defaults when zero.
 	HTTPPort int `json:"http_port,omitempty"`
 	GRPCPort int `json:"grpc_port,omitempty"`
+	// P2PPort is the listen.port a sibling can dial to peer with this node.
+	// `network add` reads it from every existing entry to populate the new
+	// node's active_peers so it can immediately join the P2P mesh.
+	P2PPort int `json:"p2p_port,omitempty"`
 	// Labels mirror intent.NodeSpec.Labels and survive across CLI sessions
 	// so test harnesses can filter via `trond list --label key=value`
 	// without touching the original intent file.


### PR DESCRIPTION
**What does this PR do?**

Fixes `trond network add` so the new node actually joins the running private network instead of sitting orphaned. Two related fixes:

1. Attach the new container to the shared `trond-<name>` docker network (was only on its per-compose bridge).
2. Auto-populate `node.active` from existing nodes in state so the new node knows whom to dial.

Adds a `state.ManagedNode.P2PPort` field so step 2 can read the listen port without the create-time intent.

**Why are these changes required?**

`network create` already does both steps via the `sharedNet` loop and `autoWireActivePeers` in `cmd/network/create.go`. `network add` was never updated to mirror them, so an added node has no DNS reachability to siblings and no peer list to dial — it stays at 0 peers and never syncs blocks, even though state and naming look correct.

**This PR has been tested by:**

- Unit Tests — `go build ./...` clean.
- Manual Testing — created a 2-node private network via `trond network create`, added a third fullnode via `trond network add`. Verified the new container attaches to `trond-<name>`, the rendered HOCON contains the populated `node.active` list, and the new node received blocks 1–38 over P2P from the witness within ~30s (`RestartCount=0`).
- Backward compatibility — `P2PPort` uses `omitempty`; legacy state entries read as `0` and are skipped from the auto-wire (same convention as `HTTPPort` / `GRPCPort`).

**Follow up**

- `autoWireActivePeers` runs only at create time; this PR fills the gap unilaterally for the new node (sufficient because P2P channels are bidirectional once established), but the design may warrant revisiting for denser networks.
- Pre-existing bug, unrelated: `trond diagnose` reports `peer_count=0` for clearly-peered nodes because its probe queries `/wallet/listnodes`, which only surfaces discovery-found peers. Tracking separately.

**Extra details**
