### PR TITLE
test(dbfork): copy-on-write equivalence fixture via internal/fsclone

### DIFF
--- a/.github/workflows/dbfork-equivalence.yml
+++ b/.github/workflows/dbfork-equivalence.yml
@@ -191,6 +191,33 @@ jobs:
           ls -1 "$DB"
           df -h . | tail -1
 
+      - name: Probe copy-on-write support on the fixture filesystem
+        # internal/fsclone.CloneDir reflinks the fixture into adjacent
+        # scratch dirs to avoid a multi-GB byte copy per run. That only
+        # speeds up the gate if the runner's filesystem actually supports
+        # copy-on-write — GitHub's ext4 runners usually do NOT, in which
+        # case CloneDir silently falls back to a full copy. This probe
+        # makes the difference observable instead of guessing: it logs the
+        # device IDs of the fixture vs the scratch parent (a mismatch ⇒
+        # cross-device ⇒ EXDEV ⇒ no reflink) and the result of a real
+        # `cp --reflink=always`. Non-blocking: it never fails the job, it
+        # just tells us whether the optimization fired. (Task #185 / #186.)
+        if: always()
+        run: |
+          set -uo pipefail
+          DB="${{ github.workspace }}/nile-fixture/output-directory"
+          if [ ! -d "$DB" ]; then echo "fixture dir absent, skipping probe"; exit 0; fi
+          echo "fixture device : $(stat -c '%d' "$DB" 2>/dev/null || echo '?')  ($(stat -f -c '%T' "$DB" 2>/dev/null || echo '?'))"
+          echo "scratch device : $(stat -c '%d' "$(dirname "$DB")" 2>/dev/null || echo '?')  (scratch is created adjacent to the fixture, so this should match)"
+          probe="$DB/.cow-probe"
+          head -c 1048576 /dev/zero > "$probe" 2>/dev/null || true
+          if cp --reflink=always "$probe" "$probe.clone" 2>/dev/null; then
+            echo "REFLINK: SUPPORTED on the fixture filesystem — CloneDir will copy-on-write (gate is fast)"
+          else
+            echo "REFLINK: NOT supported on the fixture filesystem — CloneDir falls back to byte copy (gate is as slow as before; the optimization only helps on CoW filesystems)"
+          fi
+          rm -f "$probe" "$probe.clone" 2>/dev/null || true
+
       - name: Run equivalence test
         env:
           DBFORK_NILE_FIXTURE: ${{ github.workspace }}/nile-fixture/output-directory

--- a/TODOS.md
+++ b/TODOS.md
@@ -1,0 +1,24 @@
+# TODOS
+
+Deferred work captured during reviews. Each item carries enough context to pick
+up cold.
+
+## Public `trond snapshot clone` verb
+
+- **What:** Expose the `internal/fsclone` copy-on-write clone primitive as a
+  user-facing `trond snapshot clone <src> <dst>` CLI verb.
+- **Why:** Lets agents / operators build a warm pool of fixtures interactively —
+  clone a cached, pinned snapshot to a fresh isolated dir in seconds instead of
+  re-downloading or re-copying 30–90 GB.
+- **Pros:** Completes the warm-pool story as a first-class capability; useful for
+  the "a new agent just uses trond" workflow.
+- **Cons:** Speculative public API with only one consumer today (the equivalence
+  test). Adds CLI surface, docs, and a test matrix for a capability nobody is
+  asking for interactively yet.
+- **Context:** Deferred during the 2026-06-13 `/plan-eng-review` (Issue 1). The
+  reusable primitive lives in `internal/fsclone` (`x/sys/unix` clonefile/FICLONE
+  with byte-copy fallback). The outside-voice (Codex) Net agreed: don't broaden
+  to a public verb until a second real consumer exists AND CI proves CoW is
+  available where it matters.
+- **Depends on / blocked by:** `internal/fsclone` primitive landing (this PR);
+  a concrete second consumer (e.g. an agent warm-pool flow or `apply --snapshot`).

--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,7 @@ require (
 	go.opentelemetry.io/otel/sdk v1.43.0
 	go.opentelemetry.io/otel/trace v1.43.0
 	golang.org/x/crypto v0.52.0
+	golang.org/x/sys v0.45.0
 	google.golang.org/protobuf v1.36.11
 	gopkg.in/yaml.v3 v3.0.1
 )
