### PR TITLE
feat(status): A1 machine-observable rig state — healthy, container_id, logs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -145,8 +145,31 @@ trond verify --intent intent.yaml --timeout 5m -o json
 # 6. Status — readable summary the agent shows the user.
 trond status my-fullnode -o json
 # Output: {"name":"...", "status":"running", "block_height": ...,
-#          "peer_count": 12, "is_synced": true, "api_endpoints":{...}}
+#          "peer_count": 12, "is_synced": true, "healthy": true,
+#          "container_id": "<64-hex>", "api_endpoints":{...},
+#          "logs": {"runtime":"docker","container":"...","path":"/java-tron/logs/tron.log"}}
 ```
+
+**Machine-observable rig state (status / inspect `-o json`):**
+- `healthy` (bool) — liveness gate: "is the RPC serving blocks?". Always
+  present; `true` only when `status=running` AND the live `getnowblock`
+  probe returned a REAL block (non-zero block timestamp — an empty/error
+  200 does not count). It does NOT mean fully synced: `healthy` can be
+  `true` while `is_synced` is `false` on a node whose tip is stale, so gate
+  liveness on `healthy` and sync on `is_synced`/`block_height`. Fail-safe
+  `false` when stopped, unreachable, or the probe was skipped.
+- `container_id` (string) — full 64-hex docker container ID, so an agent
+  can `docker exec`/attach the exact container. Best-effort; present for
+  running/stopped docker nodes, absent for jar nodes or when the daemon
+  is unreachable.
+- `logs` (object) — runtime-discriminated locator for reading node logs
+  without screen-scraping (point `mcp-logs` here). `runtime=docker`:
+  `docker exec <container> cat <path>` (java-tron logs to a file *inside*
+  the container, not stdout). `runtime=jar`: `journalctl -u <unit>`.
+- `api_endpoints.http` is the private-net RPC — point read-only on-chain
+  readers (e.g. `tron-toolkit`) at it for the verify half of a loop.
+- `chain_id` is NOT yet emitted (TRON's chain id is genesis-derived, not
+  a single cheap RPC field) — tracked in TODOS.md.
 
 **Idempotency**: `apply` is hash-gated. Same intent → no-op. Changed
 intent without `--auto-approve` → exit 10. The agent should always

--- a/TODOS.md
+++ b/TODOS.md
@@ -23,6 +23,26 @@ up cold.
 - **Depends on / blocked by:** `internal/fsclone` primitive landing (this PR);
   a concrete second consumer (e.g. an agent warm-pool flow or `apply --snapshot`).
 
+## Emit `chain_id` in `status` / `inspect` -o json
+
+- **What:** The ai-ops A1 ask lists `chain_id` in the per-node `status
+  --json` shape. The 2026-06 A1 increment shipped `healthy`,
+  `container_id`, and the `logs` locator but deferred `chain_id`.
+- **Why deferred:** TRON has no single cheap RPC that returns a tidy chain
+  id. It's derived from the genesis block (the genesis block ID / its
+  trailing bytes), so producing it means a `/wallet/getblockbynum?num=0`
+  probe + a documented derivation — more than the additive-field A1 scope.
+  The operational A1 definition ("expose rpc_endpoint + node-log paths")
+  does not require it; tron-toolkit/mcp-logs are unblocked without it.
+- **How to add:** in `internal/apply` add a best-effort probe that fetches
+  block 0 and derives the chain id (match java-tron's
+  `Wallet.getChainId()` / the genesis block-id convention), surface it in
+  `LiveStatus` or a sibling, wire into status/inspect + schemas, bump
+  SchemaVersion (additive → MINOR per the C1/A1 precedent).
+- **Context:** flagged while implementing A1 (2026-06). For a private net
+  the value is deterministic from the genesis the intent pins, so it
+  doubles as a B1 "echo the resolved rig identity" signal.
+
 ## Rename `network-create`'s `network` output field
 
 - **What:** `network create -o json` returns `network` = the network's intent

--- a/cmd/inspect.go
+++ b/cmd/inspect.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/tronprotocol/tron-deployment/internal/apply"
 	"github.com/tronprotocol/tron-deployment/internal/output"
 	"github.com/tronprotocol/tron-deployment/internal/state"
 )
@@ -178,15 +179,21 @@ func manifestForNode(ctx context.Context, n *state.ManagedNode) map[string]any {
 		"target":       n.Target,
 		"last_applied": n.LastApplied,
 		"endpoints":    endpoints,
+		// logs: runtime-discriminated locator so a log consumer knows how
+		// to read this node's logs without screen-scraping (A1).
+		"logs": apply.LogsDescriptor(n),
 	}
 
-	// Best-effort container IP for docker nodes — only attempted if the
-	// node is local; SSH inspect would need a remote docker call which
+	// Best-effort container IP + ID for docker nodes — only attempted if
+	// the node is local; SSH inspect would need a remote docker call which
 	// pulls in target resolution. The test harness usually runs on the
 	// same host as the docker daemon, so this is the common case.
 	if n.Runtime == "docker" && n.Target.Type == "local" {
 		if ip := dockerContainerIP(ctx, n.Name); ip != "" {
 			entry["container_ip"] = ip
+		}
+		if id := dockerContainerID(ctx, n.Name); id != "" {
+			entry["container_id"] = id
 		}
 	}
 
@@ -209,4 +216,17 @@ func dockerContainerIP(ctx context.Context, name string) string {
 		return ""
 	}
 	return ip
+}
+
+// dockerContainerID shells out to docker inspect for the full container ID.
+// Validation (64-hex, reject docker error text) is shared with
+// apply.ContainerID via apply.NormalizeContainerID so the format rule has a
+// single source of truth across the local (string) and target.Exec ([]byte)
+// paths.
+func dockerContainerID(ctx context.Context, name string) string {
+	out, err := localDockerExec(ctx, "inspect", "-f", "{{.Id}}", name)
+	if err != nil {
+		return ""
+	}
+	return apply.NormalizeContainerID(out)
 }

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -81,19 +81,56 @@ func runStatus(cmd *cobra.Command, args []string) error {
 		// then false (fail-safe — an agent treats "unknown" as not-safe).
 		"network":    node.Network,
 		"is_private": intent.IsPrivate(node.Network),
+		// healthy is the single boolean an agent gates on for "is this
+		// node answering RPC". Seeded false so the field is always present
+		// and fail-safe; the live probe flips it true only on a parseable
+		// getnowblock. logs tells an external consumer (mcp-logs) how to
+		// read this node's logs without screen-scraping. Both are A1.
+		"healthy": false,
+		"logs":    apply.LogsDescriptor(node),
 		"api_endpoints": map[string]any{
 			"http": fmt.Sprintf("http://127.0.0.1:%d", effectivePort(node.HTTPPort, 8090)),
 			"grpc": fmt.Sprintf("127.0.0.1:%d", effectivePort(node.GRPCPort, 50051)),
 		},
 	}
 
-	// Live probe — best effort, 3s timeout. We skip if the node isn't
-	// running per state, since calling curl against a stopped node is
-	// just noise.
-	if node.Status == "running" {
-		ctx, cancel := context.WithTimeout(cmd.Context(), 3*time.Second)
-		defer cancel()
-		maps.Copy(statusInfo, liveStatusProbe(ctx, node))
+	// Resolve the target at most once, and only when we actually need it.
+	// Resolving is cheap for a local target but opens an SSH connection for
+	// an ssh one — and SSHTarget.Connect() is NOT bound by the 3s context
+	// below — so we must never resolve just to fetch container_id from a
+	// stopped remote node (that would turn an instant `status` into a
+	// blocking SSH dial). We resolve when:
+	//   - the node is running (the live probe needs a target regardless), or
+	//   - it's a LOCAL docker node (cheap; lets us read container_id even
+	//     when stopped — a stopped container still has an ID).
+	// An ssh docker node still gets container_id, but only piggybacked on
+	// the running-node probe resolution — never via a fresh dial for a
+	// stopped node. Best-effort throughout: failure just omits the fields.
+	needLocalDockerID := node.Runtime == "docker" && node.Target.Type == "local"
+	if node.Status == "running" || needLocalDockerID {
+		if tgt, err := resolveTargetFromNode(node); err == nil {
+			if c, ok := any(tgt).(interface{ Close() error }); ok {
+				defer c.Close()
+			}
+			// Live probe FIRST and with its own 3s budget: `healthy` is the
+			// primary signal, and it must not be starved by a slow
+			// `docker inspect` for the optional container_id. Each call gets
+			// an independent deadline off the command context.
+			if node.Status == "running" {
+				pctx, pcancel := context.WithTimeout(cmd.Context(), 3*time.Second)
+				maps.Copy(statusInfo, apply.LiveStatus(pctx, tgt, node))
+				pcancel()
+			}
+			// container_id (optional metadata) lets an agent attach/exec
+			// against the exact container. ContainerID no-ops for non-docker
+			// nodes, so it's safe to call unconditionally on the resolved
+			// target.
+			cctx, ccancel := context.WithTimeout(cmd.Context(), 3*time.Second)
+			if id := apply.ContainerID(cctx, tgt, node); id != "" {
+				statusInfo["container_id"] = id
+			}
+			ccancel()
+		}
 	}
 
 	if node.Monitoring != nil && node.Monitoring.Enabled {
@@ -123,6 +160,12 @@ func runStatus(cmd *cobra.Command, args []string) error {
 	if syn, ok := statusInfo["is_synced"].(bool); ok {
 		fmt.Printf("Synced:       %v\n", syn)
 	}
+	if h, ok := statusInfo["healthy"].(bool); ok {
+		fmt.Printf("Healthy:      %v\n", h)
+	}
+	if id, ok := statusInfo["container_id"].(string); ok && id != "" {
+		fmt.Printf("Container:    %s\n", id[:12])
+	}
 
 	// Show monitoring stack health if deployed.
 	if node.Monitoring != nil && node.Monitoring.Enabled {
@@ -139,20 +182,6 @@ func effectivePort(stored, fallback int) int {
 		return stored
 	}
 	return fallback
-}
-
-// liveStatusProbe wraps the package-level apply.LiveStatus so cmd/
-// callers don't have to think about target resolution. The actual
-// probe logic lives in internal/apply for reuse by MCP / recipe.
-func liveStatusProbe(ctx context.Context, node *state.ManagedNode) map[string]any {
-	tgt, err := resolveTargetFromNode(node)
-	if err != nil {
-		return map[string]any{}
-	}
-	if c, ok := any(tgt).(interface{ Close() error }); ok {
-		defer c.Close()
-	}
-	return apply.LiveStatus(ctx, tgt, node)
 }
 
 // probeMonitoringStatus returns a short health status string for the

--- a/cmd/status_observe_test.go
+++ b/cmd/status_observe_test.go
@@ -1,0 +1,113 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/tronprotocol/tron-deployment/internal/paths"
+	"github.com/tronprotocol/tron-deployment/internal/state"
+)
+
+// TestRunStatus_EmitsHealthyAndLogs is the A1 status wire test: `status
+// -o json` must always carry `healthy` (seeded false, fail-safe) and a
+// runtime-discriminated `logs` locator. Uses a stopped jar node so no
+// live probe and no docker call fires (hermetic, fast).
+func TestRunStatus_EmitsHealthyAndLogs(t *testing.T) {
+	dir := t.TempDir()
+	paths.SetBaseDir(dir)
+	t.Cleanup(func() { paths.SetBaseDir("") })
+
+	store, err := state.NewStore(paths.State())
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	if err := store.Save(&state.DeploymentState{
+		Version: 1,
+		Nodes: []state.ManagedNode{{
+			Name:        "sr0",
+			Status:      "stopped", // skip live probe
+			Runtime:     "jar",     // skip docker container_id call
+			Network:     "private",
+			LastApplied: time.Now().UTC(),
+		}},
+	}); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	c := &cobra.Command{}
+	c.Flags().String("output", "json", "")
+	c.SetContext(context.Background())
+
+	old := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+	runErr := runStatus(c, []string{"sr0"})
+	_ = w.Close()
+	os.Stdout = old
+	out, _ := io.ReadAll(r)
+	if runErr != nil {
+		t.Fatalf("runStatus: %v", runErr)
+	}
+
+	var m map[string]any
+	if err := json.Unmarshal(out, &m); err != nil {
+		t.Fatalf("status JSON parse: %v\n%s", err, out)
+	}
+
+	// healthy must be PRESENT and false (node stopped → probe skipped → the
+	// seeded fail-safe value survives). Absence would let an agent misread
+	// "field missing" as "can't tell".
+	h, ok := m["healthy"]
+	if !ok {
+		t.Fatalf("status missing `healthy`; A1 requires it always present")
+	}
+	if h != false {
+		t.Errorf("healthy = %v; want false for a stopped node", h)
+	}
+
+	logs, ok := m["logs"].(map[string]any)
+	if !ok {
+		t.Fatalf("status missing `logs` object; got %v", m["logs"])
+	}
+	if logs["runtime"] != "jar" {
+		t.Errorf("logs.runtime = %v; want jar", logs["runtime"])
+	}
+	if logs["unit"] != "tron-sr0.service" {
+		t.Errorf("logs.unit = %v; want tron-sr0.service", logs["unit"])
+	}
+}
+
+// TestManifestForNode_EmitsLogs covers the `trond inspect` manifest's A1
+// logs locator for both runtimes. Uses jar + an ssh-target docker node so
+// the local-docker enrichment guard (Runtime==docker && Target==local) is
+// never hit — no real docker daemon call fires, keeping the test hermetic.
+func TestManifestForNode_EmitsLogs(t *testing.T) {
+	cases := []struct {
+		node    state.ManagedNode
+		wantRT  string
+		wantKey string // a key the descriptor must carry
+		wantVal string
+	}{
+		{state.ManagedNode{Name: "sr0", Runtime: "jar"}, "jar", "unit", "tron-sr0.service"},
+		{state.ManagedNode{Name: "fn0", Runtime: "docker", Target: state.NodeTarget{Type: "ssh"}}, "docker", "path", "/java-tron/logs/tron.log"},
+	}
+	for _, tc := range cases {
+		entry := manifestForNode(context.Background(), &tc.node)
+		logs, ok := entry["logs"].(map[string]any)
+		if !ok {
+			t.Fatalf("%s: manifest missing `logs`; got %v", tc.node.Name, entry["logs"])
+		}
+		if logs["runtime"] != tc.wantRT {
+			t.Errorf("%s: logs.runtime = %v; want %s", tc.node.Name, logs["runtime"], tc.wantRT)
+		}
+		if logs[tc.wantKey] != tc.wantVal {
+			t.Errorf("%s: logs.%s = %v; want %s", tc.node.Name, tc.wantKey, logs[tc.wantKey], tc.wantVal)
+		}
+	}
+}

