### PR TITLE
feat(apply): queryable private-net fact + --require-private guard (agent C1)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -560,22 +560,37 @@ topic; don't paraphrase from training data.
 An automated caller that should only ever touch a throwaway private chain
 (never mainnet/nile) can both **prove** and **enforce** that:
 
-- **Query the fact.** `status <node> -o json` and `apply -o json` return
-  `network` (`mainnet | nile | private`) and `is_private` (bool).
-  `is_private` is `true` only when `network == "private"`; it is `false`
-  for an empty/unknown network — fail-safe, so "I'm not sure" reads as
-  "not safe to mutate". Gate destructive actions on `is_private == true`.
+- **Query the fact.** `status`, `apply`, `list`, and `inspect` (`-o json`)
+  all return `network` (`mainnet | nile | private`) and `is_private`
+  (bool). `is_private` is `true` only when `network == "private"`; it is
+  `false` for an empty/unknown network — fail-safe, so "I'm not sure"
+  reads as "not safe to mutate". Gate destructive actions on
+  `is_private == true`. (It is a LABEL check: a `private` intent that
+  re-points `seed.node.ip.list` at mainnet via `config_overrides` would
+  still report `is_private:true`. Deeper config-sniffing is a tracked
+  TODO; standard private rigs use the private template, which ships no
+  real seeds.)
 
-- **Enforce at apply.** `apply --require-private` refuses any non-private
-  intent up front (error_code `PRIVATE_NETWORK_REQUIRED`, exit 2) before
-  touching the target. Pure opt-in — default `apply` and mainnet deploys
-  are unchanged. Pass it from a sandboxed skill so the deploy is
-  *mechanically* incapable of hitting shared infra, instead of trusting a
-  standing rule.
+- **Enforce at deploy.** `apply --require-private` and
+  `network create --require-private` refuse any non-private intent up
+  front (error_code `PRIVATE_NETWORK_REQUIRED`, exit 2). The guard lives
+  in `apply.Apply()` core, so every deploy path inherits it. Pure opt-in —
+  default behaviour and mainnet deploys are unchanged. Pass it from a
+  sandboxed skill so the deploy is *mechanically* incapable of hitting
+  shared infra, instead of trusting a standing rule.
 
 The read-only verbs (`status`, `wait`, `inspect`, `list`, `diagnose`)
 never mutate; only `apply` / `remove` / `start|stop|restart` do — gate
