### PR TITLE
feat(snapshot): add `snapshot clone` — CoW clone a chain-DB dir for warm-pool fixtures

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -271,6 +271,29 @@ trond snapshot prune                      # default policy
 trond snapshot prune --all -o json        # ignore age, return JSON
 ```
 
+### Warm pool — `trond snapshot clone`
+
+Once you have a chain DB on disk (a downloaded snapshot, or a STOPPED
+node's data dir), fork it into isolated fixtures in seconds instead of
+re-downloading 30-90GB:
+
+```bash
+trond snapshot clone ./output-directory ./rig-a/output-directory -o json
+# → {"source":"...","dest":"...","method":"clonefile","duration_ms":3}
+```
+
+`method` is `clonefile` (macOS APFS) or `ficlone` (Linux btrfs/xfs) for a
+copy-on-write clone — instant, sharing extents, near-zero extra disk. It is
+`copy` when source and dest are on different filesystems (or a non-CoW FS):
+a full byte copy is made (slow, full disk) and a warning prints to stderr,
+so keep the clone target on the SAME filesystem as the source for the fast
+path. `<dst>` must not already exist (clone refuses rather than overwrite),
+and the source must be **quiescent** — stop a node before cloning its live
+DB, or the point-in-time view is undefined. Cross-FS clones get a
+free-space preflight (refused with `DISK_SPACE_ERROR` if the copy won't
+fit). CLI-only (not an MCP tool): it mutates the filesystem, so it stays
+out of the read-only agent fleet.
+
 The intent needs `storage.data: /srv/tron/<node>/output-directory` so
 the bind mount lines up with where the tarball extracts. See
 `examples/mainnet-fullnode-snapshot.yaml`.

--- a/TODOS.md
+++ b/TODOS.md
@@ -3,25 +3,26 @@
 Deferred work captured during reviews. Each item carries enough context to pick
 up cold.
 
-## Public `trond snapshot clone` verb
+## `trond snapshot clone --from-node <name>` (resolve a node's DB dir)
 
-- **What:** Expose the `internal/fsclone` copy-on-write clone primitive as a
-  user-facing `trond snapshot clone <src> <dst>` CLI verb.
-- **Why:** Lets agents / operators build a warm pool of fixtures interactively —
-  clone a cached, pinned snapshot to a fresh isolated dir in seconds instead of
-  re-downloading or re-copying 30–90 GB.
-- **Pros:** Completes the warm-pool story as a first-class capability; useful for
-  the "a new agent just uses trond" workflow.
-- **Cons:** Speculative public API with only one consumer today (the equivalence
-  test). Adds CLI surface, docs, and a test matrix for a capability nobody is
-  asking for interactively yet.
-- **Context:** Deferred during the 2026-06-13 `/plan-eng-review` (Issue 1). The
-  reusable primitive lives in `internal/fsclone` (`x/sys/unix` clonefile/FICLONE
-  with byte-copy fallback). The outside-voice (Codex) Net agreed: don't broaden
-  to a public verb until a second real consumer exists AND CI proves CoW is
-  available where it matters.
-- **Depends on / blocked by:** `internal/fsclone` primitive landing (this PR);
-  a concrete second consumer (e.g. an agent warm-pool flow or `apply --snapshot`).
+- **What:** Add a `--from-node <name>` source to `snapshot clone` that resolves a
+  managed node's chain-DB directory from state, for BOTH docker and jar runtimes,
+  and refuses to clone unless the node is stopped.
+- **Why:** Lets an agent fork a live rig's DB by node name instead of hand-typing
+  the on-disk path.
+- **Cons / why it was deferred from B3:** the existing `destFromNode`
+  (`cmd/snapshot/download.go`) is jar-only (rejects docker) and returns
+  `install_path`, NOT the chain-DB dir — so it can't be reused as-is. Docker
+  storage paths live in render logic, not `state.json`, so this needs a new
+  runtime-aware DB-path resolver. And `fsclone.CloneDir`'s contract requires a
+  *quiescent* source, so `--from-node` must hard-refuse a running node (or stop
+  it) to avoid a corrupt point-in-time clone.
+- **Context:** Deferred during the 2026-06-17 `/plan-eng-review` of B3 (the
+  outside-voice/Codex caught that the originally-planned `--from-node` was
+  jar-only + unsafe-on-running). B3 shipped positional-paths-only
+  (`clone <src> <dst>`); this is the by-node convenience layer on top.
+- **Depends on / blocked by:** B3 (`snapshot clone`) landing first; a
+  runtime-aware DB-path resolver (docker storage path is not in state today).
 
 ## Emit `chain_id` in `status` / `inspect` -o json
 

--- a/cmd/schema_coverage_test.go
+++ b/cmd/schema_coverage_test.go
@@ -94,6 +94,7 @@ func TestSchemaCoverage(t *testing.T) {
 		"trond recipe show":        "recipe-show",
 		"trond shadow-fork mutate": "shadow-fork-mutate",
 		"trond snapshot download":  "snapshot-download",
+		"trond snapshot clone":     "snapshot-clone",
 		"trond snapshot jobs":      "snapshot-jobs",
 		"trond snapshot list":      "snapshot-list",
 		"trond snapshot sources":   "snapshot-sources",

--- a/cmd/snapshot/clone.go
+++ b/cmd/snapshot/clone.go
@@ -1,0 +1,250 @@
+package snapshot
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/tronprotocol/tron-deployment/internal/fsclone"
+	"github.com/tronprotocol/tron-deployment/internal/output"
+	"github.com/tronprotocol/tron-deployment/internal/target"
+)
+
+// clone wires `trond snapshot clone <src> <dst>` — a thin presentation
+// layer over internal/fsclone.CloneDir. It exists so an operator/agent can
+// build a warm pool of chain-DB fixtures: fork a cached snapshot (or a
+// STOPPED node's data dir) into a fresh isolated directory in seconds via
+// a copy-on-write clone, instead of re-downloading or re-copying 30-90GB.
+//
+//	src ──stat/guard──> CloneDir(src,dst) ──> {clonefile|ficlone|copy}
+//	     same FS? ─no─> free-space preflight (full copy is guaranteed)
+//	     dst ⊄ src?  (canonical-path containment guard)
+//
+// Mutating (creates dst) so it is CLI-only — deliberately NOT an MCP tool,
+// keeping filesystem-mutating capability out of the read-only agent fleet.
+var cloneCmd = &cobra.Command{
+	Use:   "clone <src> <dst>",
+	Short: "Copy-on-write clone a chain-DB directory into a fresh path",
+	Long: `Clone an existing chain database directory (a downloaded snapshot, or a
+STOPPED node's data dir) into a new, independent directory. When source
+and destination live on the same filesystem this is a copy-on-write
+clone (APFS clonefile / Linux FICLONE): seconds and near-zero extra disk
+even for a 30-90GB store. Across filesystems (or on a filesystem without
+CoW) it falls back to a full byte copy — a warning is printed and the
+"method" field reports "copy".
+
+<src> is cloned verbatim: point it at whatever level you want
+materialised (the snapshot's output-directory, or its parent). <dst>
+must not already exist — clone refuses rather than overwrite.
+
+The source must be QUIESCENT. Cloning a running node's live database
+yields an undefined point-in-time view; stop the node first.`,
+	Example: `  # Fork a cached snapshot into an isolated fixture (instant on APFS/btrfs/xfs)
+  trond snapshot clone ./output-directory ./rig-a/output-directory
+
+  # Clone a stopped node's data dir, JSON output
+  trond snapshot clone ~/.trond/deployments/fn0/output-directory ./fixture -o json`,
+	Args: cobra.ExactArgs(2),
+	RunE: runClone,
+}
+
+func runClone(cmd *cobra.Command, args []string) error {
+	outputFmt, _ := cmd.Flags().GetString("output")
+	src, dst := args[0], args[1]
+
+	// Source must exist and be a directory. CloneDir re-checks, but we
+	// want a clean VALIDATION_ERROR before any staging work.
+	srcInfo, err := os.Stat(src)
+	if err != nil {
+		return output.NewError("VALIDATION_ERROR", output.ExitValidationError,
+			fmt.Sprintf("source %s: %v", src, err))
+	}
+	if !srcInfo.IsDir() {
+		return output.NewError("VALIDATION_ERROR", output.ExitValidationError,
+			fmt.Sprintf("source %s is not a directory", src))
+	}
+
+	// Refuse a pre-existing destination — clone never overwrites (matches
+	// CloneDir's contract). No --force / destructive path in trond.
+	if _, statErr := os.Stat(dst); statErr == nil {
+		return output.NewError("VALIDATION_ERROR", output.ExitValidationError,
+			fmt.Sprintf("destination %s already exists; choose a fresh path or remove it first", dst))
+	} else if !os.IsNotExist(statErr) {
+		return output.NewError("VALIDATION_ERROR", output.ExitValidationError,
+			fmt.Sprintf("stat destination %s: %v", dst, statErr))
+	}
+
+	// Containment guard on CANONICAL paths. A dst inside src would make the
+	// clone walk re-enter its own staging area (corruption/bloat). Raw
+	// string-prefix checks are bypassable via symlinks/relative paths, so
+	// resolve to absolute, symlink-free paths first.
+	if err := assertDisjoint(src, dst); err != nil {
+		return output.NewError("VALIDATION_ERROR", output.ExitValidationError, err.Error())
+	}
+
+	// Free-space preflight, but ONLY when CoW cannot fire (src and dst on
+	// different filesystems → a full byte copy is guaranteed). A same-FS
+	// CoW clone shares extents and needs ~no space, so a free>=size check
+	// there would falsely refuse on a near-full disk.
+	anc := firstExistingAncestor(dst)
+	if sameFS, devErr := sameFilesystem(src, anc); devErr == nil && !sameFS {
+		need, sizeErr := dirSize(src)
+		free, freeErr := target.NewLocalTarget().DiskFree(cmd.Context(), anc)
+		if sizeErr == nil && freeErr == nil && need > 0 && free < need {
+			return output.NewError("DISK_SPACE_ERROR", output.ExitGeneralError,
+				fmt.Sprintf("cross-filesystem clone of %s requires a full byte copy (~%d bytes) "+
+					"but only %d bytes are free at %s", src, need, free, anc))
+		}
+	}
+
+	start := time.Now()
+	method, err := fsclone.CloneDir(src, dst)
+	if err != nil {
+		return output.NewError("CLONE_ERROR", output.ExitGeneralError, err.Error())
+	}
+	durMs := time.Since(start).Milliseconds()
+
+	// CoW didn't fire — surface it loudly. The "fast clone" became a slow
+	// full copy; the caller (and any human watching) should know.
+	if method == methodCopyName {
+		fmt.Fprintf(os.Stderr,
+			"warning: copy-on-write unavailable (cross-filesystem or unsupported FS) — "+
+				"fell back to a full byte copy of %s; this is slow and uses full disk\n", src)
+	}
+
+	res := map[string]any{
+		"source":      src,
+		"dest":        dst,
+		"method":      method,
+		"duration_ms": durMs,
+	}
+	if outputFmt == "json" {
+		return output.WriteJSON(os.Stdout, res)
+	}
+	fmt.Printf("Cloned %s -> %s (method: %s, %dms)\n", src, dst, method, durMs)
+	return nil
+}
+
+// methodCopyName mirrors fsclone's "copy" fallback label. Kept as a local
+// const so the warning trigger doesn't hard-code a bare string twice.
+const methodCopyName = "copy"
+
+// assertDisjoint rejects src==dst, dst-inside-src, and src-inside-dst using
+// canonical (absolute, symlink-resolved) paths. dst need not exist yet, so
+// its nearest existing ancestor is resolved and the remainder re-appended.
+func assertDisjoint(src, dst string) error {
+	cs, err := canonical(src)
+	if err != nil {
+		return fmt.Errorf("resolve source %s: %v", src, err)
+	}
+	cd, err := canonicalDst(dst)
+	if err != nil {
+		return fmt.Errorf("resolve destination %s: %v", dst, err)
+	}
+	if cs == cd {
+		return fmt.Errorf("source and destination resolve to the same path: %s", cs)
+	}
+	if within(cd, cs) {
+		return fmt.Errorf("destination %s is inside source %s; choose a destination outside the source tree", dst, src)
+	}
+	if within(cs, cd) {
+		return fmt.Errorf("source %s is inside destination %s", src, dst)
+	}
+	return nil
+}
+
+// canonical returns the absolute, symlink-resolved form of an existing path.
+func canonical(p string) (string, error) {
+	abs, err := filepath.Abs(p)
+	if err != nil {
+		return "", err
+	}
+	return filepath.EvalSymlinks(abs)
+}
+
+// canonicalDst canonicalises a path that may not exist yet: resolve symlinks
+// on the nearest existing ancestor, then re-join the not-yet-created tail.
+func canonicalDst(dst string) (string, error) {
+	abs, err := filepath.Abs(dst)
+	if err != nil {
+		return "", err
+	}
+	anc := firstExistingAncestor(abs)
+	resolvedAnc, err := filepath.EvalSymlinks(anc)
+	if err != nil {
+		return "", err
+	}
+	rest, err := filepath.Rel(anc, abs)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(resolvedAnc, rest), nil
+}
+
+// within reports whether child is strictly inside parent (not equal).
+func within(child, parent string) bool {
+	rel, err := filepath.Rel(parent, child)
+	if err != nil {
+		return false
+	}
+	if rel == "." {
+		return false
+	}
+	return rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator))
+}
+
+// firstExistingAncestor walks up from an absolute path until it finds a
+// directory that exists (the filesystem root always does).
+func firstExistingAncestor(p string) string {
+	abs, err := filepath.Abs(p)
+	if err != nil {
+		abs = p
+	}
+	for {
+		if _, statErr := os.Stat(abs); statErr == nil {
+			return abs
+		}
+		parent := filepath.Dir(abs)
+		if parent == abs {
+			return abs
+		}
+		abs = parent
+	}
+}
+
+// sameFilesystem reports whether two existing paths sit on the same device,
+// i.e. whether a copy-on-write clone between them can share extents.
+func sameFilesystem(a, b string) (bool, error) {
+	var sa, sb syscall.Stat_t
+	if err := syscall.Stat(a, &sa); err != nil {
+		return false, err
+	}
+	if err := syscall.Stat(b, &sb); err != nil {
+		return false, err
+	}
+	return sa.Dev == sb.Dev, nil
+}
+
+// dirSize sums the apparent size of all regular files under root.
+func dirSize(root string) (uint64, error) {
+	var total uint64
+	err := filepath.WalkDir(root, func(_ string, d os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if d.Type().IsRegular() {
+			info, infoErr := d.Info()
+			if infoErr != nil {
+				return infoErr
+			}
+			total += uint64(info.Size())
+		}
+		return nil
+	})
+	return total, err
+}

--- a/cmd/snapshot/clone_test.go
+++ b/cmd/snapshot/clone_test.go
@@ -1,0 +1,153 @@
+package snapshot
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+
+	"github.com/tronprotocol/tron-deployment/internal/output"
+)
+
+// runCloneCapture runs runClone with a cobra command carrying the given
+// output format, capturing stdout, and returns the raw stdout + run error.
+func runCloneCapture(t *testing.T, src, dst, format string) (string, error) {
+	t.Helper()
+	c := &cobra.Command{}
+	c.Flags().String("output", format, "")
+	c.SetContext(context.Background())
+
+	old := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+	err := runClone(c, []string{src, dst})
+	_ = w.Close()
+	os.Stdout = old
+	raw, _ := io.ReadAll(r)
+	return string(raw), err
+}
+
+// invokeClone is the JSON-output convenience wrapper: it parses stdout into
+// a map. Error cases return a nil map + the error.
+func invokeClone(t *testing.T, src, dst string) (map[string]any, error) {
+	t.Helper()
+	raw, err := runCloneCapture(t, src, dst, "json")
+	var m map[string]any
+	if len(raw) > 0 {
+		if jsonErr := json.Unmarshal([]byte(raw), &m); jsonErr != nil && err == nil {
+			t.Fatalf("clone JSON parse: %v\n%s", jsonErr, raw)
+		}
+	}
+	return m, err
+}
+
+func wantValidationError(t *testing.T, err error) {
+	t.Helper()
+	if err == nil {
+		t.Fatal("expected an error, got nil")
+	}
+	var se *output.StructuredError
+	if !errors.As(err, &se) {
+		t.Fatalf("expected *output.StructuredError, got %T: %v", err, err)
+	}
+	if se.ExitCode != output.ExitValidationError {
+		t.Errorf("exit code = %d, want %d (validation); err=%v", se.ExitCode, output.ExitValidationError, err)
+	}
+}
+
+func TestRunClone_SrcMissing(t *testing.T) {
+	tmp := t.TempDir()
+	_, err := invokeClone(t, filepath.Join(tmp, "nope"), filepath.Join(tmp, "dst"))
+	wantValidationError(t, err)
+}
+
+func TestRunClone_DstExists(t *testing.T) {
+	tmp := t.TempDir()
+	src := filepath.Join(tmp, "src")
+	dst := filepath.Join(tmp, "dst")
+	mustMkdir(t, src)
+	mustMkdir(t, dst) // dst already present → refuse
+	_, err := invokeClone(t, src, dst)
+	wantValidationError(t, err)
+}
+
+func TestRunClone_DstInsideSrc(t *testing.T) {
+	tmp := t.TempDir()
+	src := filepath.Join(tmp, "src")
+	mustMkdir(t, src)
+	dst := filepath.Join(src, "sub") // dst is inside src → reject
+	_, err := invokeClone(t, src, dst)
+	wantValidationError(t, err)
+	// dst must not have been created
+	if _, statErr := os.Stat(dst); !os.IsNotExist(statErr) {
+		t.Errorf("dst should not exist after a rejected clone")
+	}
+}
+
+// TestRunClone_HappyRoundTrip clones a small tree into an ADJACENT directory
+// (same filesystem, so CoW can fire) and asserts: the wire JSON shape, that
+// a method was reported (clonefile|ficlone|copy — any is valid; CI
+// filesystems return copy even for adjacent dirs), and that data is
+// byte-identical in the clone.
+func TestRunClone_HappyRoundTrip(t *testing.T) {
+	tmp := t.TempDir()
+	src := filepath.Join(tmp, "src")
+	dst := filepath.Join(tmp, "dst") // adjacent to src → same FS
+	mustMkdir(t, filepath.Join(src, "database"))
+	payload := []byte("MANIFEST-000001\nleveldb-data")
+	if err := os.WriteFile(filepath.Join(src, "database", "CURRENT"), payload, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	m, err := invokeClone(t, src, dst)
+	if err != nil {
+		t.Fatalf("runClone: %v", err)
+	}
+	if m["source"] != src || m["dest"] != dst {
+		t.Errorf("source/dest = %v/%v; want %s/%s", m["source"], m["dest"], src, dst)
+	}
+	method, _ := m["method"].(string)
+	switch method {
+	case "clonefile", "ficlone", "copy":
+	default:
+		t.Errorf("method = %q; want one of clonefile|ficlone|copy", method)
+	}
+	if _, ok := m["duration_ms"]; !ok {
+		t.Errorf("duration_ms missing from clone JSON")
+	}
+	got, readErr := os.ReadFile(filepath.Join(dst, "database", "CURRENT"))
+	if readErr != nil {
+		t.Fatalf("read cloned file: %v", readErr)
+	}
+	if string(got) != string(payload) {
+		t.Errorf("cloned content = %q; want %q", got, payload)
+	}
+}
+
+// TestRunClone_TextOutput covers the non-JSON (human) output branch.
+func TestRunClone_TextOutput(t *testing.T) {
+	tmp := t.TempDir()
+	src := filepath.Join(tmp, "src")
+	dst := filepath.Join(tmp, "dst")
+	mustMkdir(t, src)
+	out, err := runCloneCapture(t, src, dst, "text")
+	if err != nil {
+		t.Fatalf("runClone: %v", err)
+	}
+	if !strings.Contains(out, "Cloned") || !strings.Contains(out, "method:") {
+		t.Errorf("text output = %q; want a 'Cloned ... (method: ...)' line", out)
+	}
+}
+
+func mustMkdir(t *testing.T, p string) {
+	t.Helper()
+	if err := os.MkdirAll(p, 0o755); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/cmd/snapshot/snapshot.go
+++ b/cmd/snapshot/snapshot.go
@@ -33,4 +33,5 @@ func init() {
 	Cmd.AddCommand(logsCmd)
 	Cmd.AddCommand(stopCmd)
 	Cmd.AddCommand(pruneCmd)
+	Cmd.AddCommand(cloneCmd)
 }

--- a/internal/schema/embed.go
+++ b/internal/schema/embed.go
@@ -69,7 +69,11 @@ import (
 //	        container_id + node-log paths) so external read-only tools
 //	        (tron-toolkit, mcp-logs) can attach with zero new code.
 //	        Additive optional fields.
-const SchemaVersion = "1.9.0"
+//	1.10.0 — add snapshot-clone schema (new `trond snapshot clone <src>
+//	        <dst>` command — copy-on-write clone of a chain-DB dir into a
+//	        fresh path for warm-pool fixtures, ai-ops B3). Existing schemas
+//	        unchanged.
+const SchemaVersion = "1.10.0"
 
 // JSONSchemaURLBase is the canonical URL prefix for individual output
 // schema files. Embedded $id values inside each schema mirror this so

--- a/internal/schema/files/snapshot-clone.schema.json
+++ b/internal/schema/files/snapshot-clone.schema.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/tronprotocol/tron-deployment/blob/master/schemas/output/snapshot-clone.schema.json",
+  "title": "trond snapshot clone output",
+  "description": "Returned by `trond snapshot clone <src> <dst> -o json`. Reports the outcome of a copy-on-write clone of a chain-DB directory into a fresh path.",
+  "type": "object",
+  "required": ["source", "dest", "method"],
+  "properties": {
+    "source": {
+      "type": "string",
+      "description": "The source directory that was cloned (verbatim)."
+    },
+    "dest": {
+      "type": "string",
+      "description": "The newly created destination directory."
+    },
+    "method": {
+      "type": "string",
+      "enum": ["clonefile", "ficlone", "copy"],
+      "description": "How the tree was materialised. clonefile (APFS, macOS) and ficlone (Linux FICLONE) are copy-on-write — instant, sharing extents with the source, near-zero extra disk. copy means CoW was unavailable (source and destination on different filesystems, or a filesystem without CoW support) and a full byte copy was made — slow and consuming full disk; a warning is also printed to stderr."
+    },
+    "duration_ms": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Clone wall-clock time in milliseconds."
+    }
+  },
+  "additionalProperties": false
+}

