### PR TITLE
docs(agents): sync MCP surface in AGENTS.md (23 tools + 4 prompts)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -231,6 +231,7 @@ while true; do
   sleep 60
 done
 # Or stream progress:  trond snapshot logs <job_id> -f
+# Cancel a running detached job:  trond snapshot stop <job_id> -o json
 
 # 5. Once done, the chain DB sits at <dest>/output-directory/database.
 #    Now apply with an intent whose storage.data points there.
@@ -612,14 +613,22 @@ Configure once in your client. Example for Claude Desktop
 }
 ```
 
-The server registers 20 tools (read-only unless marked):
+The server registers 23 tools (read-only unless marked):
 
 - **inspection** (3): `list`, `status`, `inspect`
 - **diagnostic** (4): `doctor`, `version`, `health`, `diagnose`
-- **config** (2): `config_validate`, `config_render`
+- **config** (3): `config_validate`, `config_render`, `verify_config`
+  (read-only — pulls the live node's `.conf`, renders fresh HOCON from
+  `--intent`, returns `diffs[]`; a cheap reconcile signal before
+  deciding whether `apply` is warranted)
+- **remediation** (1): `auto_heal` (destructive — runs the diagnostic
+  suite then applies only safe, idempotent fixes to fail checks, e.g.
+  start a stopped node; everything else surfaces in `skipped[]` with a
+  human suggestion. Pass `dry_run=true` to propose without acting)
 - **lifecycle** (2): `plan`, `apply` (destructive)
 - **snapshot** (4): `snapshot_sources`, `snapshot_list`, `snapshot_jobs`,
-  `snapshot_download` (destructive, emits MCP progress notifications)
+  `snapshot_download` (destructive, emits MCP progress notifications).
+  Job control (`snapshot stop`, `snapshot logs`) is CLI-only.
 - **knowledge** (2): `knowledge_list`, `knowledge_get`
 - **build** (3): `build_list`, `build_inspect`, `build_prune`
   (destructive — dry-run by default; `confirm=true` actually deletes).
@@ -628,6 +637,22 @@ The server registers 20 tools (read-only unless marked):
 - **shadow-fork** (1): `shadow_fork_mutate` (destructive — mutates a
   halted java-tron data dir in place; see Workflow 5 for the full
   recipe).
+
+The server also registers 4 **prompts** — pre-filled playbooks an MCP
+client surfaces as slash-commands / suggested actions. Each orchestrates
+the tools above into a guided multi-step workflow:
+
+- `deploy_fullnode` — validate → preflight → plan → apply → verify a
+  single node from an intent path (Workflow 1).
+- `setup_private_network` — bring up a multi-node private network from a
+  multi-node intent (Workflow 4).
+- `diagnose_failing_node` — the Workflow 2 decision tree as a prompt
+  (status → logs → health → diagnose → suggested fix).
+- `recover_failed_upgrade` — roll a node back to its last-good config
+  after a bad apply.
+
+Prompts are scaffolding, not new capability — they wrap the same tools,
+so an agent that prefers raw tool calls can ignore them.
 
 Destructive tools carry the MCP `destructiveHint` annotation so MCP
 clients prompt the user. The server's `Instructions` field


### PR DESCRIPTION
## What

Sync the `## MCP server` section of `AGENTS.md` with the tools/prompts trond actually registers.

## Why

The doc had drifted from `internal/mcp`, so an agent that reads `AGENTS.md` (the canonical agent contract) would miss real, callable capabilities:

- It said the server "registers **20** tools" — it registers **23**. The breakdown omitted `verify_config` (config-drift, read-only) and `auto_heal` (remediation, destructive).
- The **4 MCP prompts** wired in `prompts.go` (`deploy_fullnode`, `setup_private_network`, `diagnose_failing_node`, `recover_failed_upgrade`) were undocumented — an agent had no way to know the guided playbooks exist.
- `snapshot stop` / `snapshot logs` job control wasn't mentioned.

## Changes

- Tool count 20 → **23**; added `verify_config` to the **config** group and a new **remediation** group for `auto_heal`, each with its read-only/destructive annotation and one-line purpose.
- New **Prompts** subsection listing the 4 prompts and noting they orchestrate the same tools (scaffolding, not new capability).
- Noted snapshot job control is CLI-only and added `trond snapshot stop <job-id>` to the detached-download workflow.

## Verification

Counts checked against source: 23 `AddTool` registrations, 4 `AddPrompt` wired via `registerPrompts` in `server.go`. Docs-only change.

## Not in scope

The Prometheus/Grafana monitoring workflow (PR #185) is intentionally left undocumented here until that PR merges — flagged on #185.