@@ -50,7 +51,6 @@ require (
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/net v0.54.0 // indirect
 	golang.org/x/oauth2 v0.35.0 // indirect
-	golang.org/x/sys v0.45.0 // indirect
 	golang.org/x/text v0.37.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260401024825-9d38bb4040a9 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260401024825-9d38bb4040a9 // indirect

--- a/internal/dbfork/equivalence_test.go
+++ b/internal/dbfork/equivalence_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/hex"
 	"fmt"
-	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -18,6 +17,7 @@ import (
 	"github.com/tronprotocol/tron-deployment/internal/dbfork/db"
 	pb "github.com/tronprotocol/tron-deployment/internal/dbfork/proto/pb"
 	"github.com/tronprotocol/tron-deployment/internal/dbfork/stores"
+	"github.com/tronprotocol/tron-deployment/internal/fsclone"
 )
 
 // equivalenceEnv is the set of environment variables that gate the
@@ -104,8 +104,22 @@ func TestEquivalence_GoVsJava(t *testing.T) {
 	// identical 8 (DbFork.java:120-127) and nothing else. So copying
 	// only AllStores is provably sufficient AND cuts each scratch copy
 	// from ~90 GB to a few GB.
-	scratchGo := t.TempDir()
-	scratchJava := t.TempDir()
+	// Scratch dirs live ADJACENT to the fixture (same filesystem), NOT
+	// under t.TempDir(). t.TempDir() resolves under os.TempDir()
+	// (/var/folders, /tmp), which is frequently a different filesystem
+	// than the cached fixture — and a copy-on-write clone across
+	// filesystems fails with EXDEV and silently degrades to a full byte
+	// copy. Co-locating scratch with the fixture is what lets
+	// fsclone.CloneDir actually reflink; otherwise the optimization fires
+	// nowhere (Task #185 review, Codex finding #4).
+	fixtureParent := filepath.Dir(fixturePath)
+	scratchRoot, err := os.MkdirTemp(fixtureParent, "dbfork-scratch-*")
+	if err != nil {
+		t.Fatalf("equivalence: create scratch root adjacent to fixture: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(scratchRoot) })
+	scratchGo := filepath.Join(scratchRoot, "go")
+	scratchJava := filepath.Join(scratchRoot, "java")
 	t.Logf("equivalence: scratchGo=%s scratchJava=%s", scratchGo, scratchJava)
 	for _, dst := range []string{scratchGo, scratchJava} {
 		for _, store := range stores.AllStores {
@@ -117,9 +131,11 @@ func TestEquivalence_GoVsJava(t *testing.T) {
 				t.Logf("equivalence: store %q absent in fixture, skipping copy: %v", store, statErr)
 				continue
 			}
-			if err := copyDir(src, filepath.Join(dst, "database", store)); err != nil {
-				t.Fatalf("equivalence: copy store %q to %s: %v", store, dst, err)
+			method, cloneErr := fsclone.CloneDir(src, filepath.Join(dst, "database", store))
+			if cloneErr != nil {
+				t.Fatalf("equivalence: materialise store %q to %s: %v", store, dst, cloneErr)
 			}
+			t.Logf("equivalence: %s/%s materialised via %s", filepath.Base(dst), store, method)
 		}
 	}
 
@@ -597,50 +613,10 @@ func sortedHexKeys(m map[string][]byte) []string {
 	return out
 }
 
-// copyDir recursively copies src into dst, creating dst if missing.
-// Used to lay down two independent mutable scratch copies of the
-// Nile fixture. Symlinks are followed; permissions preserved.
-func copyDir(src, dst string) error {
-	return filepath.WalkDir(src, func(path string, d os.DirEntry, err error) error {
-		if err != nil {
-			return err
-		}
-		rel, _ := filepath.Rel(src, path)
-		target := filepath.Join(dst, rel)
-		if d.IsDir() {
-			info, err := d.Info()
-			if err != nil {
-				return err
-			}
-			return os.MkdirAll(target, info.Mode().Perm())
-		}
-		return copyFile(path, target)
-	})
-}
-
-func copyFile(src, dst string) error {
-	in, err := os.Open(src)
-	if err != nil {
-		return err
-	}
-	defer in.Close()
-	if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
-		return err
-	}
-	info, err := os.Stat(src)
-	if err != nil {
-		return err
-	}
-	out, err := os.OpenFile(dst, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, info.Mode().Perm())
-	if err != nil {
-		return err
-	}
-	defer out.Close()
-	if _, err := io.Copy(out, in); err != nil {
-		return err
-	}
-	return nil
-}
+// Fixture materialisation (CoW clone with byte-copy fallback) lives in
+// internal/fsclone now — see fsclone.CloneDir, exercised above. The
+// former test-local cloneDir/copyDir/copyFile were lifted there so there
+// is a single clone+copy implementation (Task #185 review, DRY).
 
 // --- Diff-helper unit tests ----------------------------------------------
 //
@@ -835,41 +811,12 @@ func TestKeysOnlyIn_ReturnsDifference(t *testing.T) {
 	}
 }
 
-// TestCopyDir_RoundTrip is a tiny round-trip: write a few files into
-// tmpA, copy to tmpB, verify identical contents. Catches a regression
-// in the filepath.WalkDir loop without needing the multi-GB Nile
-// fixture.
-func TestCopyDir_RoundTrip(t *testing.T) {
-	src := t.TempDir()
-	dst := filepath.Join(t.TempDir(), "copy")
-	files := map[string][]byte{
-		"a.txt":          []byte("alpha"),
-		"sub/b.txt":      []byte("bravo"),
-		"sub/deep/c.txt": []byte("charlie"),
-	}
-	for name, content := range files {
-		full := filepath.Join(src, name)
-		if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(full, content, 0o644); err != nil {
-			t.Fatal(err)
-		}
-	}
-	if err := copyDir(src, dst); err != nil {
-		t.Fatalf("copyDir: %v", err)
-	}
-	for name, want := range files {
-		got, err := os.ReadFile(filepath.Join(dst, name))
-		if err != nil {
-			t.Errorf("read %s: %v", name, err)
-			continue
-		}
-		if !bytes.Equal(got, want) {
-			t.Errorf("%s: got %q, want %q", name, got, want)
-		}
-	}
-}
+// Round-trip + independence + forced-fallback coverage for the fixture
+// clone now lives with the implementation in internal/fsclone
+// (TestCloneDir_RoundTrip, TestCloneDir_ForcedFallback,
+// TestRecursiveCopy_RoundTrip). Keeping the tests next to CloneDir means
+// the seam that forces the byte-copy fallback can be exercised
+// deterministically on any host — see Task #185.
 
 // Note: the "skip cleanly when env vars missing" path is exercised
 // by every `go test ./...` run on a machine without the Java toolkit

--- a/internal/fsclone/clone.go
+++ b/internal/fsclone/clone.go
@@ -1,0 +1,115 @@
+// Package fsclone materialises a directory tree as an independent copy,
+// preferring a copy-on-write clone (APFS clonefile on macOS, reflink /
+// FICLONE on Linux) and falling back to a byte copy when the platform
+// or filesystem can't reflink.
+//
+// Why this exists: callers that stand up throwaway copies of a large
+// on-disk tree — the dbfork equivalence gate clones an 8-store Nile
+// snapshot twice per run — pay a multi-GB recursive copy each time once
+// the source is cached locally. A CoW clone shares the underlying
+// extents, so the copy is created in milliseconds at near-zero extra
+// space; the first write to a block transparently splits it off, so the
+// clone is fully independent of the source.
+//
+// Contract (intentionally narrow — see Task #185 review):
+//   - The clone preserves file CONTENT and permission bits. It does NOT
+//     preserve xattrs, ACLs, hardlink topology, or ownership.
+//   - Symlinks: the tree is expected to contain only regular files and
+//     directories (true for LevelDB/RocksDB stores). The clone path
+//     treats a non-regular entry as "unsupported" and falls back to the
+//     byte copy, which dereferences symlinks. Don't rely on symlink
+//     fidelity.
+//   - The source must be quiescent. Cloning a live, mutating directory
+//     (e.g. a running node's DB) gives an undefined point-in-time view.
+//   - dst MUST NOT already exist — CloneDir refuses rather than merge or
+//     overwrite, so it can never clobber caller data.
+//
+// CoW vs copy is transparent: the only observable difference is speed
+// and the returned method string.
+package fsclone
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+)
+
+// errUnsupported is returned (wrapped) by a platform cloneTree when the
+// filesystem can't do a copy-on-write clone — a cross-device link, a
+// non-reflink filesystem, or a platform with no clone syscall. It is the
+// ONLY error class that triggers the byte-copy fallback; every other
+// error (permission denied, ENOSPC, unreadable source) propagates so a
+// real failure is never silently masked as a slow copy.
+var errUnsupported = errors.New("fsclone: copy-on-write not supported")
+
+// Method names returned by CloneDir, for observability (test logs, the
+// CI CoW probe). Coarse by design: "the whole tree cloned" vs "fell back
+// to a byte copy". cloneMethodName is the platform's CoW label
+// ("clonefile" on darwin, "ficlone" on linux); methodCopy is the
+// fallback.
+const methodCopy = "copy"
+
+// platformClone is the copy-on-write implementation for the current OS,
+// bound to the build-tagged cloneTree. It is a package var (not a direct
+// call) purely as a test seam: clone_test.go swaps it to return
+// errUnsupported so the fallback orchestration is exercised
+// deterministically on any host, including CoW filesystems where the
+// real clone would always succeed.
+var platformClone = cloneTree
+
+// CloneDir materialises src at dst as an independent copy and reports the
+// method used ("clonefile" | "ficlone" | "copy").
+//
+// It stages the work in a temp directory it creates as a sibling of dst
+// (so the temp lands on dst's filesystem — required for the rename to be
+// atomic and for the CoW clone to share extents), then renames the
+// staged tree into place. On any failure only the primitive's own temp
+// dir is removed; caller data at or around dst is never touched.
+//
+// dst must not exist. src must exist and be readable.
+func CloneDir(src, dst string) (method string, err error) {
+	if _, statErr := os.Stat(src); statErr != nil {
+		return "", fmt.Errorf("fsclone: source %s: %w", src, statErr)
+	}
+	if _, statErr := os.Stat(dst); statErr == nil {
+		return "", fmt.Errorf("fsclone: destination %s already exists", dst)
+	} else if !errors.Is(statErr, fs.ErrNotExist) {
+		return "", fmt.Errorf("fsclone: stat destination %s: %w", dst, statErr)
+	}
+
+	parent := filepath.Dir(dst)
+	if mkErr := os.MkdirAll(parent, 0o755); mkErr != nil {
+		return "", fmt.Errorf("fsclone: create parent %s: %w", parent, mkErr)
+	}
+	// Stage in a temp dir on dst's filesystem. The clone/copy builds into
+	// staged, then we rename staged -> dst (atomic, same filesystem).
+	tmp, mkErr := os.MkdirTemp(parent, ".fsclone-*")
+	if mkErr != nil {
+		return "", fmt.Errorf("fsclone: create staging dir in %s: %w", parent, mkErr)
+	}
+	defer os.RemoveAll(tmp) // removes the empty husk after rename, or the partial tree on error
+	staged := filepath.Join(tmp, "payload")
+
+	method = cloneMethodName
+	if cloneErr := platformClone(src, staged); cloneErr != nil {
+		if !errors.Is(cloneErr, errUnsupported) {
+			return "", cloneErr // real error — do NOT mask as a slow copy
+		}
+		// CoW genuinely unavailable: drop any partial clone and do a full
+		// byte copy into a clean staging path.
+		if rmErr := os.RemoveAll(staged); rmErr != nil {
+			return "", fmt.Errorf("fsclone: clean partial clone %s: %w", staged, rmErr)
+		}
+		if cpErr := recursiveCopy(src, staged); cpErr != nil {
+			return "", cpErr
+		}
+		method = methodCopy
+	}
+
+	if renErr := os.Rename(staged, dst); renErr != nil {
+		return "", fmt.Errorf("fsclone: finalize %s -> %s: %w", staged, dst, renErr)
+	}
+	return method, nil
+}

--- a/internal/fsclone/clone.go
+++ b/internal/fsclone/clone.go
@@ -89,7 +89,10 @@ func CloneDir(src, dst string) (method string, err error) {
 	if mkErr != nil {
 		return "", fmt.Errorf("fsclone: create staging dir in %s: %w", parent, mkErr)
 	}
-	defer os.RemoveAll(tmp) // removes the empty husk after rename, or the partial tree on error
+	// Removes the empty husk after a successful rename, or the partial
+	// tree on error. Best-effort temp cleanup — a failure here is
+	// non-actionable, so the error is deliberately discarded.
+	defer func() { _ = os.RemoveAll(tmp) }()
 	staged := filepath.Join(tmp, "payload")
 
 	method = cloneMethodName

--- a/internal/fsclone/clone_darwin.go
+++ b/internal/fsclone/clone_darwin.go
@@ -1,0 +1,32 @@
+//go:build darwin
+
+package fsclone
+
+import (
+	"fmt"
+
+	"golang.org/x/sys/unix"
+)
+
+// cloneMethodName labels a successful darwin clone in CloneDir's result.
+const cloneMethodName = "clonefile"
+
+// cloneTree clones src to dst via clonefile(2). Unlike Linux's per-file
+// FICLONE, clonefile recursively clones an entire directory hierarchy in
+// a single syscall when src is a directory, so there's no manual walk on
+// darwin. dst must not exist (clonefile creates it).
+//
+// flags=0: clonefile follows a top-level symlink src and clones nested
+// entries structurally. The fsclone contract assumes regular files +
+// dirs only, so this is fine for the snapshot stores we clone.
+func cloneTree(src, dst string) error {
+	err := unix.Clonefile(src, dst, 0)
+	if err == nil {
+		return nil
+	}
+	if isUnsupportedCoW(err) {
+		// e.g. cloning across volumes (EXDEV) or onto a non-APFS target.
+		return fmt.Errorf("fsclone: clonefile %s: %w", src, errUnsupported)
+	}
+	return fmt.Errorf("fsclone: clonefile %s -> %s: %w", src, dst, err)
+}

--- a/internal/fsclone/clone_fallback.go
+++ b/internal/fsclone/clone_fallback.go
@@ -1,0 +1,17 @@
+//go:build !darwin && !linux
+
+package fsclone
+
+import "fmt"
+
+// cloneMethodName is unused on platforms without a clone syscall — every
+// CloneDir call falls back to the byte copy — but must exist so clone.go
+// compiles. The "copy" value keeps the result string honest if it ever
+// surfaces.
+const cloneMethodName = methodCopy
+
+// cloneTree always reports unsupported on platforms with no copy-on-write
+// syscall (e.g. Windows), so CloneDir does a plain byte copy.
+func cloneTree(src, dst string) error {
+	return fmt.Errorf("fsclone: no copy-on-write syscall on this platform: %w", errUnsupported)
+}

--- a/internal/fsclone/clone_linux.go
+++ b/internal/fsclone/clone_linux.go
@@ -1,0 +1,83 @@
+//go:build linux
+
+package fsclone
+
+import (
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+
+	"golang.org/x/sys/unix"
+)
+
+// cloneMethodName labels a successful Linux clone in CloneDir's result.
+const cloneMethodName = "ficlone"
+
+// cloneTree reflinks src into dst. FICLONE is per-file (not recursive
+// like darwin's clonefile), so we recreate the directory structure and
+// reflink each regular file.
+//
+// All-or-nothing semantics: the first file the filesystem can't reflink
+// returns errUnsupported, which makes CloneDir discard the partial tree
+// and do one clean byte copy of the whole source — simpler and more
+// predictable than a half-cloned/half-copied tree, and Go's io.Copy
+// already uses copy_file_range/sendfile under the hood, so the byte-copy
+// fallback is itself kernel-accelerated where possible.
+func cloneTree(src, dst string) error {
+	return filepath.WalkDir(src, func(path string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		rel, relErr := filepath.Rel(src, path)
+		if relErr != nil {
+			return relErr
+		}
+		target := filepath.Join(dst, rel)
+
+		if d.IsDir() {
+			info, infoErr := d.Info()
+			if infoErr != nil {
+				return infoErr
+			}
+			return os.MkdirAll(target, info.Mode().Perm())
+		}
+		if !d.Type().IsRegular() {
+			// Symlinks / sockets / devices: FICLONE can't handle them.
+			// Signal unsupported so the whole tree falls back to the byte
+			// copy, keeping clone and copy semantics consistent.
+			return fmt.Errorf("fsclone: non-regular file %s: %w", path, errUnsupported)
+		}
+		return ficloneFile(path, target)
+	})
+}
+
+// ficloneFile reflinks a single regular file src -> dst via the FICLONE
+// ioctl, creating dst's parent dir and preserving src's permission bits.
+func ficloneFile(src, dst string) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+	info, err := in.Stat()
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+		return err
+	}
+	out, err := os.OpenFile(dst, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, info.Mode().Perm())
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+
+	if err := unix.IoctlFileClone(int(out.Fd()), int(in.Fd())); err != nil {
+		if isUnsupportedCoW(err) {
+			return fmt.Errorf("fsclone: ficlone %s: %w", src, errUnsupported)
+		}
+		return fmt.Errorf("fsclone: ficlone %s -> %s: %w", src, dst, err)
+	}
+	return nil
+}

--- a/internal/fsclone/clone_test.go
+++ b/internal/fsclone/clone_test.go
@@ -1,0 +1,154 @@
+package fsclone
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// writeTree lays down a small fixture tree under root and returns the
+// name→content map it created.
+func writeTree(t *testing.T, root string) map[string][]byte {
+	t.Helper()
+	files := map[string][]byte{
+		"a.txt":          []byte("alpha"),
+		"sub/b.txt":      []byte("bravo"),
+		"sub/deep/c.txt": []byte("charlie"),
+	}
+	for name, content := range files {
+		full := filepath.Join(root, name)
+		if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(full, content, 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return files
+}
+
+func assertTree(t *testing.T, dst string, want map[string][]byte) {
+	t.Helper()
+	for name, content := range want {
+		got, err := os.ReadFile(filepath.Join(dst, name))
+		if err != nil {
+			t.Errorf("read %s: %v", name, err)
+			continue
+		}
+		if !bytes.Equal(got, content) {
+			t.Errorf("%s: got %q, want %q", name, got, content)
+		}
+	}
+}
+
+// TestCloneDir_RoundTrip exercises whichever real path the host takes
+// (CoW on APFS/btrfs/xfs, byte copy otherwise): content must be
+// identical AND the clone must be independent — writing it must not
+// touch the source. Independence is the property the dbfork gate relies
+// on (two separately-mutable scratch copies).
+func TestCloneDir_RoundTrip(t *testing.T) {
+	src := t.TempDir()
+	want := writeTree(t, src)
+
+	dst := filepath.Join(t.TempDir(), "clone")
+	method, err := CloneDir(src, dst)
+	if err != nil {
+		t.Fatalf("CloneDir: %v", err)
+	}
+	t.Logf("CloneDir method: %s", method)
+	if method != cloneMethodName && method != methodCopy {
+		t.Errorf("unexpected method %q", method)
+	}
+	assertTree(t, dst, want)
+
+	// Independence: mutate the clone, source must be unchanged.
+	if err := os.WriteFile(filepath.Join(dst, "a.txt"), []byte("CHANGED"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	srcA, err := os.ReadFile(filepath.Join(src, "a.txt"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(srcA, []byte("alpha")) {
+		t.Errorf("clone not independent: source a.txt became %q", srcA)
+	}
+}
+
+// TestCloneDir_ForcedFallback swaps the platform clone seam to report
+// unsupported, so the fallback orchestration (discard partial → byte
+// copy → atomic rename) runs deterministically on ANY host — including
+// CoW filesystems where the real clone would always succeed and this
+// branch would otherwise never execute.
+func TestCloneDir_ForcedFallback(t *testing.T) {
+	orig := platformClone
+	t.Cleanup(func() { platformClone = orig })
+	platformClone = func(src, dst string) error { return errUnsupported }
+
+	src := t.TempDir()
+	want := writeTree(t, src)
+	dst := filepath.Join(t.TempDir(), "clone")
+
+	method, err := CloneDir(src, dst)
+	if err != nil {
+		t.Fatalf("CloneDir (forced fallback): %v", err)
+	}
+	if method != methodCopy {
+		t.Errorf("forced fallback should report %q, got %q", methodCopy, method)
+	}
+	assertTree(t, dst, want)
+}
+
+// TestCloneDir_RealErrorPropagates proves a non-CoW error from the
+// platform clone is NOT masked as a slow copy — it propagates, so a
+// genuine I/O failure can't masquerade as success.
+func TestCloneDir_RealErrorPropagates(t *testing.T) {
+	orig := platformClone
+	t.Cleanup(func() { platformClone = orig })
+	boom := os.ErrPermission
+	platformClone = func(src, dst string) error { return boom }
+
+	src := t.TempDir()
+	writeTree(t, src)
+	dst := filepath.Join(t.TempDir(), "clone")
+
+	if _, err := CloneDir(src, dst); err == nil {
+		t.Fatal("expected the real error to propagate, got nil")
+	}
+	// And dst must not have been created from a silent fallback.
+	if _, err := os.Stat(dst); !os.IsNotExist(err) {
+		t.Errorf("dst should not exist after a propagated error, stat err=%v", err)
+	}
+}
+
+// TestCloneDir_RefusesExistingDst pins the no-clobber contract.
+func TestCloneDir_RefusesExistingDst(t *testing.T) {
+	src := t.TempDir()
+	writeTree(t, src)
+	dst := t.TempDir() // already exists
+	if _, err := CloneDir(src, dst); err == nil {
+		t.Fatal("expected CloneDir to refuse an existing destination")
+	}
+}
+
+// TestCloneDir_MissingSrc pins that an unreadable/absent source is a
+// clean error, not a panic or a silent empty clone.
+func TestCloneDir_MissingSrc(t *testing.T) {
+	src := filepath.Join(t.TempDir(), "does-not-exist")
+	dst := filepath.Join(t.TempDir(), "clone")
+	if _, err := CloneDir(src, dst); err == nil {
+		t.Fatal("expected error for missing source")
+	}
+}
+
+// TestRecursiveCopy_RoundTrip pins the byte-copy fallback directly,
+// independent of any CoW path.
+func TestRecursiveCopy_RoundTrip(t *testing.T) {
+	src := t.TempDir()
+	want := writeTree(t, src)
+	dst := filepath.Join(t.TempDir(), "copy")
+	if err := recursiveCopy(src, dst); err != nil {
+		t.Fatalf("recursiveCopy: %v", err)
+	}
+	assertTree(t, dst, want)
+}

--- a/internal/fsclone/clone_unix.go
+++ b/internal/fsclone/clone_unix.go
@@ -1,0 +1,38 @@
+//go:build darwin || linux
+
+package fsclone
+
+import (
+	"errors"
+
+	"golang.org/x/sys/unix"
+)
+
+// isUnsupportedCoW reports whether err means "this filesystem / target
+// can't do a copy-on-write clone" — as opposed to a real I/O failure.
+// Only these errnos trigger CloneDir's byte-copy fallback:
+//
+//	EXDEV       cross-device link (src and dst on different filesystems)
+//	EOPNOTSUPP  filesystem doesn't implement clone (ext4, tmpfs, NFS, …)
+//	ENOTSUP     darwin's spelling of the same
+//	ENOTTY      ioctl not supported by this file/fs
+//	EINVAL      clone args rejected (e.g. non-reflink fs returning EINVAL)
+//	ENOSYS      syscall absent on this kernel
+//
+// Everything else (EPERM, ENOSPC, EIO, ENOENT, …) is a genuine error and
+// must propagate, never be masked as a slow copy.
+func isUnsupportedCoW(err error) bool {
+	for _, e := range []unix.Errno{
+		unix.EXDEV,
+		unix.EOPNOTSUPP,
+		unix.ENOTSUP,
+		unix.ENOTTY,
+		unix.EINVAL,
+		unix.ENOSYS,
+	} {
+		if errors.Is(err, e) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/fsclone/copy.go
+++ b/internal/fsclone/copy.go
@@ -1,0 +1,69 @@
+package fsclone
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+)
+
+// recursiveCopy is the byte-copy fallback used when a copy-on-write clone
+// isn't available. It is the single recursive-copy implementation in the
+// tree (the dbfork equivalence gate used to carry its own copyDir; that
+// has been deleted in favour of this).
+//
+// It mirrors the clone contract: preserves content and permission bits,
+// creates dst, and dereferences symlinks (os.Open follows the link and
+// copies the target's bytes as a regular file). xattrs, ACLs, ownership,
+// and hardlink topology are NOT preserved.
+//
+// On Linux io.Copy uses copy_file_range/sendfile under the hood for
+// regular *os.File pairs, so even this "fallback" is kernel-accelerated
+// where the kernel supports it — there's no separate copy_file_range
+// path to maintain.
+func recursiveCopy(src, dst string) error {
+	return filepath.WalkDir(src, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		rel, relErr := filepath.Rel(src, path)
+		if relErr != nil {
+			return relErr
+		}
+		target := filepath.Join(dst, rel)
+		if d.IsDir() {
+			info, infoErr := d.Info()
+			if infoErr != nil {
+				return infoErr
+			}
+			return os.MkdirAll(target, info.Mode().Perm())
+		}
+		return copyFile(path, target)
+	})
+}
+
+// copyFile copies one file src -> dst, creating dst's parent directory
+// and preserving src's permission bits.
+func copyFile(src, dst string) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+	info, err := os.Stat(src)
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+		return err
+	}
+	out, err := os.OpenFile(dst, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, info.Mode().Perm())
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+	if _, err := io.Copy(out, in); err != nil {
+		return fmt.Errorf("fsclone: copy %s -> %s: %w", src, dst, err)
+	}
+	return nil
+}


### PR DESCRIPTION
## What

Replace the dbfork equivalence gate's per-store byte copy with a copy-on-write clone, in a new reusable `internal/fsclone` package.

## Why

`TestEquivalence_GoVsJava` materialises the 8 dbfork stores **twice** per run (`scratchGo` + `scratchJava`). Once the Nile snapshot is cached, that recursive copy is the dominant wall-clock cost — multi-GB on the RocksDB fixture. A copy-on-write clone shares the underlying extents, so each scratch copy is created in milliseconds at near-zero extra space; the first write to a block transparently splits it off, preserving the per-scratch independence the diff requires.

## How

**`internal/fsclone.CloneDir(src, dst) (method, error)`** — build-tagged per platform:
- **darwin:** `clonefile(2)` via `x/sys/unix.Clonefile` — recursively clones a directory tree in one syscall.
- **linux:** walk + `FICLONE` per regular file (`x/sys/unix.IoctlFileClone`).
- **other:** byte-copy fallback.

Safety contract (a reusable primitive, not just a test helper):
- Stages into a temp dir it creates as a sibling of `dst`, then **atomic rename** into place.
- **Refuses a pre-existing `dst`** — never merges or clobbers.
- On failure removes only its own temp dir, never caller data.
- Falls back to a byte copy **only** on copy-on-write-unsupported errnos (`EXDEV`/`EOPNOTSUPP`/`ENOTSUP`/`ENOTTY`/`EINVAL`/`ENOSYS`); real errors (EPERM, ENOSPC, unreadable source) propagate instead of being silently masked as a slow copy.
- No manual `copy_file_range` layer — Go's `io.Copy` already uses it for `*os.File` on linux, so the fallback is kernel-accelerated where supported.

**Equivalence test:**
- Scratch dirs are now created **adjacent to the fixture** (same filesystem) instead of under `t.TempDir()`. `t.TempDir()` resolves under `os.TempDir()`, frequently a different filesystem than the cached fixture — so a clone across them returns `EXDEV` and silently degrades to a full copy, meaning the optimization would fire **nowhere**. Co-locating scratch with the fixture is what lets the clone actually reflink.
- Calls `fsclone.CloneDir`; the test-local `cloneDir`/`copyDir`/`copyFile` and their round-trip tests are deleted — there is now a single clone+copy implementation.

## Tests

`internal/fsclone` covers: round-trip + independence; a seam that **forces the byte-copy fallback deterministically on any host** (so the fallback orchestration is tested even on CoW filesystems where the real clone always succeeds); real-error propagation; pre-existing-dst refusal; missing-source error; and the `recursiveCopy` fallback directly.

Verified: gofmt/vet clean, `go build ./...`, fsclone + dbfork unit tests pass, and cross-compile builds for linux amd64/arm64 (FICLONE path), darwin, and the windows fallback.

## CI

`dbfork-equivalence.yml` gains a non-blocking copy-on-write probe that logs the fixture vs scratch device IDs and a `cp --reflink=always` result, so the run shows whether the clone actually reflinked on the runner or fell back to a copy. (GitHub's ext4 runners typically don't reflink — the win lands on copy-on-write filesystems; the probe makes that observable rather than guessed.)

## Follow-up

`TODOS.md` captures a deferred public `trond snapshot clone` verb — left internal until a second real consumer (e.g. an agent warm-pool flow or `apply --snapshot`) exists.
