### PR TITLE
render: add node.metrics.prometheus block to nile + private templates

### DIFF
--- a/internal/render/hocon_test.go
+++ b/internal/render/hocon_test.go
@@ -247,20 +247,45 @@ func TestRenderHOCON_MetricsFeatureEnables(t *testing.T) {
 		}
 	})
 
-	t.Run("nile no prometheus block is a safe no-op", func(t *testing.T) {
+	// Since #167 the nile and private templates ship the same
+	// node.metrics.prometheus block as mainnet (enable = false by
+	// default), so features.metrics flips them on too — the feature is
+	// no longer a silent no-op on those networks.
+	for _, network := range []string{"nile", "private"} {
+		t.Run(network+" flips enable=true", func(t *testing.T) {
+			out, err := RenderHOCON("", &intent.Intent{
+				Name: "m", Network: network, Target: intent.Target{Type: "local"},
+			}, &intent.NodeSpec{
+				Type:     "fullnode",
+				Features: intent.Features{Metrics: &enabled},
+				Ports:    intent.PortMapping{Metrics: 59527},
+			})
+			if err != nil {
+				t.Fatalf("render %s: %v", network, err)
+			}
+			prom := prometheusBlock(t, out)
+			if !strings.Contains(prom, "enable = true") {
+				t.Errorf("%s prometheus.enable not flipped to true; block was:\n%s", network, prom)
+			}
+			if strings.Contains(prom, "enable = false") {
+				t.Errorf("%s prometheus.enable left false despite features.metrics=true; block:\n%s", network, prom)
+			}
+		})
+	}
+
+	t.Run("default off when metrics feature absent", func(t *testing.T) {
+		// Without features.metrics the template default must stand —
+		// prometheus block present (so monitoring/features can later flip
+		// it) but enable = false, so we never expose /metrics unasked.
 		out, err := RenderHOCON("", &intent.Intent{
 			Name: "m", Network: "nile", Target: intent.Target{Type: "local"},
-		}, &intent.NodeSpec{
-			Type:     "fullnode",
-			Features: intent.Features{Metrics: &enabled},
-		})
+		}, &intent.NodeSpec{Type: "fullnode"})
 		if err != nil {
 			t.Fatalf("render nile: %v", err)
 		}
-		// Nile template has no prometheus block; render must not have
-		// synthesised a stray `enable = true` line.
-		if strings.Contains(out, "prometheus") {
-			t.Error("nile render unexpectedly contains a prometheus block")
+		prom := prometheusBlock(t, out)
+		if !strings.Contains(prom, "enable = false") {
+			t.Errorf("nile prometheus.enable should default to false; block:\n%s", prom)
 		}
 	})
 }

--- a/internal/render/hocon_test.go
+++ b/internal/render/hocon_test.go
@@ -290,6 +290,43 @@ func TestRenderHOCON_MetricsFeatureEnables(t *testing.T) {
 	})
 }
 