--- a/internal/apply/observe_test.go
+++ b/internal/apply/observe_test.go
@@ -1,0 +1,215 @@
+package apply
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/tronprotocol/tron-deployment/internal/state"
+)
+
+// execTarget is a fakeTarget whose Exec is scripted per-test. It reuses
+// fakeTarget's no-op implementations for the rest of the interface.
+type execTarget struct {
+	*fakeTarget
+	exec func(ctx context.Context, name string, args ...string) ([]byte, error)
+}
+
+func (e *execTarget) Exec(ctx context.Context, name string, args ...string) ([]byte, error) {
+	return e.exec(ctx, name, args...)
+}
+
+func newExecTarget(fn func(ctx context.Context, name string, args ...string) ([]byte, error)) *execTarget {
+	return &execTarget{fakeTarget: &fakeTarget{}, exec: fn}
+}
+
+func TestLogsDescriptor_Docker(t *testing.T) {
+	node := &state.ManagedNode{Name: "fn0", Runtime: "docker"}
+	got := LogsDescriptor(node)
+	if got["runtime"] != "docker" {
+		t.Fatalf("runtime = %v, want docker", got["runtime"])
+	}
+	if got["container"] != "fn0" {
+		t.Errorf("container = %v, want fn0", got["container"])
+	}
+	if got["path"] != "/java-tron/logs/tron.log" {
+		t.Errorf("path = %v, want the in-container tron.log", got["path"])
+	}
+	if _, ok := got["unit"]; ok {
+		t.Errorf("docker descriptor must not carry a systemd unit: %v", got)
+	}
+}
+
+func TestLogsDescriptor_Jar(t *testing.T) {
+	node := &state.ManagedNode{Name: "sr1", Runtime: "jar"}
+	got := LogsDescriptor(node)
+	if got["runtime"] != "jar" {
+		t.Fatalf("runtime = %v, want jar", got["runtime"])
+	}
+	if got["unit"] != "tron-sr1.service" {
+		t.Errorf("unit = %v, want tron-sr1.service", got["unit"])
+	}
+	if _, ok := got["path"]; ok {
+		t.Errorf("jar descriptor must not carry a container path: %v", got)
+	}
+}
+
+func TestLogsDescriptor_Nil(t *testing.T) {
+	if got := LogsDescriptor(nil); got != nil {
+		t.Errorf("LogsDescriptor(nil) = %v, want nil", got)
+	}
+}
+
+func TestContainerID(t *testing.T) {
+	const valid = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef" // 64 hex
+	node := &state.ManagedNode{Name: "fn0", Runtime: "docker"}
+
+	cases := []struct {
+		name    string
+		runtime string
+		out     string
+		err     bool
+		want    string
+	}{
+		{"valid id", "docker", valid + "\n", false, valid},
+		{"jar runtime skipped", "jar", valid, false, ""},
+		{"docker error", "docker", "", true, ""},
+		{"too short", "docker", "abc123", false, ""},
+		{"non-hex garbage", "docker", "Error: No such object: fn0", false, ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			n := *node
+			n.Runtime = tc.runtime
+			tgt := newExecTarget(func(_ context.Context, _ string, _ ...string) ([]byte, error) {
+				if tc.err {
+					return nil, context.DeadlineExceeded
+				}
+				return []byte(tc.out), nil
+			})
+			if got := ContainerID(context.Background(), tgt, &n); got != tc.want {
+				t.Errorf("ContainerID = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestContainerID_NilTarget(t *testing.T) {
+	node := &state.ManagedNode{Name: "fn0", Runtime: "docker"}
+	if got := ContainerID(context.Background(), nil, node); got != "" {
+		t.Errorf("ContainerID(nil target) = %q, want empty", got)
+	}
+}
+
+func TestLiveStatus_SetsHealthy(t *testing.T) {
+	node := &state.ManagedNode{Name: "fn0", Runtime: "jar", HTTPPort: 8090}
+	tgt := newExecTarget(func(_ context.Context, _ string, args ...string) ([]byte, error) {
+		url := args[len(args)-1]
+		switch {
+		case strings.Contains(url, "/wallet/getnowblock"):
+			return []byte(`{"block_header":{"raw_data":{"number":42,"timestamp":1}}}`), nil
+		case strings.Contains(url, "/wallet/listnodes"):
+			return []byte(`{"nodes":[{},{}]}`), nil
+		}
+		return nil, context.DeadlineExceeded
+	})
+	out := LiveStatus(context.Background(), tgt, node)
+	if out["healthy"] != true {
+		t.Errorf("healthy = %v, want true (RPC answered with a parseable block)", out["healthy"])
+	}
+	if out["block_height"] != int64(42) {
+		t.Errorf("block_height = %v, want 42", out["block_height"])
+	}
+	if out["peer_count"] != 2 {
+		t.Errorf("peer_count = %v, want 2", out["peer_count"])
+	}
+}
+
+func TestLiveStatus_NoHealthyOnProbeFailure(t *testing.T) {
+	node := &state.ManagedNode{Name: "fn0", Runtime: "jar", HTTPPort: 8090}
+	tgt := newExecTarget(func(_ context.Context, _ string, _ ...string) ([]byte, error) {
+		return nil, context.DeadlineExceeded // node down: every probe fails
+	})
+	out := LiveStatus(context.Background(), tgt, node)
+	if _, ok := out["healthy"]; ok {
+		t.Errorf("healthy must be absent when the probe fails (caller seeds false); got %v", out["healthy"])
+	}
+}
+
+// TestLiveStatus_NoHealthyOnEmptyOrErrorBody pins the integrity gate: a 200
+// that parses as JSON but isn't a real block (empty `{}`, or an error-shaped
+// object — both yield block timestamp 0) must NOT read as healthy, and must
+// not fabricate a block_height of 0.
+func TestLiveStatus_NoHealthyOnEmptyOrErrorBody(t *testing.T) {
+	for _, body := range []string{`{}`, `{"Error":"some node error"}`, `{"block_header":{"raw_data":{"number":0,"timestamp":0}}}`} {
+		node := &state.ManagedNode{Name: "fn0", Runtime: "jar", HTTPPort: 8090}
+		tgt := newExecTarget(func(_ context.Context, _ string, args ...string) ([]byte, error) {
+			if strings.Contains(args[len(args)-1], "/wallet/getnowblock") {
+				return []byte(body), nil
+			}
+			return nil, context.DeadlineExceeded
+		})
+		out := LiveStatus(context.Background(), tgt, node)
+		if _, ok := out["healthy"]; ok {
+			t.Errorf("body %q: healthy must be absent (no real block); got %v", body, out["healthy"])
+		}
+		if _, ok := out["block_height"]; ok {
+			t.Errorf("body %q: block_height must be absent for a non-block response; got %v", body, out["block_height"])
+		}
+	}
+}
+
+// TestLiveStatus_DockerProbeShape covers the docker probe command path
+// (`docker exec <name> curl ...`), distinct from the jar host-side curl, so
+// a regression in the docker arg construction is caught.
+func TestLiveStatus_DockerProbeShape(t *testing.T) {
+	node := &state.ManagedNode{Name: "fn0", Runtime: "docker", HTTPPort: 8090}
+	var sawDockerExec bool
+	tgt := newExecTarget(func(_ context.Context, name string, args ...string) ([]byte, error) {
+		if name == "docker" && len(args) >= 2 && args[0] == "exec" && args[1] == "fn0" {
+			sawDockerExec = true
+		}
+		if strings.Contains(args[len(args)-1], "/wallet/getnowblock") {
+			return []byte(`{"block_header":{"raw_data":{"number":7,"timestamp":1}}}`), nil
+		}
+		return nil, context.DeadlineExceeded
+	})
+	out := LiveStatus(context.Background(), tgt, node)
+	if !sawDockerExec {
+		t.Errorf("docker node probe must run via `docker exec <name> ...`")
+	}
+	if out["healthy"] != true {
+		t.Errorf("healthy = %v, want true", out["healthy"])
+	}
+}
+
+func TestLogsDescriptor_UnknownRuntime(t *testing.T) {
+	// A node with an unrecorded/future runtime must NOT be mislabeled docker.
+	got := LogsDescriptor(&state.ManagedNode{Name: "x", Runtime: ""})
+	if got["runtime"] != "" {
+		t.Errorf("runtime = %v, want empty (honest unknown)", got["runtime"])
+	}
+	if _, ok := got["path"]; ok {
+		t.Errorf("unknown runtime must not assert a docker path: %v", got)
+	}
+	if _, ok := got["container"]; ok {
+		t.Errorf("unknown runtime must not assert a container: %v", got)
+	}
+}
+
+func TestNormalizeContainerID(t *testing.T) {
+	const valid = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+	cases := map[string]string{
+		valid + "\n":                 valid, // trims whitespace
+		"  " + valid + "  ":          valid,
+		"abc123":                     "", // too short
+		"Error: No such object: fn0": "", // docker error text
+		strings.ToUpper(valid):       "", // uppercase hex rejected
+		"":                           "",
+	}
+	for in, want := range cases {
+		if got := NormalizeContainerID(in); got != want {
+			t.Errorf("NormalizeContainerID(%q) = %q, want %q", in, got, want)
+		}
+	}
+}

--- a/internal/apply/probe.go
+++ b/internal/apply/probe.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/tronprotocol/tron-deployment/internal/state"
@@ -52,11 +53,23 @@ func LiveStatus(ctx context.Context, tgt target.Target, node *state.ManagedNode)
 			} `json:"block_header"`
 		}
 		if json.Unmarshal(data, &block) == nil {
-			out["block_height"] = block.BlockHeader.RawData.Number
-			if block.BlockHeader.RawData.Timestamp > 0 {
+			ts := block.BlockHeader.RawData.Timestamp
+			// Gate `healthy` on a real block, not just parseable JSON. An
+			// empty body `{}` or an error-shaped 200 (`{"Error":"..."}`)
+			// unmarshals cleanly into the zero value — number 0, timestamp
+			// 0 — and must NOT read as healthy. Every genuine getnowblock
+			// (including a private-net genesis) carries a non-zero block
+			// timestamp, so ts>0 is the integrity check that the node
+			// actually served a block. healthy is liveness only ("RPC is
+			// serving blocks"), NOT a sync guarantee — is_synced/block_height
+			// carry that. Only ever set true here; callers seed false so the
+			// field is always present and fail-safe.
+			if ts > 0 {
+				out["block_height"] = block.BlockHeader.RawData.Number
+				out["healthy"] = true
 				// "synced" heuristic: tip within 60s of now. Good enough
 				// for dashboards; not a consensus-level claim.
-				lag := time.Since(time.UnixMilli(block.BlockHeader.RawData.Timestamp))
+				lag := time.Since(time.UnixMilli(ts))
 				out["is_synced"] = lag < 60*time.Second
 			}
 		}
@@ -72,4 +85,76 @@ func LiveStatus(ctx context.Context, tgt target.Target, node *state.ManagedNode)
 	}
 
 	return out
+}
+
+// ContainerID returns the full 64-hex docker container ID for a node, or
+// "" when the node isn't a docker node, the daemon can't be reached, or
+// no container exists yet. Best-effort: callers treat "" as unknown and
+// omit the field rather than surface a probe error. Works for both local
+// and ssh targets via tgt.Exec. An agent uses this to attach/exec against
+// the exact container backing the rig (A1: container_id).
+func ContainerID(ctx context.Context, tgt target.Target, node *state.ManagedNode) string {
+	if tgt == nil || node == nil || node.Runtime != "docker" {
+		return ""
+	}
+	out, err := tgt.Exec(ctx, "docker", "inspect", "-f", "{{.Id}}", node.Name)
+	if err != nil {
+		return ""
+	}
+	return NormalizeContainerID(string(out))
+}
+
+// NormalizeContainerID trims and validates raw `docker inspect -f {{.Id}}`
+// output, returning the clean 64-hex container ID or "" if the input isn't
+// exactly 64 lowercase hex chars. docker prints error text (or nothing) to
+// stdout in some states, so this rejects anything malformed. Single source
+// of truth shared by apply.ContainerID (target.Exec → []byte) and cmd's
+// dockerContainerID (localDockerExec → string) so the format rule can't
+// drift between the two call sites.
+func NormalizeContainerID(s string) string {
+	id := strings.TrimSpace(s)
+	if len(id) != 64 || strings.TrimLeft(id, "0123456789abcdef") != "" {
+		return ""
+	}
+	return id
+}
+
+// LogsDescriptor returns a machine-readable locator telling an external
+// log consumer (e.g. mcp-logs) exactly how to read this node's logs
+// without screen-scraping. The shape is runtime-discriminated because the
+// retrieval mechanism genuinely differs — a single "log_path" string would
+// be wrong for half the runtimes:
+//
+//   - docker: java-tron logs to a file INSIDE the container
+//     (/java-tron/logs/tron.log); read it via `docker exec <container>`.
+//   - jar: the systemd unit's output lands in the journal; read it via
+//     `journalctl -u <unit>`.
+//
+// Static (no I/O) and always present, so a caller can plan retrieval even
+// for a stopped node (A1: node-log paths — the mcp-logs unblocker).
+func LogsDescriptor(node *state.ManagedNode) map[string]any {
+	if node == nil {
+		return nil
+	}
+	switch node.Runtime {
+	case "jar":
+		return map[string]any{
+			"runtime": "jar",
+			"unit":    fmt.Sprintf("tron-%s.service", node.Name),
+		}
+	case "docker":
+		return map[string]any{
+			"runtime":   "docker",
+			"container": node.Name,
+			"path":      "/java-tron/logs/tron.log",
+		}
+	default:
+		// Unknown/unrecorded runtime (e.g. a legacy node from before the
+		// field was stored, or a future runtime). Don't assert a concrete
+		// locator we can't stand behind — mislabeling such a node as
+		// "docker" would point a log consumer at a container path that
+		// doesn't exist. Report the runtime honestly so the caller sees it
+		// can't act on this descriptor.
+		return map[string]any{"runtime": node.Runtime}
+	}
 }

--- a/internal/build/builder.go
+++ b/internal/build/builder.go
@@ -301,6 +301,16 @@ func resolveBuild(ctx context.Context, req Request) (*resolved, error) {
 
 	src := Source{Path: req.SourcePath, RevisionSpec: req.RevisionSpec}
 	if err := src.Resolve(ctx); err != nil {
+		// A cancelled context kills the git sub-process (rev-parse / dirty
+		// detection) mid-flight, surfacing as a raw git error rather than a
+		// cancellation. That IS a cancelled build, not an invalid source —
+		// report it as such (matches the cancellation handling below and
+		// the FR-016 contract). Without this, cancelling during source
+		// resolution races: fast git → cancel lands later (reported
+		// cancelled), slow git → cancel kills git (reported INVALID_SOURCE).
+		if errors.Is(ctx.Err(), context.Canceled) {
+			return nil, output.NewErrorf("BUILD_CANCELLED", 130, "build cancelled by user")
+		}
 		return nil, output.NewErrorf("INVALID_SOURCE", output.ExitValidationError,
 			"resolve source: %s", err.Error()).
 			WithSuggestions(

--- a/internal/mcp/tools_inspection.go
+++ b/internal/mcp/tools_inspection.go
@@ -107,20 +107,37 @@ func statusForNode(ctx context.Context, _ *mcp.CallToolRequest, args nodeArg) (*
 		"labels":       node.Labels,
 		"network":      node.Network,
 		"is_private":   intent.IsPrivate(node.Network),
+		// A1 parity with `trond status -o json`: healthy seeded false
+		// (live probe flips it true), logs is the runtime-discriminated
+		// log locator for an external consumer.
+		"healthy": false,
+		"logs":    apply.LogsDescriptor(node),
 	}
-	// Live probe — best effort, only when state says the node is
-	// running. We resolve a target via the node's stored target spec
-	// (state.NodeTarget → target.Target) and hand it to apply.LiveStatus.
-	// Errors during probe are silently dropped; the caller sees
-	// block_height / is_synced / peer_count appear or not.
-	if node.Status == "running" {
+	// Live probe + container_id — best effort, resolving the target at most
+	// once. We must not open an SSH connection just to read container_id
+	// from a stopped remote node (mcpResolveTargetFromNode.Connect() isn't
+	// bound by the probe context), so we only resolve when the node is
+	// running (the probe needs a target anyway) or it's a LOCAL docker node
+	// (cheap). An ssh docker node still gets container_id, but only
+	// piggybacked on the running-node resolution. Errors are dropped.
+	needLocalDockerID := node.Runtime == "docker" && node.Target.Type == "local"
+	if node.Status == "running" || needLocalDockerID {
 		if tgt, err := mcpResolveTargetFromNode(node); err == nil {
 			if c, ok := any(tgt).(interface{ Close() error }); ok {
 				defer c.Close()
 			}
-			probeCtx, cancel := context.WithTimeout(ctx, 3*time.Second)
-			defer cancel()
-			maps.Copy(out, apply.LiveStatus(probeCtx, tgt, node))
+			// Probe first with its own budget so a slow container_id lookup
+			// can't starve the primary `healthy` signal.
+			if node.Status == "running" {
+				pctx, pcancel := context.WithTimeout(ctx, 3*time.Second)
+				maps.Copy(out, apply.LiveStatus(pctx, tgt, node))
+				pcancel()
+			}
+			cctx, ccancel := context.WithTimeout(ctx, 3*time.Second)
+			if id := apply.ContainerID(cctx, tgt, node); id != "" {
+				out["container_id"] = id
+			}
+			ccancel()
 		}
 	}
 	return jsonResult(out)
@@ -158,6 +175,11 @@ func inspectAllNodes(ctx context.Context, _ *mcp.CallToolRequest, _ emptyArgs) (
 			"runtime":    n.Runtime,
 			"network":    n.Network,
 			"is_private": intent.IsPrivate(n.Network),
+			// logs is static (no docker call), so it's safe to include in
+			// the deliberately-static MCP inspect. container_id is omitted
+			// here (it needs a live docker query) — callers wanting it use
+			// the `status` tool, which already resolves a target.
+			"logs": apply.LogsDescriptor(&n),
 		}
 		// Endpoints: we have HTTPPort/GRPCPort persisted in state from
 		// apply; cmd/inspect.go's enrichment with container_ip

--- a/internal/mcp/tools_inspection_observe_test.go
+++ b/internal/mcp/tools_inspection_observe_test.go
@@ -1,0 +1,88 @@
+package mcp
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/tronprotocol/tron-deployment/internal/paths"
+	"github.com/tronprotocol/tron-deployment/internal/state"
+)
+
+// seedNode writes a single-node state file into an isolated base dir and
+// returns it. Mirrors the C1/A1 wire-test pattern used in cmd/.
+func seedNode(t *testing.T, n state.ManagedNode) {
+	t.Helper()
+	dir := t.TempDir()
+	paths.SetBaseDir(dir)
+	t.Cleanup(func() { paths.SetBaseDir("") })
+	store, err := state.NewStore(paths.State())
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	if err := store.Save(&state.DeploymentState{Version: 1, Nodes: []state.ManagedNode{n}}); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+}
+
+// TestStatusForNode_EmitsHealthyAndLogs is the A1 MCP-status wire test:
+// healthy seeded false (always present) + the runtime-discriminated logs
+// locator. Stopped jar node → no target resolution, no docker call.
+func TestStatusForNode_EmitsHealthyAndLogs(t *testing.T) {
+	seedNode(t, state.ManagedNode{
+		Name: "sr0", Status: "stopped", Runtime: "jar",
+		Network: "private", LastApplied: time.Now().UTC(),
+	})
+
+	_, v, err := statusForNode(context.Background(), nil, nodeArg{Name: "sr0"})
+	if err != nil {
+		t.Fatalf("statusForNode: %v", err)
+	}
+	out, ok := v.(map[string]any)
+	if !ok {
+		t.Fatalf("result is not a map: %T", v)
+	}
+	h, ok := out["healthy"]
+	if !ok {
+		t.Fatalf("MCP status missing `healthy`; A1 requires it always present")
+	}
+	if h != false {
+		t.Errorf("healthy = %v; want false for a stopped node", h)
+	}
+	logs, ok := out["logs"].(map[string]any)
+	if !ok {
+		t.Fatalf("MCP status missing `logs` object; got %v", out["logs"])
+	}
+	if logs["runtime"] != "jar" || logs["unit"] != "tron-sr0.service" {
+		t.Errorf("logs = %v; want jar/tron-sr0.service", logs)
+	}
+}
+
+// TestInspectAllNodes_EmitsLogs verifies the MCP inspect manifest carries
+// the (static) logs locator per node.
+func TestInspectAllNodes_EmitsLogs(t *testing.T) {
+	seedNode(t, state.ManagedNode{
+		Name: "fn0", Status: "stopped", Runtime: "docker",
+		Network: "private", HTTPPort: 8090, LastApplied: time.Now().UTC(),
+	})
+
+	_, v, err := inspectAllNodes(context.Background(), nil, emptyArgs{})
+	if err != nil {
+		t.Fatalf("inspectAllNodes: %v", err)
+	}
+	top, ok := v.(map[string]any)
+	if !ok {
+		t.Fatalf("result is not a map: %T", v)
+	}
+	rows, ok := top["nodes"].([]map[string]any)
+	if !ok || len(rows) != 1 {
+		t.Fatalf("nodes shape unexpected: %T %v", top["nodes"], top["nodes"])
+	}
+	logs, ok := rows[0]["logs"].(map[string]any)
+	if !ok {
+		t.Fatalf("inspect row missing `logs`; got %v", rows[0]["logs"])
+	}
+	if logs["runtime"] != "docker" || logs["path"] != "/java-tron/logs/tron.log" {
+		t.Errorf("logs = %v; want docker shape", logs)
+	}
+}

--- a/internal/schema/embed.go
+++ b/internal/schema/embed.go
@@ -62,7 +62,14 @@ import (
 //	        `is_private` (the C1 private-net safety fact); new
 //	        `apply` / `network create --require-private` gate. Additive
 //	        optional fields.
-const SchemaVersion = "1.8.0"
+//	1.9.0 — status output gains `healthy`, `container_id`, and a
+//	        runtime-discriminated `logs` locator; inspect output gains
+//	        `logs` (and now populates the already-declared `container_id`).
+//	        Completes the ai-ops A1 ask (machine-observable rig state:
+//	        container_id + node-log paths) so external read-only tools
+//	        (tron-toolkit, mcp-logs) can attach with zero new code.
+//	        Additive optional fields.
+const SchemaVersion = "1.9.0"
 
 // JSONSchemaURLBase is the canonical URL prefix for individual output
 // schema files. Embedded $id values inside each schema mirror this so

--- a/internal/schema/files/inspect.schema.json
+++ b/internal/schema/files/inspect.schema.json
@@ -30,7 +30,17 @@
             "type": "string",
             "description": "Internal docker network IP of the container; absent for jar runtime."
           },
-          "container_id": { "type": "string" },
+          "container_id": { "type": "string", "description": "Full 64-hex docker container ID (best-effort, local docker nodes only)." },
+          "logs": {
+            "type": "object",
+            "description": "Runtime-discriminated log locator (same shape as `trond status` -o json). docker: read `path` inside `container` via `docker exec`; jar: read the systemd `unit`'s journal.",
+            "properties": {
+              "runtime":   { "type": "string", "enum": ["docker", "jar"] },
+              "container": { "type": "string" },
+              "path":      { "type": "string" },
+              "unit":      { "type": "string" }
+            }
+          },
           "labels":       { "type": "object", "additionalProperties": { "type": "string" } },
           "network":      { "type": "string" }
         }

--- a/internal/schema/files/status.schema.json
+++ b/internal/schema/files/status.schema.json
@@ -57,6 +57,24 @@
       "type": "boolean",
       "description": "True when network is 'private' — a self-contained chain safe for an unattended agent to mutate. Lets an automated caller PROVE a rig is private before acting. False when network is empty/unknown (fail-safe)."
     },
+    "healthy": {
+      "type": "boolean",
+      "description": "Liveness only: true when status=running AND the live getnowblock probe returned a REAL block (non-zero block timestamp — an empty or error-shaped 200 does not count). It means 'the RPC is serving blocks', NOT that the node is fully synced — use is_synced and block_height for sync health (healthy can be true while is_synced is false on a node whose tip is stale). False when stopped, unreachable, or the probe was skipped (fail-safe). Always present."
+    },
+    "container_id": {
+      "type": "string",
+      "description": "Full 64-hex docker container ID backing this node (runtime=docker, best-effort). Lets an agent attach/exec against the exact container. Absent for jar nodes or when the docker daemon can't be reached."
+    },
+    "logs": {
+      "type": "object",
+      "description": "Runtime-discriminated locator telling an external log consumer (e.g. mcp-logs) how to read this node's logs without screen-scraping. For runtime=docker, read `path` inside `container` via `docker exec`. For runtime=jar, read the systemd `unit`'s journal via `journalctl -u`.",
+      "properties": {
+        "runtime":   { "type": "string", "enum": ["docker", "jar"] },
+        "container": { "type": "string", "description": "docker container name (runtime=docker)." },
+        "path":      { "type": "string", "description": "log file path INSIDE the container (runtime=docker)." },
+        "unit":      { "type": "string", "description": "systemd unit whose journal carries the logs (runtime=jar)." }
+      }
+    },
     "lag": {
       "type": "integer",
       "description": "Block delta between local height and the highest height the node has seen across peers; only present from live probe."

--- a/internal/schema/version_baseline.json
+++ b/internal/schema/version_baseline.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": "1.8.0",
+  "schema_version": "1.9.0",
   "entries": [
     {
       "name": "apply",
@@ -59,7 +59,7 @@
     },
     {
       "name": "inspect",
-      "hash": "b2ff5ff94b3232ca0ac697566ba81aa283fb242783485aa76a576802dd04e208"
+      "hash": "98903914b1f632a16f719576afbd39e98c43cce5b41139451ea8665de191512f"
     },
     {
       "name": "list",
@@ -115,7 +115,7 @@
     },
     {
       "name": "status",
-      "hash": "c589ec747498ce2ed52f701c80d26151cf1746757d4c05a0f24d9e54b6b96e00"
+      "hash": "d10f5c4ab65e7fa711d5fd4a725db82b5b8717f568b2e41431cebede4c629223"
     },
     {
       "name": "verify",

--- a/schemas/output/inspect.schema.json
+++ b/schemas/output/inspect.schema.json
@@ -30,7 +30,17 @@
             "type": "string",
             "description": "Internal docker network IP of the container; absent for jar runtime."
           },
-          "container_id": { "type": "string" },
+          "container_id": { "type": "string", "description": "Full 64-hex docker container ID (best-effort, local docker nodes only)." },
+          "logs": {
+            "type": "object",
+            "description": "Runtime-discriminated log locator (same shape as `trond status` -o json). docker: read `path` inside `container` via `docker exec`; jar: read the systemd `unit`'s journal.",
+            "properties": {
+              "runtime":   { "type": "string", "enum": ["docker", "jar"] },
+              "container": { "type": "string" },
+              "path":      { "type": "string" },
+              "unit":      { "type": "string" }
+            }
+          },
           "labels":       { "type": "object", "additionalProperties": { "type": "string" } },
           "network":      { "type": "string" }
         }

--- a/schemas/output/status.schema.json
+++ b/schemas/output/status.schema.json
@@ -57,6 +57,24 @@
       "type": "boolean",
       "description": "True when network is 'private' — a self-contained chain safe for an unattended agent to mutate. Lets an automated caller PROVE a rig is private before acting. False when network is empty/unknown (fail-safe)."
     },
+    "healthy": {
+      "type": "boolean",
+      "description": "Liveness only: true when status=running AND the live getnowblock probe returned a REAL block (non-zero block timestamp — an empty or error-shaped 200 does not count). It means 'the RPC is serving blocks', NOT that the node is fully synced — use is_synced and block_height for sync health (healthy can be true while is_synced is false on a node whose tip is stale). False when stopped, unreachable, or the probe was skipped (fail-safe). Always present."
+    },
+    "container_id": {
+      "type": "string",
+      "description": "Full 64-hex docker container ID backing this node (runtime=docker, best-effort). Lets an agent attach/exec against the exact container. Absent for jar nodes or when the docker daemon can't be reached."
+    },
+    "logs": {
+      "type": "object",
+      "description": "Runtime-discriminated locator telling an external log consumer (e.g. mcp-logs) how to read this node's logs without screen-scraping. For runtime=docker, read `path` inside `container` via `docker exec`. For runtime=jar, read the systemd `unit`'s journal via `journalctl -u`.",
+      "properties": {
+        "runtime":   { "type": "string", "enum": ["docker", "jar"] },
+        "container": { "type": "string", "description": "docker container name (runtime=docker)." },
+        "path":      { "type": "string", "description": "log file path INSIDE the container (runtime=docker)." },
+        "unit":      { "type": "string", "description": "systemd unit whose journal carries the logs (runtime=jar)." }
+      }
+    },
     "lag": {
       "type": "integer",
       "description": "Block delta between local height and the highest height the node has seen across peers; only present from live probe."


### PR DESCRIPTION
## What

Adds the machine-observable fields the agent-integration **A1** ask needs to `trond status` / `inspect` JSON, so external read-only tools can attach to a private-net rig with zero new code on their side. Builds on the C1 private-net fact (#190).

Per-node `status -o json` / `inspect -o json` now carry:

- **`healthy`** (bool, always present) — liveness gate: `true` only when `status=running` AND the live `getnowblock` probe returned a **real** block (non-zero block timestamp; an empty or error-shaped 200 does not count). It is liveness, **not** a sync guarantee — `healthy` can be `true` while `is_synced` is `false` on a stale tip. Fail-safe `false` when stopped/unreachable/skipped.
- **`container_id`** (string) — full 64-hex docker container ID, so an agent can `docker exec`/attach the exact container. Best-effort; `inspect` now populates the field its schema already declared.
- **`logs`** (object) — runtime-discriminated log locator (the `mcp-logs` unblocker). A single `log_path` string would lie, since docker logs to a file *inside* the container (`/java-tron/logs/tron.log`, via `docker exec`) while jar logs go to `journalctl -u <unit>`. So `logs` is `{runtime, container, path}` or `{runtime, unit}`, with an honest `{runtime}` for unknown runtimes.

`rpc_endpoint` (`api_endpoints.http`) already existed, so on-chain readers like `tron-toolkit` can point at the private-net RPC today. The MCP `status`/`inspect` tools mirror the CLI shapes.

`chain_id` (the one remaining A1 field) is deferred — TRON's chain id is genesis-derived with no cheap single-field RPC; tracked in `TODOS.md` with the derivation plan. Not required to unblock the named consumers.

## Implementation notes

- New reusable helpers in `internal/apply`: `LiveStatus` sets `healthy`; `ContainerID`, `NormalizeContainerID` (shared 64-hex validator), `LogsDescriptor`.
- Target resolution is gated so a **stopped ssh node never triggers a blocking SSH dial** just to read `container_id` (`SSHTarget.Connect()` isn't bound by the probe context). An ssh docker node still gets `container_id`, but only piggybacked on the running-node probe.
- The health probe and the optional `container_id` lookup get **independent deadlines**, so a slow `docker inspect` can't starve the primary `healthy` signal.
- `SchemaVersion` 1.8.0 → 1.9.0 (additive optional fields across `status` + `inspect`; baseline regenerated). `AGENTS.md` documents the new fields.

## Tests

Unit-tested: the helpers, the `{}`/error-body integrity gate, the docker-vs-jar probe shapes, and wire-level coverage for CLI `status`/`inspect` and MCP `status`/`inspect`. `go vet` + `golangci-lint` clean; full cmd/apply/mcp/schema suites pass.