### PR TITLE
feat(safety): enforce --require-private on every per-node mutator

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -617,19 +617,30 @@ An automated caller that should only ever touch a throwaway private chain
   TODO; standard private rigs use the private template, which ships no
   real seeds.)
 
-- **Enforce at deploy.** `apply --require-private` and
-  `network create --require-private` refuse any non-private intent up
-  front (error_code `PRIVATE_NETWORK_REQUIRED`, exit 2). The guard lives
-  in `apply.Apply()` core, so every deploy path inherits it. Pure opt-in —
-  default behaviour and mainnet deploys are unchanged. Pass it from a
-  sandboxed skill so the deploy is *mechanically* incapable of hitting
-  shared infra, instead of trusting a standing rule.
+- **Enforce on every mutation.** `--require-private` is a **persistent
+  flag** (works on any command) plus the **`TROND_REQUIRE_PRIVATE`** env
+  var. When set, every mutating verb refuses a non-private node up front
+  with `PRIVATE_NETWORK_REQUIRED` (exit 2): `apply`, `network create`, and
+  the per-node mutators `start` / `stop` / `restart` / `remove` /
+  `rollback` / `upgrade`. The MCP `apply` tool takes the same gate via a
+  `require_private` argument. Export `TROND_REQUIRE_PRIVATE=1` once at
+  session start and an unattended agent is *mechanically* incapable of
+  mutating a mainnet/nile rig — no per-call discipline, instead of trusting
+  a standing rule.
+- **It's a one-way floor, not a fallback.** The flag OR a truthy env turns
+  the gate on; once on it cannot be turned off for the invocation
+  (`--require-private=false` cannot override a truthy env). Pure opt-in —
+  default behaviour and mainnet deploys are unchanged when neither is set.
+- The guard checks the node's RECORDED network from state, using state
+  ONLY (before any SSH/target work), so an unreachable mainnet node still
+  refuses with `PRIVATE_NETWORK_REQUIRED` rather than `TARGET_UNREACHABLE`.
+  A node with no recorded network (deployed before network tracking) is
+  fail-safe-refused with a re-apply hint.
 
 The read-only verbs (`status`, `wait`, `inspect`, `list`, `diagnose`)
