### PR TITLE
feat(txgen): Falcon-512 (FN_DSA_512) post-quantum signing via liboqs CGO

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -215,7 +215,17 @@ OPENSSL_LDFLAGS ?= $(shell pkg-config --libs  openssl 2>/dev/null || echo -L/usr
 ##              Requires liboqs ≥ 0.10 installed (brew install liboqs on macOS).
 ##              Uses CGO + liboqs C library; produces a larger binary that can
 ##              sign FN_DSA_512 PQ transactions in addition to ML_DSA_44.
+##              Skipped with a warning (exit 0) when liboqs is not installed,
+##              so CI runners without liboqs do not fail.
 build-txgen-falcon: $(GO_BOOTSTRAP)
+	@if ! (pkg-config --exists liboqs 2>/dev/null || \
+	       [ -f /usr/local/include/oqs/oqs.h ] || \
+	       [ -f /opt/homebrew/include/oqs/oqs.h ]); then \
+		echo "⚠  liboqs not found — skipping build-txgen-falcon"; \
+		echo "   Install with: brew install liboqs  (macOS)"; \
+		echo "   or build from source: https://github.com/open-quantum-safe/liboqs"; \
+		exit 0; \
+	fi
 	@mkdir -p bin
 	CGO_ENABLED=1 \
 	CGO_CFLAGS="$(LIBOQS_CFLAGS)" \

--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ endif
 
 GOFLAGS    ?=
 
-.PHONY: build test lint e2e build-all clean clean-all fmt vet tidy sync-templates sync-schemas sync-knowledge snapshot-schema-baseline update-render-golden docs man cover vuln bootstrap-go build-replay install-replay build-txgen install-txgen
+.PHONY: build test lint e2e build-all clean clean-all fmt vet tidy sync-templates sync-schemas sync-knowledge snapshot-schema-baseline update-render-golden docs man cover vuln bootstrap-go build-replay install-replay build-txgen install-txgen build-txgen-falcon install-txgen-falcon
 
 ## bootstrap-go: Download + verify the project-local Go toolchain
 ##               (idempotent; safe to re-run; no-op if already current)
@@ -202,3 +202,28 @@ build-txgen: $(GO_BOOTSTRAP)
 install-txgen: build-txgen
 	cp bin/txgen $(GOBIN)/txgen
 	@echo "✓ txgen installed at $(GOBIN)/txgen"
+
+# --- liboqs pkg-config helpers (used by build-txgen-falcon) ------------------
+# Falls back to common homebrew paths when pkg-config is not found or liboqs
+# is not registered. Override by setting LIBOQS_CFLAGS / LIBOQS_LDFLAGS in
+# the environment before calling make.
+LIBOQS_CFLAGS  ?= $(shell pkg-config --cflags liboqs 2>/dev/null || echo -I/usr/local/include -I/opt/homebrew/include)
+LIBOQS_LDFLAGS ?= $(shell pkg-config --libs   liboqs 2>/dev/null || echo -L/usr/local/lib -L/opt/homebrew/lib -loqs)
+OPENSSL_LDFLAGS ?= $(shell pkg-config --libs  openssl 2>/dev/null || echo -L/usr/local/opt/openssl@3/lib -L/opt/homebrew/opt/openssl@3/lib -lcrypto)
+
+## build-txgen-falcon: Build bin/txgen with Falcon-512 (FN_DSA_512) support.
+##              Requires liboqs ≥ 0.10 installed (brew install liboqs on macOS).
+##              Uses CGO + liboqs C library; produces a larger binary that can
+##              sign FN_DSA_512 PQ transactions in addition to ML_DSA_44.
+build-txgen-falcon: $(GO_BOOTSTRAP)
+	@mkdir -p bin
+	CGO_ENABLED=1 \
+	CGO_CFLAGS="$(LIBOQS_CFLAGS)" \
+	CGO_LDFLAGS="$(LIBOQS_LDFLAGS) $(OPENSSL_LDFLAGS)" \
+	$(GO) build -tags falcon -ldflags "$(LDFLAGS)" -o bin/txgen ./tools/txgen
+	@echo "✓ bin/txgen (with Falcon-512 via liboqs) built"
+
+## install-txgen-falcon: Build + copy Falcon-enabled txgen into $(GOBIN).
+install-txgen-falcon: build-txgen-falcon
+	cp bin/txgen $(GOBIN)/txgen
+	@echo "✓ txgen (with Falcon-512) installed at $(GOBIN)/txgen"

--- a/internal/knowledge/files/snapshots.md
+++ b/internal/knowledge/files/snapshots.md
@@ -222,3 +222,81 @@ version change.
   - The tarball got corrupted in flight or the mirror is serving a
     different file than its sidecar advertises. Retry; if the mismatch
     persists, switch `--region` or `--domain`.
+
+## Local database backup with `db_cp`
+
+`scripts/db_cp.sh` makes a fast, space-efficient local copy of a
+java-tron LevelDB/RocksDB database directory. It is the recommended way
+to snapshot an already-extracted database before a risky operation (node
+upgrade, config migration, shadow-fork mutation, etc.).
+
+### Why not plain `cp -r`?
+
+A mainnet database is hundreds of GB of `.sst` immutable segment files.
+`cp` would duplicate every byte. `db_cp` hard-links `.sst` files instead
+— the destination shares the same data blocks, so the copy is nearly
+instantaneous and uses negligible extra disk space. Only the small
+bookkeeping files (LOCK, CURRENT, MANIFEST, OPTIONS) get independent
+inodes, which is required so each copy can be opened independently by
+java-tron.
+
+### Requirements
+
+- `rsync` (handles the non-`.sst` tree)
+- `ln` (POSIX hard-link; src and dst must be on the **same filesystem**)
+
+### Usage
+
+```bash
+# source the function into the current shell
+source scripts/db_cp.sh
+
+# one-liner backup with a timestamp suffix
+db_cp \
+  /data/tron/output-directory/mainnet/database \
+  /data/tron/output-directory/mainnet/database-backup-$(date +%Y%m%d-%H%M%S)
+```
+
+Or run it directly as a script:
+
+```bash
+./scripts/db_cp.sh <src> <dst>
+```
+
+### Disk-space accounting
+
+| File type | Copy method | Incremental disk cost |
+|---|---|---|
+| `.sst` segment files | `ln` (hard-link) | ~0 (shared blocks) |
+| LOCK / CURRENT / MANIFEST / OPTIONS | `rsync` (full copy) | bytes, negligible |
+
+The destination directory must not exist before the call — `db_cp`
+refuses to clobber an existing path.
+
+### Typical workflow
+
+```bash
+# 1. Stop the node (or use a quiesced snapshot)
+trond stop --node mainnet-1
+
+# 2. Back up the database
+source scripts/db_cp.sh
+db_cp \
+  /data/tron/output-directory/mainnet/database \
+  /data/tron/output-directory/mainnet/database-bak-$(date +%Y%m%d-%H%M%S)
+
+# 3. Perform the risky operation (upgrade, mutation, …)
+trond apply --intent intent.yaml --auto-approve --wait
+
+# 4. If something goes wrong, restore:
+#    stop the node, delete the current database, rename the backup back.
+```
+
+### Limitations
+
+- Hard-links only work within a single filesystem. If src and dst are on
+  different block devices, `ln` will fail. Use `rsync -a` instead — it
+  will be slower and use full disk space.
+- Do **not** use `db_cp` on a live, write-active node. java-tron may be
+  mid-compaction, leaving `.sst` files in a transient state. Stop the
+  node (or use an OS-level snapshot) first.

--- a/knowledge/snapshots.md
+++ b/knowledge/snapshots.md
@@ -222,3 +222,81 @@ version change.
   - The tarball got corrupted in flight or the mirror is serving a
     different file than its sidecar advertises. Retry; if the mismatch
     persists, switch `--region` or `--domain`.
+
+## Local database backup with `db_cp`
+
+`scripts/db_cp.sh` makes a fast, space-efficient local copy of a
+java-tron LevelDB/RocksDB database directory. It is the recommended way
+to snapshot an already-extracted database before a risky operation (node
+upgrade, config migration, shadow-fork mutation, etc.).
+
+### Why not plain `cp -r`?
+
+A mainnet database is hundreds of GB of `.sst` immutable segment files.
+`cp` would duplicate every byte. `db_cp` hard-links `.sst` files instead
+— the destination shares the same data blocks, so the copy is nearly
+instantaneous and uses negligible extra disk space. Only the small
+bookkeeping files (LOCK, CURRENT, MANIFEST, OPTIONS) get independent
+inodes, which is required so each copy can be opened independently by
+java-tron.
+
+### Requirements
+
+- `rsync` (handles the non-`.sst` tree)
+- `ln` (POSIX hard-link; src and dst must be on the **same filesystem**)
+
+### Usage
+
+```bash
+# source the function into the current shell
+source scripts/db_cp.sh
+
+# one-liner backup with a timestamp suffix
+db_cp \
+  /data/tron/output-directory/mainnet/database \
+  /data/tron/output-directory/mainnet/database-backup-$(date +%Y%m%d-%H%M%S)
+```
+
+Or run it directly as a script:
+
+```bash
+./scripts/db_cp.sh <src> <dst>
+```
+
+### Disk-space accounting
+
+| File type | Copy method | Incremental disk cost |
+|---|---|---|
+| `.sst` segment files | `ln` (hard-link) | ~0 (shared blocks) |
+| LOCK / CURRENT / MANIFEST / OPTIONS | `rsync` (full copy) | bytes, negligible |
+
+The destination directory must not exist before the call — `db_cp`
+refuses to clobber an existing path.
+
+### Typical workflow
+
+```bash
+# 1. Stop the node (or use a quiesced snapshot)
+trond stop --node mainnet-1
+
+# 2. Back up the database
+source scripts/db_cp.sh
+db_cp \
+  /data/tron/output-directory/mainnet/database \
+  /data/tron/output-directory/mainnet/database-bak-$(date +%Y%m%d-%H%M%S)
+
+# 3. Perform the risky operation (upgrade, mutation, …)
+trond apply --intent intent.yaml --auto-approve --wait
+
+# 4. If something goes wrong, restore:
+#    stop the node, delete the current database, rename the backup back.
+```
+
+### Limitations
+
+- Hard-links only work within a single filesystem. If src and dst are on
+  different block devices, `ln` will fail. Use `rsync -a` instead — it
+  will be slower and use full disk space.
+- Do **not** use `db_cp` on a live, write-active node. java-tron may be
+  mid-compaction, leaving `.sst` files in a transient state. Stop the
+  node (or use an OS-level snapshot) first.

--- a/scripts/db_cp.sh
+++ b/scripts/db_cp.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# db_cp <src> <dst>
+#
+# Copy a java-tron LevelDB/RocksDB snapshot directory efficiently:
+#   - Non-.sst files (LOCK, CURRENT, MANIFEST, OPTIONS, …) are copied normally
+#     so each destination gets an independent inode.
+#   - .sst files are hard-linked (same data blocks, zero extra disk usage).
+#
+# Usage as a one-liner:
+#   db_cp /data/tron/database /data/tron/database-backup-$(date +%Y%m%d-%H%M%S)
+#
+# Or source this file and call db_cp directly:
+#   source scripts/db_cp.sh
+#   db_cp /src /dst
+
+db_cp() {
+  local SRC="$1"
+  local DST="$2"
+
+  if [ -z "$SRC" ] || [ -z "$DST" ]; then
+    echo "Usage: db_cp <src> <dst>" >&2
+    return 1
+  fi
+  if [ ! -d "$SRC" ]; then
+    echo "src $SRC does not exist or is not a directory" >&2
+    return 1
+  fi
+  if [ -e "$DST" ]; then
+    echo "dst $DST already exists, delete it first." >&2
+    return 1
+  fi
+
+  # Step 1: copy directory structure + non-.sst files (independent inodes)
+  rsync -a --exclude="*.sst" "$SRC/" "$DST/"
+
+  # Step 2: hard-link .sst files (no data blocks copied)
+  find "$SRC" -name "*.sst" -type f | while IFS= read -r f; do
+    local rel="${f#${SRC}/}"
+    mkdir -p "$DST/$(dirname "$rel")"
+    ln "$f" "$DST/$rel"
+  done
+
+  echo "db_cp done: $SRC -> $DST"
+}
+
+# Run directly if not being sourced
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  db_cp "$@"
+fi

--- a/tools/txgen/README.md
+++ b/tools/txgen/README.md
@@ -42,7 +42,8 @@ Save this as `txgen.json` next to the binary:
     "privateKey": "<64-hex-char sender key>",
     "outputDir": "txgen-output",
     "txType": { "transfer": 100, "transferTrc10": 0, "transferTrc20": 0 },
-    "transferAmount": 1
+    "transferAmount": 1,
+    "expirationMillis": 86400000
   },
 
   "broadcast": {
@@ -63,7 +64,10 @@ txgen generate -c txgen.json
 
 `generate` first builds `receiverAddressCount` fresh secp256k1 receivers (dumped to `txgen-output/receivers.csv` for auditability or `db fork` pre-funding), then builds `totalTxCount` signed TRX transfers fanning out across those receivers and splits them into `txgen-output/generate-tx-NNNN.csv`. Workers issue one HTTP round-trip per tx to the node (`/wallet/createtransaction`) for the unsigned form, then sign locally with secp256k1.
 
-**Time-sensitive:** the node stamps each tx with `expiration = head_block_time + 60s` by default. Broadcast within a minute, or raise `block.maxTimeUntilExpiration` in the node's `config.conf` first.
+By default txgen rewrites each unsigned transaction before signing so
+`raw_data.expiration = raw_data.timestamp + 86400000` (1 day). Override this
+with `generate.expirationMillis` when you need a shorter or longer broadcast
+window.
 
 ### 3. Broadcast to the private chain
 
@@ -187,7 +191,8 @@ transactions that should be PQ-signed (the rest are ECDSA-signed):
 
 Common helpers:
 - `Toolkit.jar db fork` with `<outputDir>/receivers.csv` to pre-fund receivers in one shot.
-- Raise `block.maxTimeUntilExpiration` in node config if your generate→broadcast gap is longer than 60s.
+- `generate.expirationMillis` defaults to 1 day, so generated CSVs can be
+  broadcast after the node's default 60 second transaction window.
 
 ---
 
@@ -263,6 +268,7 @@ txgen reads a single JSON file (default `./txgen.json`, override with `-c` / `--
     "trc10Id": "1000001",
     "trc20Address": "TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t",
     "transferAmount": 1,
+    "expirationMillis": 86400000,
     "trc20FeeLimit": 100000000
   },
 
@@ -298,6 +304,7 @@ txgen reads a single JSON file (default `./txgen.json`, override with `-c` / `--
 | `generate` | `trc10Id` | — | TRC10 token id (numeric string). Required iff `transferTrc10 > 0`. |
 | `generate` | `trc20Address` | — | TRC20 contract address (base58 or hex). Required iff `transferTrc20 > 0`. |
 | `generate` | `transferAmount` | `1` | Amount per tx in the smallest unit (SUN for TRX, raw token units otherwise). |
+| `generate` | `expirationMillis` | `86400000` | Transaction lifetime from `raw_data.timestamp`; txgen rewrites `raw_data.expiration`, `raw_data_hex`, and `txID` before signing. |
 | `generate` | `trc20FeeLimit` | `100000000` | Fee limit (SUN) on TRC20 calls. 100 TRX is plenty for a vanilla `transfer`. |
 | `generate` | `pq.enabled` | `false` | Mix in post-quantum signing (`pq_auth_sig`). See [Post-quantum transactions](#post-quantum-pq--抗量子-transactions). |
 | `generate` | `pq.scheme` | `ML_DSA_44` | PQ scheme. Only `ML_DSA_44` is supported. |
@@ -323,7 +330,7 @@ txgen reads a single JSON file (default `./txgen.json`, override with `-c` / `--
 | `generate: balance is not sufficient` (in node logs) | Sender ran out of TRX mid-run | Top up the sender, or shrink `totalTxCount`. |
 | `broadcast fail: SIGERROR: ...` | Signature didn't verify | Confirm the sender key matches the address that owns the source funds. Re-run `generate`. |
 | `broadcast fail: DUP_TRANSACTION_ERROR` | Same CSV was broadcast twice | Normal on a re-run. Move the old CSV out of `inputDir`. |
-| `broadcast fail: ... transaction expiration ...` | CSV is older than the node's expiration window | Re-run `generate`, then `broadcast` within ~60s, or raise `block.maxTimeUntilExpiration` in node config. |
+| `broadcast fail: ... transaction expiration ...` | CSV is older than `generate.expirationMillis` | Re-run `generate`, or raise `generate.expirationMillis` before generating. |
 | `statistic: fetch block X` | Block doesn't exist yet, or RPC is filtered | Tighten the range, or wait until the chain catches up. |
 
 ---

--- a/tools/txgen/README.md
+++ b/tools/txgen/README.md
@@ -13,13 +13,42 @@ Useful for:
 
 ```bash
 # From the tron-deployment repo root
-make build-txgen        # → bin/txgen
+make build-txgen        # → bin/txgen  (pure Go, no CGO)
 make install-txgen      # → $(GOBIN)/txgen
 ```
 
-Requires Go 1.21+. Builds a single ~10 MB static binary.
+Requires Go 1.21+. Builds a single ~10 MB static binary with no external runtime dependencies.
 
 The HTTP broadcast layer lives in `tools/common/broadcast/` and is shared with `tools/replay/`.
+
+### Build variants
+
+| Make target | CGO | Falcon-512 | Portability |
+|---|---|---|---|
+| `build-txgen` | No | No (stub returns error) | Any platform, cross-compile works |
+| `build-txgen-falcon` | Yes (liboqs) | Yes | Must build on target platform; liboqs required |
+
+**`build-txgen` is the default and the only variant built in CI.** The `falcon` build tag is off by
+default so Go's standard cross-compilation and static-binary guarantees are preserved.
+
+`build-txgen-falcon` requires [liboqs](https://github.com/open-quantum-safe/liboqs) ≥ 0.10 installed
+as a C library. It uses CGO, which means:
+
+- A C compiler must be present at build time on every target platform.
+- Cross-compilation (`GOOS=linux` from macOS) does not work without a cross-toolchain.
+- The binary dynamically links `liboqs.so` at runtime unless you also pass `-extldflags="-static"`.
+
+**CI behaviour:** `make build-txgen-falcon` detects whether liboqs is installed and **skips with a
+warning (exit 0)** rather than failing when it is not found. This means CI runners without liboqs
+installed will silently skip the falcon binary; they still build and test the pure-Go binary via
+`make build-txgen`.
+
+Local install (macOS):
+
+```bash
+brew install liboqs
+make build-txgen-falcon   # → bin/txgen with Falcon-512 support
+```
 
 ---
 
@@ -170,11 +199,13 @@ transactions that should be PQ-signed (the rest are ECDSA-signed):
   (when `ratio == 100`, `privateKey` is not needed). The PQ sender is derived from
   `pq.seed` as `0x41 ‖ Keccak-256(public_key)[12..32]`. `txgen generate` logs both
   sender addresses at startup.
-- **Scheme.** Only `ML_DSA_44` (FIPS 204 ML-DSA-44 / CRYSTALS-Dilithium-2) is
-  supported. It interoperates with the node's BouncyCastle verifier. Falcon-512
-  (`FN_DSA_512`) is **not** supported: java-tron uses a BouncyCastle/EIP-8052
-  specific wire encoding that no Go library reproduces, so a Go-signed Falcon
-  signature would be rejected on-chain.
+- **Scheme.** Two schemes are available:
+  - `ML_DSA_44` (FIPS 204 / CRYSTALS-Dilithium-2) — supported in the **default
+    pure-Go build** (`make build-txgen`). No extra dependencies.
+  - `FN_DSA_512` (Falcon-512) — supported only in the **falcon build**
+    (`make build-txgen-falcon`, requires liboqs). The default build returns an
+    error if `FN_DSA_512` is requested. See [Build variants](#build-variants) for
+    details on the CGO/liboqs requirement and portability trade-offs.
 - **Account provisioning (required).** The node only accepts a PQ signature when
   the PQ sender account's permission already contains this PQ public key with
   enough weight. Install it out-of-band (e.g. via `AccountPermissionUpdate`)
@@ -307,7 +338,7 @@ txgen reads a single JSON file (default `./txgen.json`, override with `-c` / `--
 | `generate` | `expirationMillis` | `86400000` | Transaction lifetime from `raw_data.timestamp`; txgen rewrites `raw_data.expiration`, `raw_data_hex`, and `txID` before signing. |
 | `generate` | `trc20FeeLimit` | `100000000` | Fee limit (SUN) on TRC20 calls. 100 TRX is plenty for a vanilla `transfer`. |
 | `generate` | `pq.enabled` | `false` | Mix in post-quantum signing (`pq_auth_sig`). See [Post-quantum transactions](#post-quantum-pq--抗量子-transactions). |
-| `generate` | `pq.scheme` | `ML_DSA_44` | PQ scheme. Only `ML_DSA_44` is supported. |
+| `generate` | `pq.scheme` | `ML_DSA_44` | PQ scheme: `ML_DSA_44` (default build) or `FN_DSA_512` (falcon build only, requires liboqs). |
 | `generate` | `pq.seed` | — (required iff `pq.enabled`) | 32-byte hex (64 chars) seed; derives the PQ keypair and sender address. |
 | `generate` | `pq.ratio` | `100` | Percent of txs PQ-signed (1–100); the rest are ECDSA-signed. Only used when `pq.enabled`. |
 | `broadcast` | `inputDir` | = `generate.outputDir` | Where to find `generate-tx-*.csv`. |

--- a/tools/txgen/broadcast.go
+++ b/tools/txgen/broadcast.go
@@ -86,13 +86,8 @@ func runBroadcast(ctx context.Context, cfg *Config) error {
 		failCount atomic.Int64
 		wg        sync.WaitGroup
 	)
-	workers := cfg.Broadcast.TpsLimit / 50
-	if workers < 4 {
-		workers = 4
-	}
-	if workers > 256 {
-		workers = 256
-	}
+	workers := cfg.Broadcast.Workers
+	log.Printf("broadcast: workers=%d tpsLimit=%d", workers, cfg.Broadcast.TpsLimit)
 	for w := 0; w < workers; w++ {
 		wg.Add(1)
 		go func() {

--- a/tools/txgen/config.go
+++ b/tools/txgen/config.go
@@ -59,7 +59,7 @@ type Config struct {
 	Broadcast struct {
 		InputDir   string `json:"inputDir"`
 		TpsLimit   int    `json:"tpsLimit"`
-		Workers    int    `json:"workers"`    // concurrent HTTP workers; 0 = auto (tpsLimit/50, min 4, max 256)
+		Workers    int    `json:"workers"` // concurrent HTTP workers; 0 = auto (tpsLimit/50, min 4, max 256)
 		SaveTxID   bool   `json:"saveTxId"`
 		TxIDFile   string `json:"txIdFile"`
 		ReportFile string `json:"reportFile"`

--- a/tools/txgen/config.go
+++ b/tools/txgen/config.go
@@ -23,6 +23,7 @@ type Config struct {
 		Concurrency          int    `json:"concurrency"`
 		PrivateKey           string `json:"privateKey"`
 		OutputDir            string `json:"outputDir"`
+		ExpirationMillis     int64  `json:"expirationMillis"`
 		TxType               struct {
 			Transfer      int `json:"transfer"`
 			TransferTRC10 int `json:"transferTrc10"`
@@ -58,6 +59,7 @@ type Config struct {
 	Broadcast struct {
 		InputDir   string `json:"inputDir"`
 		TpsLimit   int    `json:"tpsLimit"`
+		Workers    int    `json:"workers"`    // concurrent HTTP workers; 0 = auto (tpsLimit/50, min 4, max 256)
 		SaveTxID   bool   `json:"saveTxId"`
 		TxIDFile   string `json:"txIdFile"`
 		ReportFile string `json:"reportFile"`
@@ -105,6 +107,9 @@ func (c *Config) applyDefaults() {
 	if c.Generate.TransferAmount == 0 {
 		c.Generate.TransferAmount = 1
 	}
+	if c.Generate.ExpirationMillis == 0 {
+		c.Generate.ExpirationMillis = 86_400_000 // 1 day
+	}
 	if c.Generate.TRC20FeeLimit == 0 {
 		c.Generate.TRC20FeeLimit = 100_000_000 // 100 TRX
 	}
@@ -123,6 +128,15 @@ func (c *Config) applyDefaults() {
 	}
 	if c.Broadcast.TpsLimit == 0 {
 		c.Broadcast.TpsLimit = 1000
+	}
+	if c.Broadcast.Workers == 0 {
+		c.Broadcast.Workers = c.Broadcast.TpsLimit / 50
+		if c.Broadcast.Workers < 4 {
+			c.Broadcast.Workers = 4
+		}
+		if c.Broadcast.Workers > 256 {
+			c.Broadcast.Workers = 256
+		}
 	}
 	if c.Broadcast.TxIDFile == "" {
 		c.Broadcast.TxIDFile = "broadcast-txid.csv"
@@ -191,6 +205,9 @@ func (c *Config) validate() error {
 	}
 	if c.Generate.ReceiverAddressCount <= 0 {
 		return errors.New("generate.receiverAddressCount must be > 0")
+	}
+	if c.Generate.ExpirationMillis < 0 {
+		return errors.New("generate.expirationMillis must be >= 0")
 	}
 	return nil
 }

--- a/tools/txgen/config.go
+++ b/tools/txgen/config.go
@@ -35,14 +35,22 @@ type Config struct {
 
 		// PQ: when enabled, a `ratio` percent of transactions are signed
 		// with a post-quantum scheme and carry a pq_auth_sig instead of the
-		// ECDSA signature; the remainder are ECDSA-signed. The PQ sender is
-		// derived from the PQ seed (its account permission must already
-		// register this PQ public key); the ECDSA sender from privateKey.
+		// ECDSA signature; the remainder are ECDSA-signed.
+		//
+		// ML_DSA_44: set scheme="ML_DSA_44" and seed (32-byte hex, 64 chars).
+		// The keypair is derived deterministically from the seed.
+		//
+		// FN_DSA_512 (Falcon-512): set scheme="FN_DSA_512" and provide the
+		// privateKey (1281-byte liboqs SK, 2562 hex chars) and publicKey
+		// (896-byte h polynomial, 1792 hex chars). Generate a keypair with
+		// `txgen keygen` (requires build-txgen-falcon).
 		PQ struct {
-			Enabled bool   `json:"enabled"`
-			Scheme  string `json:"scheme"` // only "ML_DSA_44" is supported
-			Seed    string `json:"seed"`   // 32-byte hex (64 hex chars)
-			Ratio   int    `json:"ratio"`  // percent of txs PQ-signed, 1-100 (default 100)
+			Enabled    bool   `json:"enabled"`
+			Scheme     string `json:"scheme"`     // "ML_DSA_44" or "FN_DSA_512"
+			Seed       string `json:"seed"`       // ML_DSA_44: 32-byte hex (64 hex chars)
+			PrivateKey string `json:"privateKey"` // FN_DSA_512: liboqs SK hex (2562 chars)
+			PublicKey  string `json:"publicKey"`  // FN_DSA_512: h polynomial hex (1792 chars)
+			Ratio      int    `json:"ratio"`      // percent of txs PQ-signed, 1-100 (default 100)
 		} `json:"pq"`
 	} `json:"generate"`
 
@@ -143,11 +151,20 @@ func (c *Config) validate() error {
 		return fmt.Errorf("generate.txType weights must sum to 100, got %d", sum)
 	}
 	if c.Generate.PQ.Enabled {
-		if c.Generate.PQ.Scheme != SchemeMLDSA44 {
-			return fmt.Errorf("generate.pq.scheme %q unsupported (only %s)", c.Generate.PQ.Scheme, SchemeMLDSA44)
-		}
-		if len(c.Generate.PQ.Seed) != pqSeedHexLen {
-			return fmt.Errorf("generate.pq.seed must be %d hex chars (32 bytes)", pqSeedHexLen)
+		switch c.Generate.PQ.Scheme {
+		case SchemeMLDSA44:
+			if len(c.Generate.PQ.Seed) != pqSeedHexLen {
+				return fmt.Errorf("generate.pq.seed must be %d hex chars (32 bytes) for ML_DSA_44", pqSeedHexLen)
+			}
+		case SchemeFNDSA512:
+			if len(c.Generate.PQ.PrivateKey) != falconSKHexLen {
+				return fmt.Errorf("generate.pq.privateKey must be %d hex chars (%d bytes) for FN_DSA_512", falconSKHexLen, falconSKLen)
+			}
+			if len(c.Generate.PQ.PublicKey) != falconHHexLen {
+				return fmt.Errorf("generate.pq.publicKey must be %d hex chars (%d bytes h polynomial) for FN_DSA_512", falconHHexLen, falconHLen)
+			}
+		default:
+			return fmt.Errorf("generate.pq.scheme %q unsupported (supported: %s, %s)", c.Generate.PQ.Scheme, SchemeMLDSA44, SchemeFNDSA512)
 		}
 		if c.Generate.PQ.Ratio < 1 || c.Generate.PQ.Ratio > 100 {
 			return fmt.Errorf("generate.pq.ratio must be 1-100, got %d", c.Generate.PQ.Ratio)

--- a/tools/txgen/falcon.go
+++ b/tools/txgen/falcon.go
@@ -6,8 +6,7 @@ package main
 //
 // Wire-format compatibility with java-tron's BouncyCastle verifier:
 //
-//   - Algorithm: "Falcon-padded-512" — produces constant 666-byte signatures,
-//     always within TRON's [617, 667] acceptance window.
+//   - Algorithm: "Falcon-512" — produces compressed variable-length signatures.
 //
 //   - Header byte: 0x39 (= 0x30 + logn, logn=9 for Falcon-512). Matches the
 //     compressed-format marker that BouncyCastle's FalconSigner emits and that
@@ -39,7 +38,7 @@ import (
 	"unsafe"
 )
 
-const falconAlg = "Falcon-padded-512" // constant 666-byte sigs, header 0x39
+const falconAlg = "Falcon-512" // compressed variable-length sigs, header 0x39
 
 // FalconSigner signs transaction IDs with Falcon-512 (FN_DSA_512) using liboqs.
 // Create via NewFalconSigner (load existing keypair) or GenerateFalconKeypair
@@ -95,7 +94,7 @@ func (s *FalconSigner) Close() {
 	}
 }
 
-// Sign produces a 666-byte Falcon-padded-512 signature over the 32-byte txID
+// Sign produces a compressed Falcon-512 signature over the 32-byte txID
 // (hex-encoded). The message signed is the raw txID bytes — the same digest
 // ECDSA and ML-DSA-44 sign — matching java-tron's verifier path.
 func (s *FalconSigner) Sign(txIDHex string) ([]byte, error) {
@@ -190,7 +189,7 @@ func newOQSSig() (*C.OQS_SIG, error) {
 	defer C.free(unsafe.Pointer(alg))
 	sig := C.OQS_SIG_new(alg)
 	if sig == nil {
-		return nil, errors.New("liboqs: Falcon-padded-512 not available (is liboqs built with OQS_ENABLE_SIG_falcon_padded_512?)")
+		return nil, errors.New("liboqs: Falcon-512 not available (is liboqs built with OQS_ENABLE_SIG_falcon_512?)")
 	}
 	return sig, nil
 }

--- a/tools/txgen/falcon.go
+++ b/tools/txgen/falcon.go
@@ -1,0 +1,196 @@
+//go:build falcon
+
+package main
+
+// Falcon-512 post-quantum signing via liboqs (https://github.com/open-quantum-safe/liboqs).
+//
+// Wire-format compatibility with java-tron's BouncyCastle verifier:
+//
+//   - Algorithm: "Falcon-padded-512" — produces constant 666-byte signatures,
+//     always within TRON's [617, 667] acceptance window.
+//
+//   - Header byte: 0x39 (= 0x30 + logn, logn=9 for Falcon-512). Matches the
+//     compressed-format marker that BouncyCastle's FalconSigner emits and that
+//     FNDSA512.java checks explicitly before calling verifySignature.
+//
+//   - Public key on-chain: 896 bytes (liboqs pk minus the leading 0x09 header
+//     byte). Matches BouncyCastle's FalconPublicKeyParameters(PARAMS, getH())
+//     which strips the same header.
+//
+//   - Address derivation: 0x41 ‖ Keccak-256(896-byte-h)[12..32], identical to
+//     ECDSA and ML-DSA-44 paths in addressFromPubBytes.
+//
+// Build:
+//
+//   make build-txgen-falcon
+//
+// which sets CGO_ENABLED=1 and the liboqs / OpenSSL link flags. See the Makefile
+// for the exact pkg-config invocations.
+
+/*
+#include <oqs/oqs.h>
+#include <stdlib.h>
+*/
+import "C"
+import (
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"unsafe"
+)
+
+const falconAlg = "Falcon-padded-512" // constant 666-byte sigs, header 0x39
+
+// FalconSigner signs transaction IDs with Falcon-512 (FN_DSA_512) using liboqs.
+// Create via NewFalconSigner (load existing keypair) or GenerateFalconKeypair
+// (generate + immediately construct).
+type FalconSigner struct {
+	oqsSig  *C.OQS_SIG // retained across Sign calls; freed by Close
+	skBytes []byte     // 1281-byte liboqs secret key
+	hPoly   []byte     // 896-byte h polynomial (on-chain public key)
+	hexAddr string     // 0x41-prefixed hex address
+	b58Addr string     // Base58Check "T..." address
+}
+
+// NewFalconSigner builds a signer from an already-generated keypair.
+//   - skHex: 2562 hex chars (1281-byte liboqs Falcon-512 secret key)
+//   - pkHex: 1792 hex chars (896-byte h polynomial, header byte stripped)
+//
+// Generate a fresh keypair with GenerateFalconKeypair or `txgen keygen`.
+func NewFalconSigner(skHex, pkHex string) (*FalconSigner, error) {
+	if len(skHex) != falconSKHexLen {
+		return nil, fmt.Errorf("FN_DSA_512 privateKey must be %d hex chars (%d bytes)", falconSKHexLen, falconSKLen)
+	}
+	if len(pkHex) != falconHHexLen {
+		return nil, fmt.Errorf("FN_DSA_512 publicKey must be %d hex chars (%d bytes h polynomial)", falconHHexLen, falconHLen)
+	}
+	sk, err := hex.DecodeString(skHex)
+	if err != nil {
+		return nil, fmt.Errorf("decode FN_DSA_512 privateKey: %w", err)
+	}
+	hPoly, err := hex.DecodeString(pkHex)
+	if err != nil {
+		return nil, fmt.Errorf("decode FN_DSA_512 publicKey: %w", err)
+	}
+	sig, err := newOQSSig()
+	if err != nil {
+		return nil, err
+	}
+	hexAddr, b58 := addressFromPubBytes(hPoly)
+	return &FalconSigner{
+		oqsSig:  sig,
+		skBytes: sk,
+		hPoly:   hPoly,
+		hexAddr: hexAddr,
+		b58Addr: b58,
+	}, nil
+}
+
+// Close releases the underlying liboqs OQS_SIG object.
+// Call when the signer is no longer needed (e.g. via defer s.Close()).
+func (s *FalconSigner) Close() {
+	if s.oqsSig != nil {
+		C.OQS_SIG_free(s.oqsSig)
+		s.oqsSig = nil
+	}
+}
+
+// Sign produces a 666-byte Falcon-padded-512 signature over the 32-byte txID
+// (hex-encoded). The message signed is the raw txID bytes — the same digest
+// ECDSA and ML-DSA-44 sign — matching java-tron's verifier path.
+func (s *FalconSigner) Sign(txIDHex string) ([]byte, error) {
+	msg, err := hex.DecodeString(txIDHex)
+	if err != nil {
+		return nil, err
+	}
+	if len(msg) != 32 {
+		return nil, errors.New("txID must be 32 bytes")
+	}
+
+	sigBuf := make([]byte, falconSigLen)
+	var sigLen C.size_t
+
+	rc := C.OQS_SIG_sign(
+		s.oqsSig,
+		(*C.uint8_t)(unsafe.Pointer(&sigBuf[0])),
+		&sigLen,
+		(*C.uint8_t)(unsafe.Pointer(&msg[0])),
+		C.size_t(len(msg)),
+		(*C.uint8_t)(unsafe.Pointer(&s.skBytes[0])),
+	)
+	if rc != C.OQS_SUCCESS {
+		return nil, errors.New("liboqs: Falcon signing failed")
+	}
+	return sigBuf[:int(sigLen)], nil
+}
+
+// SchemeName returns "FN_DSA_512" — the PQScheme enum name used in
+// java-tron's HTTP JSON pq_auth_sig envelope.
+func (s *FalconSigner) SchemeName() string { return SchemeFNDSA512 }
+
+// PublicKeyHex returns the 896-byte h polynomial as lowercase hex.
+// This is the on-chain public key format expected by BouncyCastle's
+// FalconPublicKeyParameters(PARAMS, getH()).
+func (s *FalconSigner) PublicKeyHex() string { return hex.EncodeToString(s.hPoly) }
+
+// HexAddress returns the PQ-derived TRON address (21-byte hex form).
+func (s *FalconSigner) HexAddress() string { return s.hexAddr }
+
+// Base58Address returns the PQ-derived TRON address ("T..." form).
+func (s *FalconSigner) Base58Address() string { return s.b58Addr }
+
+// FalconKeypair holds a freshly generated Falcon-512 keypair ready for use in
+// txgen config and on-chain account provisioning.
+type FalconKeypair struct {
+	PrivateKeyHex string `json:"privateKey"` // 2562 hex chars (liboqs 1281-byte SK)
+	PublicKeyHex  string `json:"publicKey"`  // 1792 hex chars (896-byte h polynomial)
+	HexAddress    string `json:"hexAddress"` // 42 hex chars, 0x41-prefixed
+	Base58Address string `json:"address"`    // Base58Check "T..." form
+}
+
+// GenerateFalconKeypair generates a fresh Falcon-512 keypair via liboqs and
+// returns it as a FalconKeypair ready to be marshalled to JSON or loaded into
+// NewFalconSigner.
+func GenerateFalconKeypair() (*FalconKeypair, error) {
+	sig, err := newOQSSig()
+	if err != nil {
+		return nil, err
+	}
+	defer C.OQS_SIG_free(sig)
+
+	pkBuf := make([]byte, falconPKLen) // 897 bytes (with 0x09 header)
+	skBuf := make([]byte, falconSKLen) // 1281 bytes
+
+	rc := C.OQS_SIG_keypair(
+		sig,
+		(*C.uint8_t)(unsafe.Pointer(&pkBuf[0])),
+		(*C.uint8_t)(unsafe.Pointer(&skBuf[0])),
+	)
+	if rc != C.OQS_SUCCESS {
+		return nil, errors.New("liboqs: Falcon keypair generation failed")
+	}
+
+	// Strip the 0x09 serialization header: liboqs pk = 0x09 ‖ h_polynomial.
+	// BouncyCastle's FalconPublicKeyParameters(PARAMS, getH()) takes the
+	// 896-byte h polynomial without the header.
+	hPoly := pkBuf[1:] // 896 bytes
+
+	hexAddr, b58 := addressFromPubBytes(hPoly)
+	return &FalconKeypair{
+		PrivateKeyHex: hex.EncodeToString(skBuf),
+		PublicKeyHex:  hex.EncodeToString(hPoly),
+		HexAddress:    hexAddr,
+		Base58Address: b58,
+	}, nil
+}
+
+// newOQSSig allocates an OQS_SIG context for Falcon-padded-512.
+func newOQSSig() (*C.OQS_SIG, error) {
+	alg := C.CString(falconAlg)
+	defer C.free(unsafe.Pointer(alg))
+	sig := C.OQS_SIG_new(alg)
+	if sig == nil {
+		return nil, errors.New("liboqs: Falcon-padded-512 not available (is liboqs built with OQS_ENABLE_SIG_falcon_padded_512?)")
+	}
+	return sig, nil
+}

--- a/tools/txgen/falcon_const.go
+++ b/tools/txgen/falcon_const.go
@@ -12,7 +12,7 @@ const (
 	falconSKLen  = 1281 // liboqs Falcon-512 secret key bytes
 	falconPKLen  = 897  // liboqs Falcon-512 public key bytes (with 0x09 header)
 	falconHLen   = 896  // on-chain public key: h polynomial (header stripped)
-	falconSigLen = 666  // Falcon-padded-512 constant signature length
+	falconSigLen = 690  // liboqs Falcon-512 max signature buffer
 
 	falconSKHexLen = falconSKLen * 2 // 2562 hex chars
 	falconHHexLen  = falconHLen * 2  // 1792 hex chars

--- a/tools/txgen/falcon_const.go
+++ b/tools/txgen/falcon_const.go
@@ -1,0 +1,19 @@
+package main
+
+// Falcon-512 scheme name and key/signature size constants. Defined without a
+// build tag so both config.go (validation) and the build-tag-gated
+// implementation files (falcon.go / falcon_stub.go) can share them.
+
+const (
+	// SchemeFNDSA512 is the PQScheme enum name as serialized in java-tron's
+	// HTTP JSON pq_auth_sig envelope.
+	SchemeFNDSA512 = "FN_DSA_512"
+
+	falconSKLen  = 1281 // liboqs Falcon-512 secret key bytes
+	falconPKLen  = 897  // liboqs Falcon-512 public key bytes (with 0x09 header)
+	falconHLen   = 896  // on-chain public key: h polynomial (header stripped)
+	falconSigLen = 666  // Falcon-padded-512 constant signature length
+
+	falconSKHexLen = falconSKLen * 2 // 2562 hex chars
+	falconHHexLen  = falconHLen * 2  // 1792 hex chars
+)

--- a/tools/txgen/falcon_stub.go
+++ b/tools/txgen/falcon_stub.go
@@ -20,12 +20,12 @@ type FalconSigner struct{}
 // NewFalconSigner always returns errFalconUnavailable in non-falcon builds.
 func NewFalconSigner(_, _ string) (*FalconSigner, error) { return nil, errFalconUnavailable }
 
-func (s *FalconSigner) Close()                          {}
-func (s *FalconSigner) Sign(_ string) ([]byte, error)   { return nil, errFalconUnavailable }
-func (s *FalconSigner) SchemeName() string               { return SchemeFNDSA512 }
-func (s *FalconSigner) PublicKeyHex() string             { return "" }
-func (s *FalconSigner) HexAddress() string               { return "" }
-func (s *FalconSigner) Base58Address() string            { return "" }
+func (s *FalconSigner) Close()                        {}
+func (s *FalconSigner) Sign(_ string) ([]byte, error) { return nil, errFalconUnavailable }
+func (s *FalconSigner) SchemeName() string            { return SchemeFNDSA512 }
+func (s *FalconSigner) PublicKeyHex() string          { return "" }
+func (s *FalconSigner) HexAddress() string            { return "" }
+func (s *FalconSigner) Base58Address() string         { return "" }
 
 // FalconKeypair holds a freshly generated Falcon-512 keypair.
 type FalconKeypair struct {

--- a/tools/txgen/falcon_stub.go
+++ b/tools/txgen/falcon_stub.go
@@ -1,0 +1,39 @@
+//go:build !falcon
+
+package main
+
+// Stub definitions for when the binary is built without the `falcon` build tag.
+// FN_DSA_512 signing is not available in this build; attempting to use it
+// returns a descriptive error pointing to the correct Makefile target.
+
+import "errors"
+
+// errFalconUnavailable is returned by all FN_DSA_512 operations when the binary
+// was built without the `falcon` tag (i.e. without liboqs CGO support).
+var errFalconUnavailable = errors.New(
+	"FN_DSA_512 requires liboqs: rebuild with `make build-txgen-falcon` (CGO_ENABLED=1 + liboqs installed)",
+)
+
+// FalconSigner is a placeholder that always returns errFalconUnavailable.
+type FalconSigner struct{}
+
+// NewFalconSigner always returns errFalconUnavailable in non-falcon builds.
+func NewFalconSigner(_, _ string) (*FalconSigner, error) { return nil, errFalconUnavailable }
+
+func (s *FalconSigner) Close()                          {}
+func (s *FalconSigner) Sign(_ string) ([]byte, error)   { return nil, errFalconUnavailable }
+func (s *FalconSigner) SchemeName() string               { return SchemeFNDSA512 }
+func (s *FalconSigner) PublicKeyHex() string             { return "" }
+func (s *FalconSigner) HexAddress() string               { return "" }
+func (s *FalconSigner) Base58Address() string            { return "" }
+
+// FalconKeypair holds a freshly generated Falcon-512 keypair.
+type FalconKeypair struct {
+	PrivateKeyHex string `json:"privateKey"`
+	PublicKeyHex  string `json:"publicKey"`
+	HexAddress    string `json:"hexAddress"`
+	Base58Address string `json:"address"`
+}
+
+// GenerateFalconKeypair always returns errFalconUnavailable in non-falcon builds.
+func GenerateFalconKeypair() (*FalconKeypair, error) { return nil, errFalconUnavailable }

--- a/tools/txgen/falcon_test.go
+++ b/tools/txgen/falcon_test.go
@@ -1,0 +1,128 @@
+//go:build falcon
+
+package main
+
+import (
+	"encoding/hex"
+	"strings"
+	"testing"
+)
+
+func TestGenerateFalconKeypair(t *testing.T) {
+	kp, err := GenerateFalconKeypair()
+	if err != nil {
+		t.Fatalf("GenerateFalconKeypair: %v", err)
+	}
+
+	sk, err := hex.DecodeString(kp.PrivateKeyHex)
+	if err != nil {
+		t.Fatalf("decode SK: %v", err)
+	}
+	if len(sk) != falconSKLen {
+		t.Errorf("SK len = %d, want %d", len(sk), falconSKLen)
+	}
+
+	hPoly, err := hex.DecodeString(kp.PublicKeyHex)
+	if err != nil {
+		t.Fatalf("decode h polynomial: %v", err)
+	}
+	if len(hPoly) != falconHLen {
+		t.Errorf("h polynomial len = %d, want %d", len(hPoly), falconHLen)
+	}
+
+	if len(kp.HexAddress) != AddressHexLen {
+		t.Errorf("hex addr len = %d, want %d", len(kp.HexAddress), AddressHexLen)
+	}
+	if !strings.HasPrefix(kp.HexAddress, "41") {
+		t.Errorf("hex addr missing 0x41 prefix: %s", kp.HexAddress)
+	}
+	if !strings.HasPrefix(kp.Base58Address, "T") {
+		t.Errorf("b58 addr should start with T: %s", kp.Base58Address)
+	}
+
+	// Two consecutive keypairs must differ.
+	kp2, err := GenerateFalconKeypair()
+	if err != nil {
+		t.Fatalf("GenerateFalconKeypair (2nd): %v", err)
+	}
+	if kp.PrivateKeyHex == kp2.PrivateKeyHex {
+		t.Error("two keypairs are identical — randomness not advancing")
+	}
+}
+
+func TestFalconSignerSign(t *testing.T) {
+	kp, err := GenerateFalconKeypair()
+	if err != nil {
+		t.Fatalf("GenerateFalconKeypair: %v", err)
+	}
+
+	s, err := NewFalconSigner(kp.PrivateKeyHex, kp.PublicKeyHex)
+	if err != nil {
+		t.Fatalf("NewFalconSigner: %v", err)
+	}
+	defer s.Close()
+
+	txID := "a1b2c3d4e5f6071829304a5b6c7d8e9f00112233445566778899aabbccddeeff"
+	sig, err := s.Sign(txID)
+	if err != nil {
+		t.Fatalf("Sign: %v", err)
+	}
+
+	// Must be within TRON's acceptance window [617, 667].
+	if len(sig) < 617 || len(sig) > 667 {
+		t.Errorf("sig len = %d, want [617, 667]", len(sig))
+	}
+	// Must start with compressed-format header 0x39 that BouncyCastle checks.
+	if sig[0] != 0x39 {
+		t.Errorf("sig[0] = 0x%02x, want 0x39 (compressed Falcon header)", sig[0])
+	}
+
+	// Falcon signing is randomized — successive signatures must differ.
+	sig2, err := s.Sign(txID)
+	if err != nil {
+		t.Fatalf("Sign (2nd): %v", err)
+	}
+	if string(sig) == string(sig2) {
+		t.Error("two signatures are identical — randomness not advancing")
+	}
+
+	// Scheme / key accessors.
+	if s.SchemeName() != SchemeFNDSA512 {
+		t.Errorf("SchemeName = %q, want %q", s.SchemeName(), SchemeFNDSA512)
+	}
+	if s.PublicKeyHex() != kp.PublicKeyHex {
+		t.Error("PublicKeyHex mismatch")
+	}
+	if s.HexAddress() != kp.HexAddress {
+		t.Error("HexAddress mismatch")
+	}
+
+	// Address derived from the same h polynomial must match keygen output.
+	hexAddr, _ := addressFromPubBytes([]byte(func() []byte {
+		b, _ := hex.DecodeString(kp.PublicKeyHex)
+		return b
+	}()))
+	if hexAddr != kp.HexAddress {
+		t.Errorf("address re-derived from pubkey = %s, want %s", hexAddr, kp.HexAddress)
+	}
+
+	// Bad-input paths.
+	if _, err := s.Sign("nothex"); err == nil {
+		t.Error("expected error for non-hex txID")
+	}
+	if _, err := s.Sign("abcd"); err == nil {
+		t.Error("expected error for wrong-length txID")
+	}
+}
+
+func TestFalconSignerBadInput(t *testing.T) {
+	// Too-short SK.
+	if _, err := NewFalconSigner(strings.Repeat("ab", 100), strings.Repeat("cd", falconHLen)); err == nil {
+		t.Error("expected error for short SK")
+	}
+	// Too-short PK (h polynomial).
+	kp, _ := GenerateFalconKeypair()
+	if _, err := NewFalconSigner(kp.PrivateKeyHex, strings.Repeat("ab", 10)); err == nil {
+		t.Error("expected error for short h polynomial")
+	}
+}

--- a/tools/txgen/generate.go
+++ b/tools/txgen/generate.go
@@ -33,10 +33,8 @@ import (
 // inspectable in a text editor.
 //
 // Note on expiration: the node assigns expiration = head_block_time +
-// 60s by default for HTTP-built transactions. txgen does NOT extend
-// that, so generated txs must be broadcast quickly (within a minute on
-// mainnet pacing, longer on a slow private chain). If you need long
-// shelf-life txs, raise `block.maxTimeUntilExpiration` in node config.
+// 60s by default for HTTP-built transactions. txgen rewrites raw_data
+// before signing so generated transactions use cfg.Generate.ExpirationMillis.
 func runGenerate(ctx context.Context, cfg *Config) error {
 	if err := os.MkdirAll(cfg.Generate.OutputDir, 0o755); err != nil {
 		return err
@@ -309,6 +307,10 @@ func generateBatch(
 			unsigned, buildErr = node.CreateTRC20Transfer(ctx, sgn.senderHex, c20, receiver, cfg.Generate.TransferAmount, cfg.Generate.TRC20FeeLimit)
 		}
 		if buildErr != nil {
+			fail++
+			continue
+		}
+		if err := unsigned.ExtendExpiration(cfg.Generate.ExpirationMillis); err != nil {
 			fail++
 			continue
 		}

--- a/tools/txgen/generate.go
+++ b/tools/txgen/generate.go
@@ -155,10 +155,32 @@ func buildSigners(cfg *Config) (*signerSet, error) {
 	set := &signerSet{}
 
 	if pqcfg.Enabled {
-		ps, err := NewPQSigner(pqcfg.Scheme, pqcfg.Seed)
-		if err != nil {
-			return nil, fmt.Errorf("init pq signer: %w", err)
+		type pqSigner interface {
+			SchemeName() string
+			PublicKeyHex() string
+			HexAddress() string
+			Base58Address() string
+			Sign(txIDHex string) ([]byte, error)
 		}
+
+		var ps pqSigner
+		switch pqcfg.Scheme {
+		case SchemeMLDSA44:
+			s, err := NewPQSigner(pqcfg.Scheme, pqcfg.Seed)
+			if err != nil {
+				return nil, fmt.Errorf("init pq signer: %w", err)
+			}
+			ps = s
+		case SchemeFNDSA512:
+			s, err := NewFalconSigner(pqcfg.PrivateKey, pqcfg.PublicKey)
+			if err != nil {
+				return nil, fmt.Errorf("init falcon signer: %w", err)
+			}
+			ps = s
+		default:
+			return nil, fmt.Errorf("unsupported pq scheme %q", pqcfg.Scheme)
+		}
+
 		set.pqRatio = pqcfg.Ratio
 		set.pq = &signer{
 			senderHex: ps.HexAddress(),

--- a/tools/txgen/keygen.go
+++ b/tools/txgen/keygen.go
@@ -1,0 +1,107 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
+	"strings"
+)
+
+// runKeygen generates a post-quantum keypair and writes it to stdout or a file.
+//
+// For FN_DSA_512 this requires the binary to be built with the `falcon` tag
+// (make build-txgen-falcon). The generated JSON contains the private key, the
+// on-chain public key (896-byte h polynomial), and the derived TRON address.
+//
+// Usage:
+//
+//	txgen keygen [--scheme FN_DSA_512] [--out falcon-keypair.json]
+//
+// The output JSON can be used in txgen.json as:
+//
+//	"pq": {
+//	    "enabled": true,
+//	    "scheme": "FN_DSA_512",
+//	    "privateKey": "<from keypair JSON>",
+//	    "publicKey":  "<from keypair JSON>"
+//	}
+func runKeygen(args []string) error {
+	scheme := SchemeFNDSA512
+	outPath := ""
+
+	for i := 0; i < len(args); i++ {
+		switch args[i] {
+		case "--scheme", "-scheme":
+			if i+1 >= len(args) {
+				return fmt.Errorf("--scheme requires a value")
+			}
+			i++
+			scheme = strings.ToUpper(args[i])
+		case "--out", "-out", "-o":
+			if i+1 >= len(args) {
+				return fmt.Errorf("--out requires a path")
+			}
+			i++
+			outPath = args[i]
+		default:
+			return fmt.Errorf("unknown keygen flag %q", args[i])
+		}
+	}
+
+	switch scheme {
+	case SchemeFNDSA512:
+		return runFalconKeygen(outPath)
+	default:
+		return fmt.Errorf("unsupported scheme %q for keygen (supported: FN_DSA_512)", scheme)
+	}
+}
+
+func runFalconKeygen(outPath string) error {
+	log.Printf("keygen: generating Falcon-512 keypair via liboqs…")
+	kp, err := GenerateFalconKeypair()
+	if err != nil {
+		return fmt.Errorf("keygen: %w", err)
+	}
+
+	raw, err := json.MarshalIndent(kp, "", "  ")
+	if err != nil {
+		return err
+	}
+
+	if outPath != "" {
+		if err := os.WriteFile(outPath, append(raw, '\n'), 0o600); err != nil {
+			return fmt.Errorf("keygen: write %s: %w", outPath, err)
+		}
+		log.Printf("keygen: keypair written to %s", outPath)
+	} else {
+		fmt.Printf("%s\n", raw)
+	}
+
+	fmt.Fprintf(os.Stderr, `
+Falcon-512 keypair generated.
+TRON address: %s (%s)
+
+Before generating transactions, provision this account on-chain:
+  1. Fund the address (%s) with TRX (activation fee + transfer amount).
+  2. Call AccountPermissionUpdate to add the Falcon-512 public key:
+       public_key: %s...
+       weight: ≥ threshold
+
+Add to txgen.json generate.pq section:
+  "pq": {
+    "enabled": true,
+    "scheme": "FN_DSA_512",
+    "privateKey": %q,
+    "publicKey":  %q,
+    "ratio": 30
+  }
+`, kp.Base58Address, kp.HexAddress,
+		kp.Base58Address,
+		kp.PublicKeyHex[:32],
+		kp.PrivateKeyHex,
+		kp.PublicKeyHex,
+	)
+
+	return nil
+}

--- a/tools/txgen/main.go
+++ b/tools/txgen/main.go
@@ -51,6 +51,7 @@ Subcommands:
   generate     Build + sign synthetic txs → CSV files (receivers auto-generated)
   broadcast    Replay generated CSV at a target TPS → report
   statistic    Compute on-chain TPS for a block range
+  keygen       Generate a post-quantum keypair (FN_DSA_512 requires build-txgen-falcon)
   help         Print this help
 
 Flags:
@@ -67,6 +68,12 @@ func main() {
 	switch os.Args[1] {
 	case "help", "-h", "--help":
 		fmt.Print(usage)
+		return
+	case "keygen":
+		// keygen does not use a config file; parse its own flags.
+		if err := runKeygen(os.Args[2:]); err != nil {
+			log.Fatal(err)
+		}
 		return
 	case "generate", "broadcast", "statistic":
 		// known subcommand; validated here so the os.Exit below runs

--- a/tools/txgen/node.go
+++ b/tools/txgen/node.go
@@ -13,8 +13,9 @@ import (
 	"strings"
 	"time"
 
-	tronpb "github.com/tronprotocol/tron-deployment/internal/dbfork/proto/pb"
 	"google.golang.org/protobuf/proto"
+
+	tronpb "github.com/tronprotocol/tron-deployment/internal/dbfork/proto/pb"
 )
 
 // NodeClient wraps the subset of java-tron's HTTP API needed by txgen:

--- a/tools/txgen/node.go
+++ b/tools/txgen/node.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
@@ -11,6 +12,9 @@ import (
 	"net/http"
 	"strings"
 	"time"
+
+	tronpb "github.com/tronprotocol/tron-deployment/internal/dbfork/proto/pb"
+	"google.golang.org/protobuf/proto"
 )
 
 // NodeClient wraps the subset of java-tron's HTTP API needed by txgen:
@@ -190,6 +194,71 @@ func parseUnsigned(respBytes []byte) (*UnsignedTx, error) {
 	}
 	u.Raw = append([]byte{}, respBytes...)
 	return &u, nil
+}
+
+// ExtendExpiration rewrites raw_data.expiration before signing, then refreshes
+// raw_data_hex and txID so signatures cover the updated transaction body.
+func (u *UnsignedTx) ExtendExpiration(expirationMillis int64) error {
+	if expirationMillis <= 0 {
+		return nil
+	}
+	rawBytes, err := hex.DecodeString(u.RawDataHex)
+	if err != nil {
+		return fmt.Errorf("decode raw_data_hex: %w", err)
+	}
+	var raw tronpb.TransactionRaw
+	if err := proto.Unmarshal(rawBytes, &raw); err != nil {
+		return fmt.Errorf("decode raw_data proto: %w", err)
+	}
+	if raw.Timestamp <= 0 {
+		return errors.New("raw_data timestamp is missing")
+	}
+	raw.Expiration = raw.Timestamp + expirationMillis
+	updatedRaw, err := proto.Marshal(&raw)
+	if err != nil {
+		return fmt.Errorf("encode raw_data proto: %w", err)
+	}
+	sum := sha256.Sum256(updatedRaw)
+	rawHex := hex.EncodeToString(updatedRaw)
+	txID := hex.EncodeToString(sum[:])
+
+	var obj map[string]json.RawMessage
+	if err := json.Unmarshal(u.Raw, &obj); err != nil {
+		return fmt.Errorf("decode unsigned tx json: %w", err)
+	}
+	rawHexJSON, err := json.Marshal(rawHex)
+	if err != nil {
+		return err
+	}
+	txIDJSON, err := json.Marshal(txID)
+	if err != nil {
+		return err
+	}
+	var rawObj map[string]json.RawMessage
+	if err := json.Unmarshal(obj["raw_data"], &rawObj); err != nil {
+		return fmt.Errorf("decode raw_data json: %w", err)
+	}
+	expirationJSON, err := json.Marshal(raw.Expiration)
+	if err != nil {
+		return err
+	}
+	rawObj["expiration"] = expirationJSON
+	rawObjJSON, err := json.Marshal(rawObj)
+	if err != nil {
+		return fmt.Errorf("encode raw_data json: %w", err)
+	}
+	obj["raw_data"] = rawObjJSON
+	obj["raw_data_hex"] = rawHexJSON
+	obj["txID"] = txIDJSON
+	updatedTx, err := json.Marshal(obj)
+	if err != nil {
+		return fmt.Errorf("encode unsigned tx json: %w", err)
+	}
+
+	u.RawDataHex = rawHex
+	u.TxID = txID
+	u.Raw = updatedTx
+	return nil
 }
 
 func (c *NodeClient) post(ctx context.Context, path string, body any) ([]byte, error) {


### PR DESCRIPTION
## Summary

- **Falcon-512 signing** (`tools/txgen`): add `FN_DSA_512` scheme support via liboqs CGO binding (`//go:build falcon`). Wire-format compatible with java-tron's BouncyCastle verifier — compressed signature (header `0x39`), 896-byte h-polynomial public key, `0x41 ‖ Keccak-256(h)[12..32]` address derivation.
- **`expirationMillis` config field**: override transaction expiry window (default 1 day) per run; useful for short-lived private-net stress tests.
- **Configurable broadcast workers**: expose `broadcast.workers` in txgen config (previously always auto-derived).
- **`scripts/db_cp.sh`**: space-efficient local database backup — rsync for metadata, hard-links for `.sst` files. Documented in `knowledge/snapshots.md`.
- **CI / build**: `build-txgen-falcon` detects liboqs at build time and skips with `exit 0` when not found, so CI runners without liboqs do not fail. Default `build-txgen` remains pure Go, CGO-free, cross-compile-friendly.

## Build

```bash
# Default (pure Go, no CGO, all platforms)
make build-txgen

# With Falcon-512 support (requires liboqs ≥ 0.10)
brew install liboqs      # macOS
make build-txgen-falcon  # → bin/txgen with FN_DSA_512
```

## Test plan

- [ ] `go test ./tools/txgen/...` passes (ML-DSA-44 + stub path for FN_DSA_512)
- [ ] `go test ./internal/knowledge/...` passes (knowledge mirror in sync)
- [ ] `golangci-lint run ./...` clean
- [ ] `make build-txgen-falcon` on macOS with liboqs installed builds successfully
- [ ] `make build-txgen-falcon` without liboqs prints skip warning and exits 0
- [ ] `db_cp` smoke test: copy a small LevelDB dir, verify `.sst` hard-linked (`stat` shows `nlink > 1`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)