--- a/internal/schema/manifest.go
+++ b/internal/schema/manifest.go
@@ -88,6 +88,7 @@ var DefaultSchemaLookup = map[string]string{
 	"trond snapshot sources":   "snapshot-sources",
 	"trond snapshot list":      "snapshot-list",
 	"trond snapshot download":  "snapshot-download",
+	"trond snapshot clone":     "snapshot-clone",
 	"trond snapshot jobs":      "snapshot-jobs",
 	"trond recipe list":        "recipe-list",
 	"trond recipe show":        "recipe-show",

--- a/internal/schema/version_baseline.json
+++ b/internal/schema/version_baseline.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": "1.9.0",
+  "schema_version": "1.10.0",
   "entries": [
     {
       "name": "apply",
@@ -96,6 +96,10 @@
     {
       "name": "shadow-fork-mutate",
       "hash": "b5cd74b38258f5d314080aced974ee16baa29641f08c205c36756a378ee922fa"
+    },
+    {
+      "name": "snapshot-clone",
+      "hash": "e5f7355f7bd14f6e38c432b381fbcbbfb06d15d4398f72d6d24444c0a6048d4c"
     },
     {
       "name": "snapshot-download",

--- a/schemas/output/snapshot-clone.schema.json
+++ b/schemas/output/snapshot-clone.schema.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/tronprotocol/tron-deployment/blob/master/schemas/output/snapshot-clone.schema.json",
+  "title": "trond snapshot clone output",
+  "description": "Returned by `trond snapshot clone <src> <dst> -o json`. Reports the outcome of a copy-on-write clone of a chain-DB directory into a fresh path.",
+  "type": "object",
+  "required": ["source", "dest", "method"],
+  "properties": {
+    "source": {
+      "type": "string",
+      "description": "The source directory that was cloned (verbatim)."
+    },
+    "dest": {
+      "type": "string",
+      "description": "The newly created destination directory."
+    },
+    "method": {
+      "type": "string",
+      "enum": ["clonefile", "ficlone", "copy"],
+      "description": "How the tree was materialised. clonefile (APFS, macOS) and ficlone (Linux FICLONE) are copy-on-write — instant, sharing extents with the source, near-zero extra disk. copy means CoW was unavailable (source and destination on different filesystems, or a filesystem without CoW support) and a full byte copy was made — slow and consuming full disk; a warning is also printed to stderr."
+    },
+    "duration_ms": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Clone wall-clock time in milliseconds."
+    }
+  },
+  "additionalProperties": false
+}


### PR DESCRIPTION
## What

Exposes the `internal/fsclone` copy-on-write primitive (landed in #186) as a user-facing verb:

```
trond snapshot clone <src> <dst> [-o json]
→ {"source":"...","dest":"...","method":"clonefile","duration_ms":3}
```

An operator/agent forks a cached snapshot — or a **stopped** node's data dir — into an isolated fixture in seconds instead of re-downloading or re-copying 30–90 GB. This is the ai-ops **B3** ask (warm pool of rigs), and the second real consumer that the #186 review wanted before promoting the primitive to a public verb (the first being the equivalence test).

- **Same filesystem → copy-on-write** (APFS `clonefile` / Linux `FICLONE`): instant, sharing extents, near-zero extra disk.
- **Cross filesystem (or non-CoW FS) → full byte copy**, with a stderr warning; `method` (`clonefile|ficlone|copy`) is always in the JSON so a caller can tell which happened.

## Scope & hardening (from `/plan-eng-review` + a Codex outside-voice pass)

- **Positional `<src> <dst>` only.** A `--from-node <name>` source was considered and dropped: the existing `destFromNode` is jar-only and returns `install_path` (not the chain-DB dir), and `CloneDir` requires a *quiescent* source so cloning a running node is unsafe. A proper runtime-aware + quiesce-guarded `--from-node` is tracked in TODOS.md.
- **Canonical-path containment guard** (`filepath.Abs` + `EvalSymlinks`, not string-prefix) rejects dst-inside-src / src-inside-dst — a dst inside src would make the clone walk re-enter its own staging area.
- **Refuse a pre-existing `<dst>`** → `VALIDATION_ERROR` (exit 2). No `--force` / destructive path.
- **Free-space preflight only on the cross-FS copy path** (same-device detection via `Statfs`), so a same-filesystem CoW clone is never falsely refused on a near-full disk.
- **CLI-only** — deliberately not an MCP tool, keeping filesystem-mutating capability out of the read-only agent fleet.

## Contract

New `snapshot-clone.schema.json`, registered in the manifest + schema-coverage lookups. `SchemaVersion` 1.9.0 → **1.10.0** (new schema; existing schemas unchanged), baseline regenerated. `AGENTS.md` documents the warm-pool flow.

## Tests

`go vet` + `golangci-lint` clean; full cmd/snapshot/schema/fsclone suites pass. Covers src-missing, dst-exists, dst-inside-src, happy round-trip (data byte-identical; `method` accepted as any of `clonefile|ficlone|copy` since CI filesystems return `copy` even for adjacent dirs), and the text-output path.