-never mutate; only `apply` / `remove` / `start|stop|restart` do — gate
-the mutating ones behind the `is_private` check. (`--require-private`
-currently enforces on `apply` + `network create`; the rarer mutators
-gate via the `is_private` query for now.)
+never mutate and are always safe. The multi-node mutators (chaos
+`disconnect`/`partition`, `network add`/`destroy`/`upgrade`) are not yet
+gated — a tracked TODO; gate them via the `is_private` query meanwhile.
 
 > ⚠️ **`network` means two things across commands.** In `apply` / `status`
 > / `list` / `inspect` it is the chain kind (`mainnet|nile|private`,

--- a/TODOS.md
+++ b/TODOS.md
@@ -44,6 +44,25 @@ up cold.
   the value is deterministic from the genesis the intent pins, so it
   doubles as a B1 "echo the resolved rig identity" signal.
 
+## `--require-private` on the multi-node mutators (chaos + network ops)
+
+- **What:** Extend the `--require-private` / `TROND_REQUIRE_PRIVATE` gate to
+  the chaos primitives (`disconnect` / `partition` / `connect` / `heal`) and
+  the network ops (`network add` / `destroy` / `upgrade`).
+- **Why:** These mutate a rig too, so an airtight "an agent can't touch a
+  non-private net" boundary needs them. The per-node mutators
+  (start/stop/restart/remove/rollback/upgrade) + apply + network-create are
+  already gated via `internal/guard`.
+- **Cons / why deferred:** they operate on MULTIPLE nodes or a whole network,
+  so it isn't the per-node one-liner — it needs an "are ALL involved nodes
+  private?" check (chaos spans 2+ nodes; `network destroy`/`add` span the
+  network's node set). Different guard shape from the single-node path.
+- **Context:** deferred during the 2026-06-17 `/plan-eng-review` of the
+  per-node `--require-private` rollout. The shared predicate + error live in
+  `internal/guard` (`Enforce`/`EnforceArg`/`Requested`); a multi-node guard
+  would iterate the involved nodes and call `guard.Enforce` per node.
+- **Depends on / blocked by:** the per-node rollout landing (this PR).
+
 ## Rename `network-create`'s `network` output field
 
 - **What:** `network create -o json` returns `network` = the network's intent

--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -9,6 +9,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/tronprotocol/tron-deployment/internal/apply"
+	"github.com/tronprotocol/tron-deployment/internal/guard"
 	"github.com/tronprotocol/tron-deployment/internal/intent"
 	"github.com/tronprotocol/tron-deployment/internal/output"
 	"github.com/tronprotocol/tron-deployment/internal/state"
@@ -16,12 +17,11 @@ import (
 )
 
 var (
-	applyIntentPath     string
-	applyAutoApprove    bool
-	applyWait           bool
-	applyWaitTimeout    time.Duration
-	applyMonitor        bool
-	applyRequirePrivate bool
+	applyIntentPath  string
+	applyAutoApprove bool
+	applyWait        bool
+	applyWaitTimeout time.Duration
+	applyMonitor     bool
 )
 
 var applyCmd = &cobra.Command{
@@ -47,7 +47,9 @@ func init() {
 	applyCmd.Flags().BoolVar(&applyWait, "wait", false, "Block until the deployed node's HTTP API is reachable")
 	applyCmd.Flags().DurationVar(&applyWaitTimeout, "wait-timeout", 5*time.Minute, "Total wait budget when --wait is set")
 	applyCmd.Flags().BoolVar(&applyMonitor, "monitor", false, "Deploy monitoring stack (Prometheus + Grafana) alongside the node")
-	applyCmd.Flags().BoolVar(&applyRequirePrivate, "require-private", false, "Refuse to apply unless the intent's network is private (machine-enforced safety gate for unattended agents)")
+	// --require-private is the persistent root flag (see cmd/root.go) +
+	// TROND_REQUIRE_PRIVATE env, enforced via internal/guard — apply
+	// inherits it like every other verb, so no per-command flag here.
 	mustMarkRequired(applyCmd, "intent")
 	mustMarkRequired(applyCmd, "intent")
 	rootCmd.AddCommand(applyCmd)
@@ -68,13 +70,10 @@ func runApply(cmd *cobra.Command, args []string) error {
 	// but we ALSO check here, first — before target resolution and the
 	// HUMAN_REQUIRED change-detection gate — so a non-private intent
 	// refuses with PRIVATE_NETWORK_REQUIRED (exit 2) rather than being
-	// masked by HUMAN_REQUIRED (exit 10). Both checks delegate to the one
-	// intent.IsPrivate predicate; this is layered defense, not divergent
-	// logic.
-	if applyRequirePrivate && !intent.IsPrivate(parsed.Network) {
-		return exitWithError("PRIVATE_NETWORK_REQUIRED", output.ExitValidationError,
-			fmt.Sprintf("--require-private set but intent network is %q (not private); refusing to apply", parsed.Network),
-			"Set network: private in the intent, or drop --require-private to allow mainnet/nile")
+	// masked by HUMAN_REQUIRED (exit 10). The predicate + error live in
+	// internal/guard (shared with every mutator); this is layered defense.
+	if err := guard.Enforce(parsed.Network); err != nil {
+		return err
 	}
 
 	// Monitoring is opt-in: only deploy when --monitor is explicitly passed.
@@ -145,7 +144,7 @@ func runApply(cmd *cobra.Command, args []string) error {
 		IntentPath:     applyIntentPath, // FR-021: relative build.source resolves vs this
 		Wait:           applyWait,
 		WaitTimeout:    applyWaitTimeout,
-		RequirePrivate: applyRequirePrivate,
+		RequirePrivate: guard.Requested(),
 	})
 	if err != nil {
 		return wrapApplyError(err)

--- a/cmd/apply_require_private_test.go
+++ b/cmd/apply_require_private_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/tronprotocol/tron-deployment/internal/guard"
 	"github.com/tronprotocol/tron-deployment/internal/output"
 	"github.com/tronprotocol/tron-deployment/internal/paths"
 )
@@ -31,8 +32,8 @@ func TestRunApply_RequirePrivate_RefusesNonPrivate(t *testing.T) {
 	t.Cleanup(func() { paths.SetBaseDir("") })
 
 	// Global flag state is package-level; save + restore.
-	oldPath, oldReq := applyIntentPath, applyRequirePrivate
-	t.Cleanup(func() { applyIntentPath, applyRequirePrivate = oldPath, oldReq })
+	oldPath, oldReq := applyIntentPath, guard.FlagValue
+	t.Cleanup(func() { applyIntentPath, guard.FlagValue = oldPath, oldReq })
 
 	intentPath := filepath.Join(t.TempDir(), "intent.yaml")
 	body := "name: guard-test\nnetwork: mainnet\n" +
@@ -45,7 +46,7 @@ func TestRunApply_RequirePrivate_RefusesNonPrivate(t *testing.T) {
 	cmd := &cobra.Command{}
 	cmd.SetContext(context.Background())
 	applyIntentPath = intentPath
-	applyRequirePrivate = true
+	guard.FlagValue = true
 
 	err := runApply(cmd, nil)
 	if err == nil {

--- a/cmd/network/add.go
+++ b/cmd/network/add.go
@@ -176,6 +176,11 @@ func runAdd(cmd *cobra.Command, args []string) error {
 	store.UpsertNode(deployState, state.ManagedNode{
 		Name:    nodeName,
 		Version: node.Version,
+		// Record the network kind (mainnet|nile|private) so the C1
+		// is_private fact and the --require-private guard work for added
+		// nodes too — without this they'd read as legacy/unknown and a
+		// private-net node would be fail-safe-refused by every mutator.
+		Network: parsed.Network,
 		// Persist the FULL target so subsequent stop/start/files/inspect
 		// can rebuild the SSH connection. Earlier this only stored
 		// Type, leaving Host/User/Port/IdentityFile blank — which then

--- a/cmd/network/create.go
+++ b/cmd/network/create.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/tronprotocol/tron-deployment/internal/guard"
 	"github.com/tronprotocol/tron-deployment/internal/intent"
 	"github.com/tronprotocol/tron-deployment/internal/output"
 	"github.com/tronprotocol/tron-deployment/internal/paths"
@@ -20,9 +21,8 @@ import (
 )
 
 var (
-	createIntentPath     string
-	createMonitor        bool
-	createRequirePrivate bool
+	createIntentPath string
+	createMonitor    bool
 )
 
 var createCmd = &cobra.Command{
@@ -35,7 +35,8 @@ var createCmd = &cobra.Command{
 func init() {
 	createCmd.Flags().StringVar(&createIntentPath, "intent", "", "Path to intent.yaml (required)")
 	createCmd.Flags().BoolVar(&createMonitor, "monitor", false, "Deploy Prometheus + Grafana monitoring stack for the network")
-	createCmd.Flags().BoolVar(&createRequirePrivate, "require-private", false, "Refuse to create the network unless its intent network is private (machine-enforced safety gate for unattended agents)")
+	// --require-private is the persistent root flag + TROND_REQUIRE_PRIVATE
+	// env, enforced via internal/guard — inherited here, no local flag.
 	if err := createCmd.MarkFlagRequired("intent"); err != nil {
 		panic(err)
 	}
@@ -51,10 +52,9 @@ func runCreate(cmd *cobra.Command, args []string) error {
 
 	// --require-private: same machine-enforced safety gate as `apply`,
 	// applied to the multi-node path. Refuse a non-private network before
-	// deploying anything.
-	if createRequirePrivate && !intent.IsPrivate(parsed.Network) {
-		return output.NewError("PRIVATE_NETWORK_REQUIRED", output.ExitValidationError,
-			fmt.Sprintf("--require-private set but intent network is %q (not private); refusing to create", parsed.Network))
+	// deploying anything. Predicate + error live in internal/guard.
+	if err := guard.Enforce(parsed.Network); err != nil {
+		return err
 	}
 
 	// Apply monitoring defaults early so RenderHOCON can inject metrics config.

--- a/cmd/remove.go
+++ b/cmd/remove.go
@@ -33,6 +33,14 @@ func init() {
 func runRemove(cmd *cobra.Command, args []string) error {
 	name := args[0]
 
+	// --require-private precedes the destructive-confirm gate: an agent must
+	// learn "not private" (PRIVATE_NETWORK_REQUIRED, exit 2) before it is
+	// asked to confirm a destroy (HUMAN_REQUIRED, exit 10). State-only check,
+	// no target resolution.
+	if err := requirePrivateForNode(name); err != nil {
+		return err
+	}
+
 	// Require confirmation
 	if removeConfirm != name {
 		return exitWithError("HUMAN_REQUIRED", output.ExitHumanRequired,

--- a/cmd/require_private_mutators_test.go
+++ b/cmd/require_private_mutators_test.go
@@ -1,0 +1,103 @@
+package cmd
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/tronprotocol/tron-deployment/internal/guard"
+	"github.com/tronprotocol/tron-deployment/internal/output"
+	"github.com/tronprotocol/tron-deployment/internal/paths"
+	"github.com/tronprotocol/tron-deployment/internal/state"
+)
+
+// seedMainnetNode writes a single mainnet node to an isolated state dir and
+// turns the --require-private gate on for the test (restored after). A
+// mutator that runs the state-only guard BEFORE resolveNodeContext refuses
+// here without ever touching docker/SSH — so this is hermetic.
+func seedMainnetNode(t *testing.T, name string) {
+	t.Helper()
+	paths.SetBaseDir(t.TempDir())
+	t.Cleanup(func() { paths.SetBaseDir("") })
+
+	store, err := state.NewStore(paths.State())
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	if err := store.Save(&state.DeploymentState{
+		Version: 1,
+		Nodes: []state.ManagedNode{{
+			Name: name, Status: "running", Runtime: "docker",
+			Network: "mainnet", LastApplied: time.Now().UTC(),
+		}},
+	}); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	old := guard.FlagValue
+	guard.FlagValue = true
+	t.Cleanup(func() { guard.FlagValue = old })
+}
+
+func newCmd() *cobra.Command {
+	c := &cobra.Command{}
+	c.SetContext(context.Background())
+	c.Flags().String("output", "json", "")
+	return c
+}
+
+func wantPrivateRequired(t *testing.T, err error) {
+	t.Helper()
+	if err == nil {
+		t.Fatal("expected PRIVATE_NETWORK_REQUIRED, got nil (mutator ran on a mainnet node with the gate on)")
+	}
+	var se *output.StructuredError
+	if !errors.As(err, &se) {
+		t.Fatalf("expected *output.StructuredError, got %T: %v", err, err)
+	}
+	if se.Code != "PRIVATE_NETWORK_REQUIRED" || se.ExitCode != output.ExitValidationError {
+		t.Errorf("got code=%q exit=%d; want PRIVATE_NETWORK_REQUIRED/%d", se.Code, se.ExitCode, output.ExitValidationError)
+	}
+}
+
+// TestMutators_RefuseMainnetUnderRequirePrivate proves every per-node mutator
+// runs the gate (and runs it before any docker/SSH work — the test would
+// otherwise need a real runtime). A guard accidentally placed AFTER the
+// mutation would fail here because the call wouldn't return PRIVATE_NETWORK_REQUIRED.
+func TestMutators_RefuseMainnetUnderRequirePrivate(t *testing.T) {
+	mutators := map[string]func(*cobra.Command, []string) error{
+		"start":    runStart,
+		"stop":     runStop,
+		"restart":  runRestart,
+		"rollback": runRollback,
+		"upgrade":  runUpgrade,
+		"remove":   runRemove,
+	}
+	for name, run := range mutators {
+		t.Run(name, func(t *testing.T) {
+			seedMainnetNode(t, "n0")
+			if name == "upgrade" {
+				old := upgradeVersion
+				upgradeVersion = "GreatVoyage-v4.8.0"
+				t.Cleanup(func() { upgradeVersion = old })
+			}
+			wantPrivateRequired(t, run(newCmd(), []string{"n0"}))
+		})
+	}
+}
+
+// TestRemove_PrivateGuardPrecedesConfirm proves the C1 precedence: with the
+// gate on and NO --confirm, remove returns PRIVATE_NETWORK_REQUIRED (exit 2),
+// NOT HUMAN_REQUIRED (exit 10) — the agent learns "not private" before being
+// asked to confirm a destroy.
+func TestRemove_PrivateGuardPrecedesConfirm(t *testing.T) {
+	seedMainnetNode(t, "n0")
+	oldConfirm := removeConfirm
+	removeConfirm = "" // no confirmation supplied
+	t.Cleanup(func() { removeConfirm = oldConfirm })
+
+	wantPrivateRequired(t, runRemove(newCmd(), []string{"n0"}))
+}

--- a/cmd/resolve.go
+++ b/cmd/resolve.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/tronprotocol/tron-deployment/internal/guard"
 	"github.com/tronprotocol/tron-deployment/internal/output"
 	"github.com/tronprotocol/tron-deployment/internal/runtime"
 	"github.com/tronprotocol/tron-deployment/internal/security"
@@ -44,6 +45,33 @@ func (nc *nodeContext) runtimeExec(ctx context.Context, bin string, args ...stri
 	}
 	full := append([]string{"exec", nc.Node.Name, bin}, args...)
 	return nc.Target.Exec(ctx, "docker", full...)
+}
+
+// requirePrivateForNode enforces the --require-private / TROND_REQUIRE_PRIVATE
+// safety gate against a node's RECORDED network, using state ONLY — no target
+// resolution. Mutators must call this BEFORE resolveNodeContext (which opens
+// the target and can fail with TARGET_UNREACHABLE, masking the gate) and
+// before any HUMAN_REQUIRED confirmation, so an agent learns "not private"
+// first. Fast path: when the gate is off it reads no state at all. A missing
+// node returns nil here — resolveNodeContext emits the canonical
+// NODE_NOT_FOUND so the message isn't duplicated.
+func requirePrivateForNode(name string) error {
+	if !guard.Requested() {
+		return nil
+	}
+	store, err := state.NewStore(statePath())
+	if err != nil {
+		return err
+	}
+	deployState, err := store.Load()
+	if err != nil {
+		return err
+	}
+	node := store.GetNode(deployState, name)
+	if node == nil {
+		return nil
+	}
+	return guard.Enforce(node.Network)
 }
 
 // resolveNodeContext loads a node from state and constructs its target and runtime.

--- a/cmd/restart.go
+++ b/cmd/restart.go
@@ -24,6 +24,10 @@ func runRestart(cmd *cobra.Command, args []string) error {
 	name := args[0]
 	start := time.Now()
 
+	if err := requirePrivateForNode(name); err != nil {
+		return err
+	}
+
 	nc, err := resolveNodeContext(name)
 	if err != nil {
 		return err

--- a/cmd/rollback.go
+++ b/cmd/rollback.go
@@ -25,6 +25,10 @@ func runRollback(cmd *cobra.Command, args []string) error {
 	name := args[0]
 	start := time.Now()
 
+	if err := requirePrivateForNode(name); err != nil {
+		return err
+	}
+
 	nc, err := resolveNodeContext(name)
 	if err != nil {
 		return err

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -11,6 +11,7 @@ import (
 	networkCmd "github.com/tronprotocol/tron-deployment/cmd/network"
 	shadowforkCmd "github.com/tronprotocol/tron-deployment/cmd/shadowfork"
 	snapshotCmd "github.com/tronprotocol/tron-deployment/cmd/snapshot"
+	"github.com/tronprotocol/tron-deployment/internal/guard"
 	"github.com/tronprotocol/tron-deployment/internal/output"
 	"github.com/tronprotocol/tron-deployment/internal/paths"
 )
@@ -70,6 +71,12 @@ func init() {
 	rootCmd.PersistentFlags().BoolVar(&noColor, "no-color", false, "Disable ANSI colors")
 	rootCmd.PersistentFlags().StringVar(&configFile, "config", "", "Config file (default ~/.trond/config.yaml)")
 	rootCmd.PersistentFlags().StringVar(&stateDirFlag, "state-dir", "", "Directory for state.json, audit.log, deployments (default ~/.trond, env: TROND_STATE_DIR)")
+	// Persistent safety gate: refuse any mutating verb unless the node's
+	// network is private. A one-way floor — this flag OR a truthy
+	// TROND_REQUIRE_PRIVATE turns it on; once on it cannot be disabled for
+	// the invocation. See internal/guard.
+	rootCmd.PersistentFlags().BoolVar(&guard.FlagValue, "require-private", false,
+		"Refuse to mutate a node unless its network is private (also: "+guard.EnvVar+"; a one-way safety floor for unattended agents)")
 }
 
 // Root returns the configured root cobra command, used by the doc/manpage

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -24,6 +24,10 @@ func runStart(cmd *cobra.Command, args []string) error {
 	name := args[0]
 	start := time.Now()
 
+	if err := requirePrivateForNode(name); err != nil {
+		return err
+	}
+
 	nc, err := resolveNodeContext(name)
 	if err != nil {
 		return err

--- a/cmd/stop.go
+++ b/cmd/stop.go
@@ -24,6 +24,10 @@ func runStop(cmd *cobra.Command, args []string) error {
 	name := args[0]
 	start := time.Now()
 
+	if err := requirePrivateForNode(name); err != nil {
+		return err
+	}
+
 	nc, err := resolveNodeContext(name)
 	if err != nil {
 		return err

--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -30,6 +30,10 @@ func runUpgrade(cmd *cobra.Command, args []string) error {
 	name := args[0]
 	start := time.Now()
 
+	if err := requirePrivateForNode(name); err != nil {
+		return err
+	}
+
 	nc, err := resolveNodeContext(name)
 	if err != nil {
 		return err

--- a/internal/guard/guard.go
+++ b/internal/guard/guard.go
@@ -1,0 +1,96 @@
+// Package guard holds the cross-cutting "require private network" safety
+// predicate. It lives in internal/ (not cmd/) on purpose: both cmd/ (root
+// mutators) and cmd/network/ need it, and a helper in cmd/ could not be
+// imported by cmd/network/ without an import cycle.
+//
+// The gate is the C1 safety boundary extended to every mutating verb: an
+// unattended agent can assert "I will only ever touch a private rig" and
+// trond machine-enforces it.
+//
+//	requested? ──no──> allow (gate off)
+//	   │ yes
+//	   ▼
+//	IsPrivate(network)? ──yes──> allow
+//	   │ no
+//	   ▼
+//	PRIVATE_NETWORK_REQUIRED (exit 2)
+package guard
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/tronprotocol/tron-deployment/internal/intent"
+	"github.com/tronprotocol/tron-deployment/internal/output"
+)
+
+// FlagValue is bound to the persistent --require-private flag by cmd/root.go.
+// It is a package var (rather than a getter) so the cobra flag can write it
+// directly and both cmd/ and cmd/network/ can read it via Requested().
+var FlagValue bool
+
+// EnvVar is the environment variable that also turns the gate on. An agent
+// exports it once at session start so every mutating call is gated without
+// per-command discipline.
+const EnvVar = "TROND_REQUIRE_PRIVATE"
+
+// Requested reports whether the private-network gate is on. Semantics are a
+// one-way SAFETY FLOOR, NOT a --state-dir-style fallback: the flag OR a
+// truthy env turns it on, and once on it cannot be turned off for the
+// invocation. That is deliberate — the whole point of the gate is that an
+// unattended agent can neither forget to set it nor accidentally (or via a
+// compromised caller) disable it mid-session. `--require-private=false`
+// therefore cannot override a truthy env.
+func Requested() bool {
+	return FlagValue || envTruthy(os.Getenv(EnvVar))
+}
+
+// envTruthy treats 1/true/yes/on (any case, trimmed) as true; everything
+// else, including empty, as false.
+func envTruthy(v string) bool {
+	switch strings.ToLower(strings.TrimSpace(v)) {
+	case "1", "true", "yes", "on", "t":
+		return true
+	default:
+		return false
+	}
+}
+
+// Enforce returns a PRIVATE_NETWORK_REQUIRED error (exit 2) when the gate is
+// requested and the given network is not private; otherwise nil. network is
+// the value recorded in state (state.ManagedNode.Network) or the intent's
+// network. An empty network (a node deployed before network tracking) is
+// treated as not-private (fail-safe) with a message that points at the fix.
+//
+// Callers must run Enforce on state-only data BEFORE any target resolution
+// (which can fail with TARGET_UNREACHABLE and mask this gate) and before any
+// HUMAN_REQUIRED confirmation gate, so the agent learns "not private" first.
+func Enforce(network string) error {
+	return EnforceArg(false, network)
+}
+
+// EnforceArg is Enforce plus an explicit per-call request, OR-ed with the
+// flag/env floor. Callers that carry their own opt-in signal (e.g. the MCP
+// apply tool's require_private argument, where there is no cobra flag) pass
+// it here; requested=true forces the gate on for this call even if the
+// global flag/env are off. CLI mutators use Enforce (requested=false).
+func EnforceArg(requested bool, network string) error {
+	if !(requested || Requested()) || intent.IsPrivate(network) {
+		return nil
+	}
+	if network == "" {
+		return output.NewError("PRIVATE_NETWORK_REQUIRED", output.ExitValidationError,
+			"--require-private is set but this node has no recorded network "+
+				"(it was deployed before network tracking)").
+			WithSuggestions(
+				"Re-apply the node so its network is recorded in state, then retry",
+				"Or unset --require-private / "+EnvVar+" if you accept operating on it",
+			)
+	}
+	return output.NewError("PRIVATE_NETWORK_REQUIRED", output.ExitValidationError,
+		fmt.Sprintf("--require-private is set but this node's network is %q (not private); refusing the operation", network)).
+		WithSuggestions(
+			"Target a private-network node, or drop --require-private / " + EnvVar,
+		)
+}

--- a/internal/guard/guard_test.go
+++ b/internal/guard/guard_test.go
@@ -1,0 +1,127 @@
+package guard
+
+import (
+	"errors"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/tronprotocol/tron-deployment/internal/output"
+)
+
+// setGate sets the flag + env for one test and restores both after.
+func setGate(t *testing.T, flag bool, env string) {
+	t.Helper()
+	oldFlag := FlagValue
+	oldEnv, hadEnv := os.LookupEnv(EnvVar)
+	FlagValue = flag
+	if env == "" {
+		_ = os.Unsetenv(EnvVar)
+	} else {
+		_ = os.Setenv(EnvVar, env)
+	}
+	t.Cleanup(func() {
+		FlagValue = oldFlag
+		if hadEnv {
+			_ = os.Setenv(EnvVar, oldEnv)
+		} else {
+			_ = os.Unsetenv(EnvVar)
+		}
+	})
+}
+
+func TestRequested_Floor(t *testing.T) {
+	cases := []struct {
+		flag bool
+		env  string
+		want bool
+	}{
+		{false, "", false},
+		{true, "", true},
+		{false, "1", true},
+		{false, "true", true},
+		{false, "yes", true},
+		{false, "on", true},
+		{false, "0", false},
+		{false, "false", false},
+		{false, "nonsense", false},
+		{true, "0", true}, // flag on, env off → still on (OR)
+	}
+	for _, tc := range cases {
+		setGate(t, tc.flag, tc.env)
+		if got := Requested(); got != tc.want {
+			t.Errorf("Requested(flag=%v env=%q) = %v, want %v", tc.flag, tc.env, got, tc.want)
+		}
+	}
+}
+
+func TestEnvTruthy(t *testing.T) {
+	for _, v := range []string{"1", "true", "TRUE", "Yes", "on", " t "} {
+		if !envTruthy(v) {
+			t.Errorf("envTruthy(%q) = false, want true", v)
+		}
+	}
+	for _, v := range []string{"", "0", "false", "no", "off", "x"} {
+		if envTruthy(v) {
+			t.Errorf("envTruthy(%q) = true, want false", v)
+		}
+	}
+}
+
+func wantPrivReq(t *testing.T, err error) {
+	t.Helper()
+	if err == nil {
+		t.Fatal("expected PRIVATE_NETWORK_REQUIRED, got nil")
+	}
+	var se *output.StructuredError
+	if !errors.As(err, &se) {
+		t.Fatalf("expected *output.StructuredError, got %T: %v", err, err)
+	}
+	if se.Code != "PRIVATE_NETWORK_REQUIRED" || se.ExitCode != output.ExitValidationError {
+		t.Errorf("got code=%q exit=%d; want PRIVATE_NETWORK_REQUIRED/%d", se.Code, se.ExitCode, output.ExitValidationError)
+	}
+}
+
+func TestEnforce(t *testing.T) {
+	// Gate off → always allow, even mainnet.
+	setGate(t, false, "")
+	if err := Enforce("mainnet"); err != nil {
+		t.Errorf("gate off: Enforce(mainnet) = %v, want nil", err)
+	}
+
+	// Gate on.
+	setGate(t, true, "")
+	if err := Enforce("private"); err != nil {
+		t.Errorf("Enforce(private) = %v, want nil", err)
+	}
+	wantPrivReq(t, Enforce("mainnet"))
+	wantPrivReq(t, Enforce("nile"))
+
+	// Empty network (legacy node) refuses with a re-apply suggestion.
+	err := Enforce("")
+	wantPrivReq(t, err)
+	var se *output.StructuredError
+	_ = errors.As(err, &se)
+	foundReapply := false
+	for _, s := range se.Suggestions {
+		if strings.Contains(strings.ToLower(s), "re-apply") {
+			foundReapply = true
+		}
+	}
+	if !foundReapply {
+		t.Errorf("empty-network error should suggest re-apply; got %v", se.Suggestions)
+	}
+}
+
+func TestEnforceArg_ForcesWhenGlobalOff(t *testing.T) {
+	setGate(t, false, "") // global gate OFF
+	// requested=true forces enforcement for this call.
+	wantPrivReq(t, EnforceArg(true, "mainnet"))
+	if err := EnforceArg(true, "private"); err != nil {
+		t.Errorf("EnforceArg(true, private) = %v, want nil", err)
+	}
+	// requested=false + global off → allow.
+	if err := EnforceArg(false, "mainnet"); err != nil {
+		t.Errorf("EnforceArg(false, mainnet) with gate off = %v, want nil", err)
+	}
+}

--- a/internal/mcp/tools_lifecycle.go
+++ b/internal/mcp/tools_lifecycle.go
@@ -2,6 +2,7 @@ package mcp
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"time"
@@ -9,6 +10,7 @@ import (
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 
 	"github.com/tronprotocol/tron-deployment/internal/apply"
+	"github.com/tronprotocol/tron-deployment/internal/guard"
 	"github.com/tronprotocol/tron-deployment/internal/intent"
 	"github.com/tronprotocol/tron-deployment/internal/output"
 	"github.com/tronprotocol/tron-deployment/internal/paths"
@@ -85,9 +87,10 @@ func planTool(ctx context.Context, _ *mcp.CallToolRequest, args planArg) (*mcp.C
 }
 
 type applyArgs struct {
-	Path        string `json:"path" jsonschema:"absolute path to an intent.yaml file"`
-	AutoApprove bool   `json:"auto_approve,omitempty" jsonschema:"required to apply changes to an already-deployed node; otherwise the call returns HUMAN_REQUIRED"`
-	Wait        bool   `json:"wait,omitempty" jsonschema:"block until the node's HTTP API responds"`
+	Path           string `json:"path" jsonschema:"absolute path to an intent.yaml file"`
+	AutoApprove    bool   `json:"auto_approve,omitempty" jsonschema:"required to apply changes to an already-deployed node; otherwise the call returns HUMAN_REQUIRED"`
+	Wait           bool   `json:"wait,omitempty" jsonschema:"block until the node's HTTP API responds"`
+	RequirePrivate bool   `json:"require_private,omitempty" jsonschema:"refuse to apply unless the intent's network is private; returns PRIVATE_NETWORK_REQUIRED otherwise (the C1 safety gate, also forced on by the TROND_REQUIRE_PRIVATE env)"`
 }
 
 func applyTool(ctx context.Context, _ *mcp.CallToolRequest, args applyArgs) (*mcp.CallToolResult, any, error) {
@@ -98,6 +101,15 @@ func applyTool(ctx context.Context, _ *mcp.CallToolRequest, args applyArgs) (*mc
 	parsed, err := intent.Load(args.Path)
 	if err != nil {
 		return errResult(output.NewError("VALIDATION_ERROR", output.ExitValidationError, err.Error()))
+	}
+
+	// --require-private (early gate, precedence): refuse a non-private intent
+	// BEFORE target resolution and the HUMAN_REQUIRED change gate, so the
+	// agent gets PRIVATE_NETWORK_REQUIRED (exit 2) rather than
+	// TARGET_UNREACHABLE or HUMAN_REQUIRED masking it. Honors the tool arg
+	// OR the TROND_REQUIRE_PRIVATE env floor.
+	if err := guard.EnforceArg(args.RequirePrivate, parsed.Network); err != nil {
+		return errResult(err)
 	}
 
 	tgt, err := resolveTarget(parsed)
@@ -145,8 +157,17 @@ func applyTool(ctx context.Context, _ *mcp.CallToolRequest, args applyArgs) (*mc
 		EnvVars:        resolveEnvVars(&parsed.Nodes[0]),
 		Wait:           args.Wait,
 		WaitTimeout:    5 * time.Minute,
+		RequirePrivate: args.RequirePrivate || guard.Requested(),
 	})
 	if err != nil {
+		// Pass a structured error (e.g. the core PRIVATE_NETWORK_REQUIRED
+		// gate) through with its own code/exit; only opaque errors get the
+		// generic DEPLOY_ERROR wrap. Without this, threading RequirePrivate
+		// into the core would surface as DEPLOY_ERROR and lose the contract.
+		var se *output.StructuredError
+		if errors.As(err, &se) {
+			return errResult(se)
+		}
 		return errResult(output.NewError("DEPLOY_ERROR", output.ExitGeneralError, err.Error()))
 	}
 	return jsonResult(res)

--- a/internal/mcp/tools_lifecycle_require_private_test.go
+++ b/internal/mcp/tools_lifecycle_require_private_test.go
@@ -1,0 +1,41 @@
+package mcp
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/tronprotocol/tron-deployment/internal/paths"
+)
+
+// TestApplyTool_RequirePrivate_RefusesNonPrivate is the MCP-side C1 guard
+// test: apply with require_private=true against a mainnet intent must refuse
+// at the EARLY guard (before target resolution / HUMAN_REQUIRED) with
+// PRIVATE_NETWORK_REQUIRED — not TARGET_UNREACHABLE, HUMAN_REQUIRED, or a
+// re-wrapped DEPLOY_ERROR. No docker needed: it returns at guard time.
+func TestApplyTool_RequirePrivate_RefusesNonPrivate(t *testing.T) {
+	paths.SetBaseDir(t.TempDir())
+	t.Cleanup(func() { paths.SetBaseDir("") })
+
+	intentPath := filepath.Join(t.TempDir(), "intent.yaml")
+	body := "name: guard-mcp\nnetwork: mainnet\n" +
+		"target:\n  type: local\n  runtime: docker\n" +
+		"nodes:\n  - type: fullnode\n    version: latest\n"
+	if err := os.WriteFile(intentPath, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	res, _, err := applyTool(context.Background(), nil, applyArgs{Path: intentPath, RequirePrivate: true})
+	if err != nil {
+		t.Fatalf("applyTool returned a transport error: %v", err)
+	}
+	if res == nil || !res.IsError {
+		t.Fatalf("expected an error result, got %+v", res)
+	}
+	text := extractText(t, res)
+	if !strings.Contains(text, "PRIVATE_NETWORK_REQUIRED") {
+		t.Errorf("error result should carry PRIVATE_NETWORK_REQUIRED; got:\n%s", text)
+	}
+}

--- a/internal/schema/embed.go
+++ b/internal/schema/embed.go
@@ -73,7 +73,14 @@ import (
 //	        <dst>` command — copy-on-write clone of a chain-DB dir into a
 //	        fresh path for warm-pool fixtures, ai-ops B3). Existing schemas
 //	        unchanged.
-const SchemaVersion = "1.10.0"
+//	1.11.0 — `--require-private` becomes a PERSISTENT root flag (+ env
+//	        TROND_REQUIRE_PRIVATE) enforced on every per-node mutator
+//	        (start/stop/restart/remove/rollback/upgrade) and the MCP apply
+//	        tool, not just apply/network-create. Inherited persistent flags
+//	        are collected into the `trond schema` manifest, so the manifest
+//	        surface changes for every command (additive). The C1 safety
+//	        boundary now covers all single-node mutations.
+const SchemaVersion = "1.11.0"
 
 // JSONSchemaURLBase is the canonical URL prefix for individual output
 // schema files. Embedded $id values inside each schema mirror this so

--- a/internal/schema/version_baseline.json
+++ b/internal/schema/version_baseline.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": "1.10.0",
+  "schema_version": "1.11.0",
   "entries": [
     {
       "name": "apply",


### PR DESCRIPTION
## What

Extends the C1 private-net safety gate from `apply`/`network create` to **every per-node mutator**, so an unattended agent can assert "I will only ever touch a private rig" and trond machine-enforces it.

- **`internal/guard`** — `Requested()` (a one-way **floor**: the flag OR a truthy `TROND_REQUIRE_PRIVATE` turns it on, and once on it cannot be disabled for the invocation — NOT a `--state-dir`-style fallback), and `Enforce`/`EnforceArg` returning the existing `PRIVATE_NETWORK_REQUIRED` (exit 2). It lives in `internal/` so both `cmd/` and `cmd/network/` use it without an import cycle.
- **Persistent `--require-private` root flag + `TROND_REQUIRE_PRIVATE` env.** `apply` and `network create` are refactored off their per-command flags onto the shared one (the local flags are deleted so they can't shadow the inherited persistent flag). Export the env once and every mutating call is gated — no per-call discipline.
- **Guarded mutators:** `start` / `stop` / `restart` / `remove` / `rollback` / **`upgrade`**. The guard runs on **state only, before target resolution**, so an unreachable mainnet node still refuses with `PRIVATE_NETWORK_REQUIRED` rather than `TARGET_UNREACHABLE`; in `remove` it precedes the `HUMAN_REQUIRED` confirm (the agent learns "not private" before being asked to confirm a destroy).
- **MCP `apply`** gains a `require_private` argument with an **early guard** (before target resolution / `HUMAN_REQUIRED`) and structured-error passthrough (no `DEPLOY_ERROR` re-wrap that would mask the contract).
- **`network add`** now records `Network` in state, so nodes added to a private net aren't fail-safe-refused by the new guard.
- **Legacy nodes** (no recorded network, deployed before network tracking) fail-safe refuse with a re-apply hint.

Default behaviour and mainnet deploys are unchanged when neither the flag nor env is set.

## Scope

Per-node mutators only. The multi-node verbs (chaos `disconnect`/`partition`, `network add`/`destroy`/`upgrade`) need an "are ALL involved nodes private?" check — a different guard shape — and are deferred to TODOS.md.

## Contract

`SchemaVersion` 1.10.0 → **1.11.0**: a persistent flag is collected into the `trond schema` manifest for every command, so this is a manifest contract change (additive); baseline regenerated. `AGENTS.md` updated to document the gate, the floor semantics, and the state-only check.

## Tests

`go vet` + `golangci-lint` clean. `internal/guard` unit table (floor semantics, `envTruthy`, `Enforce`, `EnforceArg` force-on), per-mutator "mainnet refuses, op not run" ×6, `remove` precedence (`PRIVATE_NETWORK_REQUIRED` before `HUMAN_REQUIRED`), and an MCP `apply require_private` wire test. Live-binary smoke confirmed the env floor, the flag, precedence, and that the gate is a no-op when unset.

## Review

Built via `/plan-eng-review` + a Codex outside-voice pass that caught `upgrade` as an uncovered bypass, the `resolveNodeContext`-opens-target sequencing, the `cmd→cmd/network` import cycle, flag-shadowing, the MCP early-guard + error passthrough, the `network add` Network gap, and the manifest/SchemaVersion impact — all folded in.