+// TestRenderHOCON_MetricsAndMonitoringIdempotent pins that setting BOTH
+// features.metrics and monitoring.enabled yields a SINGLE
+// node.metrics.prometheus block with enable=true — never a duplicate.
+// RenderHOCON runs ensureMetricsEnabled (features path) and then
+// ensureMetricsForMonitoring (monitoring path) over the same config; now
+// that every template ships the block (#167) both just flip the existing
+// `enable` line, so they compose idempotently. This guards the
+// interaction across the planned merge of the two functions into one.
+func TestRenderHOCON_MetricsAndMonitoringIdempotent(t *testing.T) {
+	en := true
+	for _, network := range []string{"nile", "private", "mainnet"} {
+		t.Run(network, func(t *testing.T) {
+			out, err := RenderHOCON("", &intent.Intent{
+				Name: "m", Network: network, Target: intent.Target{Type: "local"},
+				Monitoring: &intent.Monitoring{Enabled: &en},
+			}, &intent.NodeSpec{
+				Type:     "fullnode",
+				Features: intent.Features{Metrics: &en},
+				Ports:    intent.PortMapping{Metrics: 59527},
+			})
+			if err != nil {
+				t.Fatalf("render %s: %v", network, err)
+			}
+			if n := strings.Count(out, "node.metrics"); n != 1 {
+				t.Errorf("%s: want exactly one node.metrics block, got %d", network, n)
+			}
+			if n := strings.Count(out, "prometheus {"); n != 1 {
+				t.Errorf("%s: want exactly one prometheus block, got %d", network, n)
+			}
+			prom := prometheusBlock(t, out)
+			if !strings.Contains(prom, "enable = true") {
+				t.Errorf("%s: prometheus.enable not true with both flags set; block:\n%s", network, prom)
+			}
+		})
+	}
+}
+
 func TestRenderHOCON_UnknownNetwork(t *testing.T) {
 	i := &intent.Intent{Network: "martian"}
 	node := &intent.NodeSpec{Type: "fullnode"}

--- a/internal/render/templates/private_net_config.conf
+++ b/internal/render/templates/private_net_config.conf
@@ -139,15 +139,22 @@ node.backup {
 crypto {
   engine = "eckey"
 }
-# prometheus metrics start
-# node.metrics = {
-#  prometheus{
-#    enable=true
-#    port="9527"
-#  }
-# }
+node.metrics = {
+  # prometheus metrics
+  prometheus {
+    enable = false
+    port = 9527
+  }
 
-# prometheus metrics end
+  # influxdb metrics
+  storageEnable = false # Whether write metrics data into InfluxDb. Default: false.
+  influxdb {
+    ip = ""
+    port = 8086
+    database = ""
+    metricsReportInterval = 10
+  }
+}
 
 node {
   # trust node for solidity node

--- a/internal/render/templates/test_net_config.conf
+++ b/internal/render/templates/test_net_config.conf
@@ -104,7 +104,22 @@ node.backup {
   ]
 }
 
+node.metrics = {
+  # prometheus metrics
+  prometheus {
+    enable = false
+    port = 9527
+  }
 
+  # influxdb metrics
+  storageEnable = false # Whether write metrics data into InfluxDb. Default: false.
+  influxdb {
+    ip = ""
+    port = 8086
+    database = ""
+    metricsReportInterval = 10
+  }
+}
 
 node {
   # trust node for solidity node

--- a/internal/render/testdata/golden/nile-fullnode.conf
+++ b/internal/render/testdata/golden/nile-fullnode.conf
@@ -104,7 +104,22 @@ node.backup {
   ]
 }
 
+node.metrics = {
+  # prometheus metrics
+  prometheus {
+    enable = false
+    port = 9527
+  }
 
+  # influxdb metrics
+  storageEnable = false # Whether write metrics data into InfluxDb. Default: false.
+  influxdb {
+    ip = ""
+    port = 8086
+    database = ""
+    metricsReportInterval = 10
+  }
+}
 
 node {
   # trust node for solidity node

--- a/private_net_config.conf
+++ b/private_net_config.conf
@@ -139,15 +139,22 @@ node.backup {
 crypto {
   engine = "eckey"
 }
-# prometheus metrics start
-# node.metrics = {
-#  prometheus{
-#    enable=true
-#    port="9527"
-#  }
-# }
+node.metrics = {
+  # prometheus metrics
+  prometheus {
+    enable = false
+    port = 9527
+  }
 
-# prometheus metrics end
+  # influxdb metrics
+  storageEnable = false # Whether write metrics data into InfluxDb. Default: false.
+  influxdb {
+    ip = ""
+    port = 8086
+    database = ""
+    metricsReportInterval = 10
+  }
+}
 
 node {
   # trust node for solidity node

--- a/test_net_config.conf
+++ b/test_net_config.conf
@@ -104,7 +104,22 @@ node.backup {
   ]
 }
 
+node.metrics = {
+  # prometheus metrics
+  prometheus {
+    enable = false
+    port = 9527
+  }
 
+  # influxdb metrics
+  storageEnable = false # Whether write metrics data into InfluxDb. Default: false.
+  influxdb {
+    ip = ""
+    port = 8086
+    database = ""
+    metricsReportInterval = 10
+  }
+}
 
 node {
   # trust node for solidity node


### PR DESCRIPTION
## What

Add the `node.metrics.prometheus` block to the **nile** and **private** templates (closes the gap tracked as #167).

## Why

The nile template shipped with no `node.metrics` block, and private had it commented out — while mainnet has it. On those two networks `features.metrics: true` was a **silent no-op**: `ensureMetricsEnabled` only flips an *existing* `enable` line and deliberately does **not** synthesize a block (to avoid polluting templates). So `--metrics` on a private/nile node never made java-tron expose `:9527`, and (post the monitoring PR) a `--monitor` private network would scrape nothing.

## Change

Add the same block mainnet already ships — `prometheus { enable = false; port = 9527 }` plus the influxdb stanza — to both templates, in both the **embedded** copies (`internal/render/templates/`, what the binary renders from) and the **root** copies (kept byte-in-sync). `enable` defaults to **false**, so behavior is opt-in:

| intent | result |
|---|---|
| `features.metrics: true` | `ensureMetricsEnabled` flips `enable = true` |
| `monitoring.enabled: true` | `ensureMetricsForMonitoring` flips `enable = true` (now hits the flip path, not append — no double block) |
| neither | stays `false`, `/metrics` not exposed |

## Tests

- Regenerated `nile-fullnode.conf` golden — diff is exactly the block. The golden test now guards against a future `make sync-templates` re-fetch silently dropping it.
- Updated `TestRenderHOCON_MetricsFeatureEnables`: the old "nile no-op" case is inverted — nile **and** private now flip to true — plus a "default off when feature absent" assertion.
- Full suite green; gofmt + golangci-lint clean.

## Follow-up this unblocks

With every template carrying the block, `ensureMetricsEnabled` and `ensureMetricsForMonitoring` both reduce to "flip `enable` on an existing block" and can be merged into one — the cleanup PR @warku123 planned after the monitoring PR landed.