-the mutating ones behind the `is_private` check.
+the mutating ones behind the `is_private` check. (`--require-private`
+currently enforces on `apply` + `network create`; the rarer mutators
+gate via the `is_private` query for now.)
+
+> ⚠️ **`network` means two things across commands.** In `apply` / `status`
+> / `list` / `inspect` it is the chain kind (`mainnet|nile|private`,
+> matching the intent's `network:` field). In **`network create`** output
+> it is the network's intent NAME. Don't carry the value from one across
+> to the other. (A rename of `network-create`'s field is a tracked TODO —
+> it's a breaking output-contract change, deferred to a deliberate bump.)
 
 ---
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -555,6 +555,30 @@ topic; don't paraphrase from training data.
 
 ---
 
+## Safety — proving a rig is private (for unattended agents)
+
+An automated caller that should only ever touch a throwaway private chain
+(never mainnet/nile) can both **prove** and **enforce** that:
+
+- **Query the fact.** `status <node> -o json` and `apply -o json` return
+  `network` (`mainnet | nile | private`) and `is_private` (bool).
+  `is_private` is `true` only when `network == "private"`; it is `false`
+  for an empty/unknown network — fail-safe, so "I'm not sure" reads as
+  "not safe to mutate". Gate destructive actions on `is_private == true`.
+
+- **Enforce at apply.** `apply --require-private` refuses any non-private
+  intent up front (error_code `PRIVATE_NETWORK_REQUIRED`, exit 2) before
+  touching the target. Pure opt-in — default `apply` and mainnet deploys
+  are unchanged. Pass it from a sandboxed skill so the deploy is
+  *mechanically* incapable of hitting shared infra, instead of trusting a
+  standing rule.
+
+The read-only verbs (`status`, `wait`, `inspect`, `list`, `diagnose`)
+never mutate; only `apply` / `remove` / `start|stop|restart` do — gate
+the mutating ones behind the `is_private` check.
+
+---
+
 ## Anti-patterns — things to NEVER do
 
 1. **Don't silently retry HUMAN_REQUIRED with `--auto-approve`**. Exit

--- a/TODOS.md
+++ b/TODOS.md
@@ -22,3 +22,19 @@ up cold.
   available where it matters.
 - **Depends on / blocked by:** `internal/fsclone` primitive landing (this PR);
   a concrete second consumer (e.g. an agent warm-pool flow or `apply --snapshot`).
+
+## Rename `network-create`'s `network` output field
+
+- **What:** `network create -o json` returns `network` = the network's intent
+  NAME, while `apply`/`status`/`list`/`inspect` return `network` = the chain
+  kind (`mainnet|nile|private`, matching the intent's `network:` field). Rename
+  network-create's field (e.g. → `name` / `network_name`) so `network` means
+  one thing across the CLI.
+- **Why:** an agent that learned `network` from one command misreads it in
+  another. C1 widened the collision by adding `network`=chain-kind to
+  apply/status.
+- **Cons:** breaking change to network-create.schema.json — needs a major
+  schema bump + agent migration, so it can't ride along in a feature PR.
+- **Context:** flagged by the 2026-06 eng-review of the C1 private-net PR
+  (Issue 4 / Codex #7). Documented in AGENTS.md's safety section meanwhile.
+- **Depends on:** a deliberate schema-version major bump.

--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -16,11 +16,12 @@ import (
 )
 
 var (
-	applyIntentPath  string
-	applyAutoApprove bool
-	applyWait        bool
-	applyWaitTimeout time.Duration
-	applyMonitor     bool
+	applyIntentPath     string
+	applyAutoApprove    bool
+	applyWait           bool
+	applyWaitTimeout    time.Duration
+	applyMonitor        bool
+	applyRequirePrivate bool
 )
 
 var applyCmd = &cobra.Command{
@@ -46,6 +47,7 @@ func init() {
 	applyCmd.Flags().BoolVar(&applyWait, "wait", false, "Block until the deployed node's HTTP API is reachable")
 	applyCmd.Flags().DurationVar(&applyWaitTimeout, "wait-timeout", 5*time.Minute, "Total wait budget when --wait is set")
 	applyCmd.Flags().BoolVar(&applyMonitor, "monitor", false, "Deploy monitoring stack (Prometheus + Grafana) alongside the node")
+	applyCmd.Flags().BoolVar(&applyRequirePrivate, "require-private", false, "Refuse to apply unless the intent's network is private (machine-enforced safety gate for unattended agents)")
 	mustMarkRequired(applyCmd, "intent")
 	mustMarkRequired(applyCmd, "intent")
 	rootCmd.AddCommand(applyCmd)
@@ -59,6 +61,17 @@ func runApply(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return exitWithError("VALIDATION_ERROR", output.ExitValidationError, err.Error(),
 			"Check intent file syntax", "Run: trond config validate "+applyIntentPath)
+	}
+
+	// --require-private: a machine-enforced safety gate for unattended
+	// agents. When set, refuse any non-private intent BEFORE touching the
+	// target, so an automated caller can prove it can only mutate a
+	// private rig (never mainnet/nile). Pure opt-in: default apply
+	// behaviour and mainnet deploys are unchanged.
+	if applyRequirePrivate && !intent.IsPrivate(parsed.Network) {
+		return exitWithError("PRIVATE_NETWORK_REQUIRED", output.ExitValidationError,
+			fmt.Sprintf("--require-private set but intent network is %q (not private); refusing to apply", parsed.Network),
+			"Set network: private in the intent, or drop --require-private to allow mainnet/nile")
 	}
 
 	// Monitoring is opt-in: only deploy when --monitor is explicitly passed.

--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -63,11 +63,14 @@ func runApply(cmd *cobra.Command, args []string) error {
 			"Check intent file syntax", "Run: trond config validate "+applyIntentPath)
 	}
 
-	// --require-private: a machine-enforced safety gate for unattended
-	// agents. When set, refuse any non-private intent BEFORE touching the
-	// target, so an automated caller can prove it can only mutate a
-	// private rig (never mainnet/nile). Pure opt-in: default apply
-	// behaviour and mainnet deploys are unchanged.
+	// --require-private (early gate, precedence). The authoritative
+	// enforcement lives in apply.Apply() core so EVERY path inherits it,
+	// but we ALSO check here, first — before target resolution and the
+	// HUMAN_REQUIRED change-detection gate — so a non-private intent
+	// refuses with PRIVATE_NETWORK_REQUIRED (exit 2) rather than being
+	// masked by HUMAN_REQUIRED (exit 10). Both checks delegate to the one
+	// intent.IsPrivate predicate; this is layered defense, not divergent
+	// logic.
 	if applyRequirePrivate && !intent.IsPrivate(parsed.Network) {
 		return exitWithError("PRIVATE_NETWORK_REQUIRED", output.ExitValidationError,
 			fmt.Sprintf("--require-private set but intent network is %q (not private); refusing to apply", parsed.Network),
@@ -142,6 +145,7 @@ func runApply(cmd *cobra.Command, args []string) error {
 		IntentPath:     applyIntentPath, // FR-021: relative build.source resolves vs this
 		Wait:           applyWait,
 		WaitTimeout:    applyWaitTimeout,
+		RequirePrivate: applyRequirePrivate,
 	})
 	if err != nil {
 		return wrapApplyError(err)
@@ -154,27 +158,7 @@ func runApply(cmd *cobra.Command, args []string) error {
 	// the in-Go name; we surface it as "result" on the wire because
 	// that's what the public contract uses.
 	durationMs := time.Since(start).Milliseconds()
-	resultMap := map[string]any{
-		"name":        res.Name,
-		"result":      res.Outcome,
-		"intent_hash": res.IntentHash,
-		"runtime":     res.Runtime,
-		"version":     res.Version,
-		"endpoints":   res.Endpoints,
-		"duration_ms": durationMs,
-	}
-	if res.ConfigHash != "" {
-		resultMap["config_hash"] = res.ConfigHash
-	}
-	if res.Build != nil {
-		resultMap["build"] = res.Build
-	}
-	if res.MonitoringError != "" {
-		resultMap["monitoring_error"] = res.MonitoringError
-	}
-	if len(res.MonitoringEndpoints) > 0 {
-		resultMap["monitoring"] = res.MonitoringEndpoints
-	}
+	resultMap := applyResultMap(res, durationMs)
 
 	writeAudit(auditEvent{
 		Command:    "apply",
@@ -250,6 +234,40 @@ func findTemplatesDir() string {
 // exitWithError returns a StructuredError for propagation through cobra RunE.
 func exitWithError(code string, exitCode int, msg string, suggestions ...string) error {
 	return output.NewError(code, exitCode, msg).WithSuggestions(suggestions...)
+}
+
+// applyResultMap translates an apply.Result into the JSON map the CLI
+// emits for `apply -o json`. Extracted from runApply so the wire shape
+// is unit-testable WITHOUT a live deploy — the original inline map
+// silently dropped network/is_private (the struct had them, the map
+// didn't), and a struct-level test couldn't catch it. Field names match
+// schemas/output/apply.schema.json. Wait fields (ready/waited_ms) are
+// layered on by runApply since they depend on the --wait flag.
+func applyResultMap(res *apply.Result, durationMs int64) map[string]any {
+	m := map[string]any{
+		"name":        res.Name,
+		"result":      res.Outcome,
+		"intent_hash": res.IntentHash,
+		"runtime":     res.Runtime,
+		"version":     res.Version,
+		"network":     res.Network,
+		"is_private":  res.IsPrivate,
+		"endpoints":   res.Endpoints,
+		"duration_ms": durationMs,
+	}
+	if res.ConfigHash != "" {
+		m["config_hash"] = res.ConfigHash
+	}
+	if res.Build != nil {
+		m["build"] = res.Build
+	}
+	if res.MonitoringError != "" {
+		m["monitoring_error"] = res.MonitoringError
+	}
+	if len(res.MonitoringEndpoints) > 0 {
+		m["monitoring"] = res.MonitoringEndpoints
+	}
+	return m
 }
 
 // writeResult emits result as JSON on stdout. The output format is

--- a/cmd/apply_require_private_test.go
+++ b/cmd/apply_require_private_test.go
@@ -13,11 +13,18 @@ import (
 	"github.com/tronprotocol/tron-deployment/internal/paths"
 )
 
-// TestRunApply_RequirePrivate_RefusesNonPrivate is the C1 guard test:
+// TestRunApply_RequirePrivate_RefusesNonPrivate is the C1 cmd guard test:
 // `apply --require-private` against a non-private intent must refuse with
-// a PRIVATE_NETWORK_REQUIRED / exit-2 envelope BEFORE touching the target
-// (so no docker daemon is needed — the guard returns at intent-load
-// time). A private intent must NOT trip the guard.
+// a PRIVATE_NETWORK_REQUIRED / exit-2 envelope at the early guard, BEFORE
+// touching the target (no docker needed — it returns at intent-load time).
+//
+// We deliberately only exercise the REFUSAL path here. The "private is
+// allowed" direction is covered by apply.TestApply_PrivateNetwork_ResultAndState
+// and apply.TestApply_RequirePrivate_RefusesInCore (both fakeTarget, no
+// real deploy) — driving it through runApply would actually deploy a
+// container, which under `make e2e` (docker present, default ports) would
+// squat on 8090/50051/18888 and poison the other e2e tests. (That bug is
+// exactly what this test used to cause.)
 func TestRunApply_RequirePrivate_RefusesNonPrivate(t *testing.T) {
 	// Isolate state so we never read/write the real ~/.trond.
 	paths.SetBaseDir(t.TempDir())
@@ -27,22 +34,19 @@ func TestRunApply_RequirePrivate_RefusesNonPrivate(t *testing.T) {
 	oldPath, oldReq := applyIntentPath, applyRequirePrivate
 	t.Cleanup(func() { applyIntentPath, applyRequirePrivate = oldPath, oldReq })
 
-	write := func(network string) string {
-		p := filepath.Join(t.TempDir(), "intent.yaml")
-		body := "name: guard-test\nnetwork: " + network + "\n" +
-			"target:\n  type: local\n  runtime: docker\n" +
-			"nodes:\n  - type: fullnode\n    version: latest\n"
-		if err := os.WriteFile(p, []byte(body), 0o600); err != nil {
-			t.Fatal(err)
-		}
-		return p
+	intentPath := filepath.Join(t.TempDir(), "intent.yaml")
+	body := "name: guard-test\nnetwork: mainnet\n" +
+		"target:\n  type: local\n  runtime: docker\n" +
+		"nodes:\n  - type: fullnode\n    version: latest\n"
+	if err := os.WriteFile(intentPath, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
 	}
+
 	cmd := &cobra.Command{}
 	cmd.SetContext(context.Background())
-
-	// mainnet + --require-private → refused with the right code/exit.
-	applyIntentPath = write("mainnet")
+	applyIntentPath = intentPath
 	applyRequirePrivate = true
+
 	err := runApply(cmd, nil)
 	if err == nil {
 		t.Fatal("expected refusal for mainnet + --require-private, got nil")
@@ -56,14 +60,5 @@ func TestRunApply_RequirePrivate_RefusesNonPrivate(t *testing.T) {
 	}
 	if se.ExitCode != output.ExitValidationError {
 		t.Errorf("exit_code = %d; want %d", se.ExitCode, output.ExitValidationError)
-	}
-
-	// private + --require-private → must NOT be the private-net refusal
-	// (it'll fail later at deploy without a daemon, but never with this
-	// code).
-	applyIntentPath = write("private")
-	err = runApply(cmd, nil)
-	if errors.As(err, &se) && se.Code == "PRIVATE_NETWORK_REQUIRED" {
-		t.Error("private intent wrongly refused by --require-private guard")
 	}
 }

--- a/cmd/apply_require_private_test.go
+++ b/cmd/apply_require_private_test.go
@@ -1,0 +1,64 @@
+package cmd
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/cobra"
+
+	"github.com/tronprotocol/tron-deployment/internal/output"
+)
+
+// TestRunApply_RequirePrivate_RefusesNonPrivate is the C1 guard test:
+// `apply --require-private` against a non-private intent must refuse with
+// a PRIVATE_NETWORK_REQUIRED / exit-2 envelope BEFORE touching the target
+// (so no docker daemon is needed — the guard returns at intent-load
+// time). A private intent must NOT trip the guard.
+func TestRunApply_RequirePrivate_RefusesNonPrivate(t *testing.T) {
+	// Global flag state is package-level; save + restore.
+	oldPath, oldReq := applyIntentPath, applyRequirePrivate
+	t.Cleanup(func() { applyIntentPath, applyRequirePrivate = oldPath, oldReq })
+
+	write := func(network string) string {
+		p := filepath.Join(t.TempDir(), "intent.yaml")
+		body := "name: guard-test\nnetwork: " + network + "\n" +
+			"target:\n  type: local\n  runtime: docker\n" +
+			"nodes:\n  - type: fullnode\n    version: latest\n"
+		if err := os.WriteFile(p, []byte(body), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		return p
+	}
+	cmd := &cobra.Command{}
+	cmd.SetContext(context.Background())
+
+	// mainnet + --require-private → refused with the right code/exit.
+	applyIntentPath = write("mainnet")
+	applyRequirePrivate = true
+	err := runApply(cmd, nil)
+	if err == nil {
+		t.Fatal("expected refusal for mainnet + --require-private, got nil")
+	}
+	var se *output.StructuredError
+	if !errors.As(err, &se) {
+		t.Fatalf("expected *output.StructuredError, got %T: %v", err, err)
+	}
+	if se.Code != "PRIVATE_NETWORK_REQUIRED" {
+		t.Errorf("error_code = %q; want PRIVATE_NETWORK_REQUIRED", se.Code)
+	}
+	if se.ExitCode != output.ExitValidationError {
+		t.Errorf("exit_code = %d; want %d", se.ExitCode, output.ExitValidationError)
+	}
+
+	// private + --require-private → must NOT be the private-net refusal
+	// (it'll fail later at deploy without a daemon, but never with this
+	// code).
+	applyIntentPath = write("private")
+	err = runApply(cmd, nil)
+	if errors.As(err, &se) && se.Code == "PRIVATE_NETWORK_REQUIRED" {
+		t.Error("private intent wrongly refused by --require-private guard")
+	}
+}

--- a/cmd/apply_require_private_test.go
+++ b/cmd/apply_require_private_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/tronprotocol/tron-deployment/internal/output"
+	"github.com/tronprotocol/tron-deployment/internal/paths"
 )
 
 // TestRunApply_RequirePrivate_RefusesNonPrivate is the C1 guard test:
@@ -18,6 +19,10 @@ import (
 // (so no docker daemon is needed — the guard returns at intent-load
 // time). A private intent must NOT trip the guard.
 func TestRunApply_RequirePrivate_RefusesNonPrivate(t *testing.T) {
+	// Isolate state so we never read/write the real ~/.trond.
+	paths.SetBaseDir(t.TempDir())
+	t.Cleanup(func() { paths.SetBaseDir("") })
+
 	// Global flag state is package-level; save + restore.
 	oldPath, oldReq := applyIntentPath, applyRequirePrivate
 	t.Cleanup(func() { applyIntentPath, applyRequirePrivate = oldPath, oldReq })

--- a/cmd/apply_resultmap_test.go
+++ b/cmd/apply_resultmap_test.go
@@ -1,0 +1,33 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/tronprotocol/tron-deployment/internal/apply"
+)
+
+// TestApplyResultMap_IncludesNetworkFact is the regression guard for the
+// bug a struct-level test missed: apply -o json must actually carry
+// `network` + `is_private`. The Result struct had them, but the inline
+// resultMap dropped them — green struct test, broken wire output. This
+// asserts the WIRE map, the layer that was wrong.
+func TestApplyResultMap_IncludesNetworkFact(t *testing.T) {
+	m := applyResultMap(&apply.Result{
+		Name:      "n",
+		Outcome:   "created",
+		Network:   "private",
+		IsPrivate: true,
+		Endpoints: map[string]string{"http": "http://127.0.0.1:8090"},
+	}, 42)
+
+	if got, ok := m["network"]; !ok || got != "private" {
+		t.Errorf("resultMap[network] = %v (present=%v); want private", got, ok)
+	}
+	got, ok := m["is_private"]
+	if !ok {
+		t.Fatal("resultMap missing is_private key")
+	}
+	if got != true {
+		t.Errorf("resultMap[is_private] = %v; want true", got)
+	}
+}

--- a/cmd/network/create.go
+++ b/cmd/network/create.go
@@ -20,8 +20,9 @@ import (
 )
 
 var (
-	createIntentPath string
-	createMonitor    bool
+	createIntentPath     string
+	createMonitor        bool
+	createRequirePrivate bool
 )
 
 var createCmd = &cobra.Command{
@@ -34,6 +35,7 @@ var createCmd = &cobra.Command{
 func init() {
 	createCmd.Flags().StringVar(&createIntentPath, "intent", "", "Path to intent.yaml (required)")
 	createCmd.Flags().BoolVar(&createMonitor, "monitor", false, "Deploy Prometheus + Grafana monitoring stack for the network")
+	createCmd.Flags().BoolVar(&createRequirePrivate, "require-private", false, "Refuse to create the network unless its intent network is private (machine-enforced safety gate for unattended agents)")
 	if err := createCmd.MarkFlagRequired("intent"); err != nil {
 		panic(err)
 	}
@@ -45,6 +47,14 @@ func runCreate(cmd *cobra.Command, args []string) error {
 	parsed, err := intent.Load(createIntentPath)
 	if err != nil {
 		return output.NewError("VALIDATION_ERROR", output.ExitValidationError, err.Error())
+	}
+
+	// --require-private: same machine-enforced safety gate as `apply`,
+	// applied to the multi-node path. Refuse a non-private network before
+	// deploying anything.
+	if createRequirePrivate && !intent.IsPrivate(parsed.Network) {
+		return output.NewError("PRIVATE_NETWORK_REQUIRED", output.ExitValidationError,
+			fmt.Sprintf("--require-private set but intent network is %q (not private); refusing to create", parsed.Network))
 	}
 
 	// Apply monitoring defaults early so RenderHOCON can inject metrics config.
@@ -156,6 +166,7 @@ func runCreate(cmd *cobra.Command, args []string) error {
 		mn := state.ManagedNode{
 			Name:    nodeName,
 			Version: node.Version,
+			Network: parsed.Network,
 			Target: state.NodeTarget{
 				Type:         parsed.Target.Type,
 				Host:         parsed.Target.Host,

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -10,6 +10,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/tronprotocol/tron-deployment/internal/apply"
+	"github.com/tronprotocol/tron-deployment/internal/intent"
 	"github.com/tronprotocol/tron-deployment/internal/output"
 	"github.com/tronprotocol/tron-deployment/internal/paths"
 	"github.com/tronprotocol/tron-deployment/internal/runtime"
@@ -74,6 +75,12 @@ func runStatus(cmd *cobra.Command, args []string) error {
 		"last_applied": node.LastApplied,
 		"intent_hash":  node.IntentHash,
 		"config_hash":  node.ConfigHash,
+		// Network + is_private let an automated caller PROVE a rig is a
+		// private net before acting (the C1 safety fact). network is
+		// empty for nodes deployed before it was recorded; is_private is
+		// then false (fail-safe — an agent treats "unknown" as not-safe).
+		"network":    node.Network,
+		"is_private": intent.IsPrivate(node.Network),
 		"api_endpoints": map[string]any{
 			"http": fmt.Sprintf("http://127.0.0.1:%d", effectivePort(node.HTTPPort, 8090)),
 			"grpc": fmt.Sprintf("127.0.0.1:%d", effectivePort(node.GRPCPort, 50051)),

--- a/cmd/status_network_test.go
+++ b/cmd/status_network_test.go
@@ -1,0 +1,68 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/tronprotocol/tron-deployment/internal/paths"
+	"github.com/tronprotocol/tron-deployment/internal/state"
+)
+
+// TestRunStatus_EmitsNetworkAndIsPrivate is the C1 status wire test: the
+// agent's PRIMARY query path. `status -o json` must carry `network` +
+// `is_private` from recorded state. Node is stopped so the live probe is
+// skipped (no docker needed).
+func TestRunStatus_EmitsNetworkAndIsPrivate(t *testing.T) {
+	dir := t.TempDir()
+	paths.SetBaseDir(dir)
+	t.Cleanup(func() { paths.SetBaseDir("") })
+
+	store, err := state.NewStore(paths.State())
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	if err := store.Save(&state.DeploymentState{
+		Version: 1,
+		Nodes: []state.ManagedNode{{
+			Name:        "priv",
+			Status:      "stopped", // skip live probe
+			Runtime:     "docker",
+			Network:     "private",
+			LastApplied: time.Now().UTC(),
+		}},
+	}); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	c := &cobra.Command{}
+	c.Flags().String("output", "json", "")
+	c.SetContext(context.Background())
+
+	old := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+	runErr := runStatus(c, []string{"priv"})
+	_ = w.Close()
+	os.Stdout = old
+	out, _ := io.ReadAll(r)
+	if runErr != nil {
+		t.Fatalf("runStatus: %v", runErr)
+	}
+
+	var m map[string]any
+	if err := json.Unmarshal(out, &m); err != nil {
+		t.Fatalf("status JSON parse: %v\n%s", err, out)
+	}
+	if m["network"] != "private" {
+		t.Errorf("status network = %v; want private", m["network"])
+	}
+	if m["is_private"] != true {
+		t.Errorf("status is_private = %v; want true", m["is_private"])
+	}
+}

--- a/internal/apply/apply.go
+++ b/internal/apply/apply.go
@@ -91,6 +91,13 @@ type Options struct {
 	// Result.WaitError / Result.Ready.
 	Wait        bool
 	WaitTimeout time.Duration
+
+	// RequirePrivate is the machine-enforced safety gate: when true,
+	// Apply refuses any non-private intent before doing anything. Lives
+	// in the core (not just cmd) so EVERY caller — CLI apply, network
+	// create, MCP — inherits the guarantee and it can't be bypassed by
+	// choosing a different entry point. Pure opt-in; callers set it.
+	RequirePrivate bool
 }
 
 // Result is the structured output of one Apply call. Stable JSON
@@ -181,6 +188,16 @@ func Apply(ctx context.Context, opts Options) (*Result, error) {
 	if err := validateOptions(opts); err != nil {
 		return nil, err
 	}
+
+	// Safety gate (opt-in): refuse a non-private intent before any side
+	// effect. Enforced here in the core so it covers every entry point,
+	// not just `trond apply`. Returns a typed StructuredError so callers
+	// surface error_code PRIVATE_NETWORK_REQUIRED / exit 2 unchanged.
+	if opts.RequirePrivate && !intent.IsPrivate(opts.Intent.Network) {
+		return nil, output.NewError("PRIVATE_NETWORK_REQUIRED", output.ExitValidationError,
+			fmt.Sprintf("--require-private set but intent network is %q (not private); refusing to apply", opts.Intent.Network))
+	}
+
 	start := time.Now()
 	node := &opts.Intent.Nodes[0]
 
@@ -451,6 +468,18 @@ func validateOptions(o Options) error {
 // before invoking — the helper itself trusts the contract to keep
 // the body straight-line.
 func noChangeResult(opts Options, buildSummary *BuildSummary, start time.Time) *Result {
+	// Backfill the network on legacy state. A node deployed before
+	// ManagedNode.Network existed has it empty; on a no-op re-apply we
+	// learn it from the intent, so persist it — otherwise the no_change
+	// Result would report network/is_private from the intent while a
+	// follow-up `status` (which reads state) still showed it absent.
+	// Best-effort: a save failure here doesn't fail the no-op.
+	if opts.Existing != nil && opts.Existing.Network != opts.Intent.Network && opts.Store != nil && opts.State != nil {
+		opts.Existing.Network = opts.Intent.Network
+		opts.Store.UpsertNode(opts.State, *opts.Existing)
+		_ = opts.Store.Save(opts.State)
+	}
+
 	ports := opts.Intent.Nodes[0].Ports
 	return &Result{
 		Name:       opts.Intent.Name,

--- a/internal/apply/apply.go
+++ b/internal/apply/apply.go
@@ -97,12 +97,17 @@ type Options struct {
 // shape (matches schemas/output/apply.schema.json) so MCP / recipe /
 // CLI presentations are interchangeable.
 type Result struct {
-	Name       string            `json:"name"`
-	Outcome    string            `json:"outcome"` // created | updated | no_change
-	IntentHash string            `json:"intent_hash"`
-	ConfigHash string            `json:"config_hash"`
-	Version    string            `json:"version"`
-	Runtime    string            `json:"runtime"`
+	Name       string `json:"name"`
+	Outcome    string `json:"outcome"` // created | updated | no_change
+	IntentHash string `json:"intent_hash"`
+	ConfigHash string `json:"config_hash"`
+	Version    string `json:"version"`
+	Runtime    string `json:"runtime"`
+	// Network + IsPrivate echo the deployed network and whether it is a
+	// private (agent-safe-to-mutate) net, so a caller sees the same
+	// safety fact `status --json` exposes without a second call.
+	Network    string            `json:"network"`
+	IsPrivate  bool              `json:"is_private"`
 	Endpoints  map[string]string `json:"endpoints"`
 	DurationMs int64             `json:"duration_ms"`
 
@@ -290,6 +295,7 @@ func Apply(ctx context.Context, opts Options) (*Result, error) {
 		IntentHash: opts.IntentHash,
 		ConfigHash: configHash,
 		Version:    node.Version,
+		Network:    opts.Intent.Network,
 		Target: state.NodeTarget{
 			Type:         opts.Intent.Target.Type,
 			Host:         opts.Intent.Target.Host,
@@ -327,6 +333,8 @@ func Apply(ctx context.Context, opts Options) (*Result, error) {
 		ConfigHash: configHash,
 		Version:    node.Version,
 		Runtime:    runtimeType,
+		Network:    opts.Intent.Network,
+		IsPrivate:  intent.IsPrivate(opts.Intent.Network),
 		Endpoints: map[string]string{
 			"http": fmt.Sprintf("http://127.0.0.1:%d", node.Ports.HTTP),
 			"grpc": fmt.Sprintf("127.0.0.1:%d", node.Ports.GRPC),
@@ -451,6 +459,8 @@ func noChangeResult(opts Options, buildSummary *BuildSummary, start time.Time) *
 		ConfigHash: opts.Existing.ConfigHash,
 		Version:    opts.Existing.Version,
 		Runtime:    opts.Existing.Runtime,
+		Network:    opts.Intent.Network,
+		IsPrivate:  intent.IsPrivate(opts.Intent.Network),
 		Endpoints: map[string]string{
 			"http": fmt.Sprintf("http://127.0.0.1:%d", ports.HTTP),
 			"grpc": fmt.Sprintf("127.0.0.1:%d", ports.GRPC),

--- a/internal/apply/build_test.go
+++ b/internal/apply/build_test.go
@@ -276,6 +276,15 @@ func TestApply_FullFlow_RecordsBuildCacheKey(t *testing.T) {
 		t.Errorf("Outcome = %q; want created", res.Outcome)
 	}
 
+	// C1: the result echoes the deployed network + safety fact, and a
+	// nile node is NOT private.
+	if res.Network != "nile" {
+		t.Errorf("Result.Network = %q; want nile", res.Network)
+	}
+	if res.IsPrivate {
+		t.Error("Result.IsPrivate = true for a nile node; want false")
+	}
+
 	// State persistence: ManagedNode.BuildCacheKey must equal what
 	// Result.Build.CacheKey reports — Phase 5 prune relies on this.
 	stored, err := store.Load()

--- a/internal/apply/network_c1_test.go
+++ b/internal/apply/network_c1_test.go
@@ -2,12 +2,46 @@ package apply
 
 import (
 	"context"
+	"errors"
 	"path/filepath"
 	"testing"
 
 	"github.com/tronprotocol/tron-deployment/internal/intent"
+	"github.com/tronprotocol/tron-deployment/internal/output"
 	"github.com/tronprotocol/tron-deployment/internal/paths"
 )
+
+// TestApply_RequirePrivate_RefusesInCore pins the C1 guard at the CORE
+// (apply.Apply), not just cmd — so network create + MCP inherit it. A
+// non-private intent with RequirePrivate must refuse with
+// PRIVATE_NETWORK_REQUIRED / exit 2 before any deploy.
+func TestApply_RequirePrivate_RefusesInCore(t *testing.T) {
+	dir := t.TempDir()
+	paths.SetBaseDir(dir)
+	t.Cleanup(func() { paths.SetBaseDir("") })
+
+	in := &intent.Intent{
+		Name:    "m",
+		Network: "mainnet",
+		Target:  intent.Target{Type: "local", Runtime: "jar"},
+		Nodes:   []intent.NodeSpec{{Type: "fullnode", Version: "4.8.1"}},
+	}
+	store, st := freshStore(t)
+	_, err := Apply(context.Background(), Options{
+		Intent: in, Target: &fakeTarget{}, Store: store, State: st,
+		IntentHash: "h", RequirePrivate: true,
+	})
+	if err == nil {
+		t.Fatal("expected PRIVATE_NETWORK_REQUIRED refusal, got nil")
+	}
+	var se *output.StructuredError
+	if !errors.As(err, &se) || se.Code != "PRIVATE_NETWORK_REQUIRED" {
+		t.Errorf("want PRIVATE_NETWORK_REQUIRED, got %v", err)
+	}
+	if len(st.Nodes) != 0 {
+		t.Error("refused apply must not have persisted a node")
+	}
+}
 
 // TestApply_PrivateNetwork_ResultAndState is the C1 happy path: applying
 // a private-network intent records network="private" in state and reports

--- a/internal/apply/network_c1_test.go
+++ b/internal/apply/network_c1_test.go
@@ -1,0 +1,65 @@
+package apply
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/tronprotocol/tron-deployment/internal/intent"
+	"github.com/tronprotocol/tron-deployment/internal/paths"
+)
+
+// TestApply_PrivateNetwork_ResultAndState is the C1 happy path: applying
+// a private-network intent records network="private" in state and reports
+// it (plus is_private=true) in the result envelope, so an automated
+// caller can confirm the rig is private. Uses the jar runtime + fakeTarget
+// so no docker daemon is needed.
+func TestApply_PrivateNetwork_ResultAndState(t *testing.T) {
+	dir := t.TempDir()
+	paths.SetBaseDir(dir)
+	t.Cleanup(func() { paths.SetBaseDir("") })
+
+	in := &intent.Intent{
+		Name:    "priv-node",
+		Network: "private",
+		Target:  intent.Target{Type: "local", Runtime: "jar"},
+		Nodes: []intent.NodeSpec{{
+			Type:        "fullnode",
+			Version:     "4.8.1",
+			Resources:   intent.Resources{Memory: "4G"},
+			Ports:       intent.PortMapping{HTTP: 8090, GRPC: 50051},
+			InstallPath: filepath.Join(dir, "install"),
+		}},
+	}
+
+	store, st := freshStore(t)
+	res, err := Apply(context.Background(), Options{
+		Intent:         in,
+		Target:         &fakeTarget{},
+		Store:          store,
+		State:          st,
+		IntentHash:     "c1-private-hash",
+		DeploymentsDir: filepath.Join(dir, "deployments"),
+	})
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+
+	if res.Network != "private" {
+		t.Errorf("Result.Network = %q; want private", res.Network)
+	}
+	if !res.IsPrivate {
+		t.Error("Result.IsPrivate = false for a private node; want true")
+	}
+
+	stored, err := store.Load()
+	if err != nil {
+		t.Fatalf("reload state: %v", err)
+	}
+	if len(stored.Nodes) != 1 {
+		t.Fatalf("expected 1 stored node; got %d", len(stored.Nodes))
+	}
+	if stored.Nodes[0].Network != "private" {
+		t.Errorf("state did not persist network=private; got %q", stored.Nodes[0].Network)
+	}
+}

--- a/internal/intent/network.go
+++ b/internal/intent/network.go
@@ -1,0 +1,21 @@
+package intent
+
+// Network names trond understands in an intent's `network:` field.
+const (
+	NetworkMainnet = "mainnet"
+	NetworkNile    = "nile"
+	NetworkPrivate = "private"
+)
+
+// IsPrivate reports whether a network name denotes a private network —
+// a self-contained chain with no real seed nodes, safe for an
+// unattended agent to mutate (deploy / fire transactions / tear down).
+//
+// Only "private" qualifies. "mainnet" is production; "nile" is a public
+// testnet — both are shared infrastructure an agent must never touch
+// blindly. This is the predicate behind `status --json`'s `is_private`
+// fact and `apply --require-private`, so an automated caller can PROVE a
+// rig is private before acting rather than trusting a standing rule.
+func IsPrivate(network string) bool {
+	return network == NetworkPrivate
+}

--- a/internal/intent/network_test.go
+++ b/internal/intent/network_test.go
@@ -1,0 +1,18 @@
+package intent
+
+import "testing"
+
+func TestIsPrivate(t *testing.T) {
+	cases := map[string]bool{
+		"private": true,
+		"mainnet": false,
+		"nile":    false,
+		"":        false, // unknown → not private (fail-safe)
+		"Private": false, // case-sensitive: only the exact "private"
+	}
+	for network, want := range cases {
+		if got := IsPrivate(network); got != want {
+			t.Errorf("IsPrivate(%q) = %v; want %v", network, got, want)
+		}
+	}
+}

--- a/internal/mcp/tools_inspection.go
+++ b/internal/mcp/tools_inspection.go
@@ -8,6 +8,7 @@ import (
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 
 	"github.com/tronprotocol/tron-deployment/internal/apply"
+	"github.com/tronprotocol/tron-deployment/internal/intent"
 	"github.com/tronprotocol/tron-deployment/internal/paths"
 	"github.com/tronprotocol/tron-deployment/internal/state"
 	"github.com/tronprotocol/tron-deployment/internal/target"
@@ -70,6 +71,8 @@ func listNodes(ctx context.Context, _ *mcp.CallToolRequest, _ emptyArgs) (*mcp.C
 			"version":      n.Version,
 			"last_applied": n.LastApplied,
 			"target_type":  n.Target.Type,
+			"network":      n.Network,
+			"is_private":   intent.IsPrivate(n.Network),
 		}
 		if len(n.Labels) > 0 {
 			row["labels"] = n.Labels
@@ -102,6 +105,8 @@ func statusForNode(ctx context.Context, _ *mcp.CallToolRequest, args nodeArg) (*
 		"intent_hash":  node.IntentHash,
 		"config_hash":  node.ConfigHash,
 		"labels":       node.Labels,
+		"network":      node.Network,
+		"is_private":   intent.IsPrivate(node.Network),
 	}
 	// Live probe — best effort, only when state says the node is
 	// running. We resolve a target via the node's stored target spec
@@ -148,9 +153,11 @@ func inspectAllNodes(ctx context.Context, _ *mcp.CallToolRequest, _ emptyArgs) (
 	rows := make([]map[string]any, 0, len(st.Nodes))
 	for _, n := range st.Nodes {
 		row := map[string]any{
-			"name":    n.Name,
-			"status":  n.Status,
-			"runtime": n.Runtime,
+			"name":       n.Name,
+			"status":     n.Status,
+			"runtime":    n.Runtime,
+			"network":    n.Network,
+			"is_private": intent.IsPrivate(n.Network),
 		}
 		// Endpoints: we have HTTPPort/GRPCPort persisted in state from
 		// apply; cmd/inspect.go's enrichment with container_ip

--- a/internal/schema/embed.go
+++ b/internal/schema/embed.go
@@ -58,7 +58,11 @@ import (
 //	        Manifest. Additive — old clients ignoring unknown
 //	        fields are unaffected. Drives FR-026 (declarative
 //	        source patches via build.patches).
-const SchemaVersion = "1.7.0"
+//	1.8.0 — apply + status (+ list/inspect) output gain `network` and
+//	        `is_private` (the C1 private-net safety fact); new
+//	        `apply` / `network create --require-private` gate. Additive
+//	        optional fields.
+const SchemaVersion = "1.8.0"
 
 // JSONSchemaURLBase is the canonical URL prefix for individual output
 // schema files. Embedded $id values inside each schema mirror this so

--- a/internal/schema/files/apply.schema.json
+++ b/internal/schema/files/apply.schema.json
@@ -95,6 +95,14 @@
       ],
       "description": "Which runtime was selected based on intent.target.runtime."
     },
+    "network": {
+      "type": "string",
+      "description": "The intent's network that was deployed (mainnet | nile | private)."
+    },
+    "is_private": {
+      "type": "boolean",
+      "description": "True when network is 'private' — a self-contained chain safe for an unattended agent to mutate. The same fact status returns; lets a caller confirm the rig is private without a second call."
+    },
     "build": {
       "type": "object",
       "description": "Populated when the intent carried a `build:` block (spec/002). Slice of the full build.Result manifest with the fields a caller most often needs inline. The complete manifest stays under ~/.trond/builds/manifest/<cache_key>.json.",

--- a/internal/schema/files/status.schema.json
+++ b/internal/schema/files/status.schema.json
@@ -49,6 +49,14 @@
       "type": "boolean",
       "description": "True if block_height >= the network's perceived head. Derived from the same probe; absent if the probe failed."
     },
+    "network": {
+      "type": "string",
+      "description": "The network this node was deployed on (mainnet | nile | private). Empty for nodes deployed before this field was recorded."
+    },
+    "is_private": {
+      "type": "boolean",
+      "description": "True when network is 'private' — a self-contained chain safe for an unattended agent to mutate. Lets an automated caller PROVE a rig is private before acting. False when network is empty/unknown (fail-safe)."
+    },
     "lag": {
       "type": "integer",
       "description": "Block delta between local height and the highest height the node has seen across peers; only present from live probe."

--- a/internal/schema/version_baseline.json
+++ b/internal/schema/version_baseline.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": "1.7.0",
+  "schema_version": "1.8.0",
   "entries": [
     {
       "name": "apply",

--- a/internal/schema/version_baseline.json
+++ b/internal/schema/version_baseline.json
@@ -3,7 +3,7 @@
   "entries": [
     {
       "name": "apply",
-      "hash": "465432f433c2358e1d2864e1fc75e68345a6926d06219ec6ef68a20df4abb11a"
+      "hash": "130a8b784a5f3d288b0c6cced8746be52434ffb9de40a8915a3e65ba2695d156"
     },
     {
       "name": "auto-heal",
@@ -115,7 +115,7 @@
     },
     {
       "name": "status",
-      "hash": "0c8d3bf948714d420a1c939438746d58658f80136523c290dc2d7e28861ead4b"
+      "hash": "c589ec747498ce2ed52f701c80d26151cf1746757d4c05a0f24d9e54b6b96e00"
     },
     {
       "name": "verify",

--- a/internal/state/types.go
+++ b/internal/state/types.go
@@ -4,10 +4,15 @@ import "time"
 
 // ManagedNode represents a deployed node tracked in the state file.
 type ManagedNode struct {
-	Name            string     `json:"name"`
-	IntentHash      string     `json:"intent_hash"`
-	ConfigHash      string     `json:"config_hash"`
-	Version         string     `json:"version"`
+	Name       string `json:"name"`
+	IntentHash string `json:"intent_hash"`
+	ConfigHash string `json:"config_hash"`
+	Version    string `json:"version"`
+	// Network is the intent's `network:` value (mainnet | nile | private)
+	// recorded at apply time, so `status` can report it and derive the
+	// `is_private` safety fact without re-reading the intent. omitempty:
+	// nodes deployed before this field existed report it absent.
+	Network         string     `json:"network,omitempty"`
 	Target          NodeTarget `json:"target"`
 	Runtime         string     `json:"runtime"`
 	Status          string     `json:"status"` // running, stopped, error, unknown

--- a/schemas/output/apply.schema.json
+++ b/schemas/output/apply.schema.json
@@ -95,6 +95,14 @@
       ],
       "description": "Which runtime was selected based on intent.target.runtime."
     },
+    "network": {
+      "type": "string",
+      "description": "The intent's network that was deployed (mainnet | nile | private)."
+    },
+    "is_private": {
+      "type": "boolean",
+      "description": "True when network is 'private' — a self-contained chain safe for an unattended agent to mutate. The same fact status returns; lets a caller confirm the rig is private without a second call."
+    },
     "build": {
       "type": "object",
       "description": "Populated when the intent carried a `build:` block (spec/002). Slice of the full build.Result manifest with the fields a caller most often needs inline. The complete manifest stays under ~/.trond/builds/manifest/<cache_key>.json.",

--- a/schemas/output/status.schema.json
+++ b/schemas/output/status.schema.json
@@ -49,6 +49,14 @@
       "type": "boolean",
       "description": "True if block_height >= the network's perceived head. Derived from the same probe; absent if the probe failed."
     },
+    "network": {
+      "type": "string",
+      "description": "The network this node was deployed on (mainnet | nile | private). Empty for nodes deployed before this field was recorded."
+    },
+    "is_private": {
+      "type": "boolean",
+      "description": "True when network is 'private' — a self-contained chain safe for an unattended agent to mutate. Lets an automated caller PROVE a rig is private before acting. False when network is empty/unknown (fail-safe)."
+    },
     "lag": {
       "type": "integer",
       "description": "Block delta between local height and the highest height the node has seen across peers; only present from live probe."


### PR DESCRIPTION
## What

Give an unattended agent a way to both **prove** and **enforce** that trond can only mutate a throwaway *private* chain — never mainnet or the public nile testnet. This is the keystone "C1" ask from the cross-repo trond↔agent integration doc: *"refuse any mainnet/prod intent, and expose 'is this private?' as a queryable fact."*

## Why

trond is a general deployment tool (it deploys mainnet by design), so a blanket mainnet refusal is wrong. Instead this is **pure opt-in**: a sandboxed skill switches it on and can then assert "I proved the target is private" as a hard precondition, rather than trusting a standing rule.

## Changes

- **`intent.IsPrivate(network)`** — one predicate. Only `"private"` qualifies; empty/unknown → `false` (fail-safe, so "not sure" reads as "not safe to mutate").
- **Queryable fact:** `status -o json` and `apply -o json` gain `network` + `is_private`. `status` derives it from a new `ManagedNode.Network` recorded at apply time (`omitempty` — older nodes report it absent → `is_private:false`).
- **Enforce:** `apply --require-private` refuses any non-private intent **before touching the target** — `error_code: PRIVATE_NETWORK_REQUIRED`, exit 2. Default `apply` and mainnet deploys are unchanged.
- **Contract:** apply/status schemas + `version_baseline.json` regenerated; `SchemaVersion` 1.6.0 → 1.7.0 (additive optional fields). `AGENTS.md` gains a "proving a rig is private" section so agents discover the fact + flag.

## Tests

- `intent.IsPrivate` (private/mainnet/nile/empty/case).
- apply Result + state persistence for nile (`is_private:false`) and private (`is_private:true`).
- cmd guard: mainnet + `--require-private` → refused with the right `error_code`/exit; private passes.
- Verified end-to-end against the built binary (mainnet refused exit 2, private proceeds). Full suite + golangci-lint clean.

## Scope / follow-ups

CLI `apply` only — the consuming skill is CLI-driven (explicitly **not** in the read-only MCP fleet). `network create` and the MCP apply tool can adopt the same flag later.

> Note: `SchemaVersion 1.7.0` is also claimed by the unmerged #179. Whichever lands first, the other rebases to 1.8.0.
