### PR TITLE
feat(status): echo resolved build revision in status/inspect (ai-ops B1)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -168,6 +168,11 @@ trond status my-fullnode -o json
   the container, not stdout). `runtime=jar`: `journalctl -u <unit>`.
 - `api_endpoints.http` is the private-net RPC — point read-only on-chain
   readers (e.g. `tron-toolkit`) at it for the verify half of a loop.
+- `build_revision` (+ `build_cache_key`) — for a node built from source
+  (intent `build:` block), the resolved java-tron git revision (short
+  12-hex) it's running, so an agent never has to assume which commit is
+  deployed. Present in `status` / `inspect -o json`; `list` carries the
+  raw `build_cache_key`. Absent for pre-built image/jar nodes.
 - `chain_id` is NOT yet emitted (TRON's chain id is genesis-derived, not
   a single cheap RPC field) — tracked in TODOS.md.
 

--- a/TODOS.md
+++ b/TODOS.md
@@ -24,6 +24,28 @@ up cold.
 - **Depends on / blocked by:** B3 (`snapshot clone`) landing first; a
   runtime-aware DB-path resolver (docker storage path is not in state today).
 
+## Reconcile `scripts/db_cp.sh` with `trond snapshot clone`
+
+- **What:** There are now TWO "fast local chain-DB copy" mechanisms: the
+  Go `trond snapshot clone` verb (copy-on-write via APFS clonefile / Linux
+  FICLONE, byte-copy fallback) added in #192, and `scripts/db_cp.sh`
+  (rsync for metadata + hard-link for `.sst`) added in #194 (bladehan1).
+  Pick one story and converge.
+- **Why:** two overlapping capabilities drift and confuse — an agent/operator
+  shouldn't have to guess which to use for a warm-pool fixture.
+- **Options:** (a) teach `snapshot clone` a hard-link tier (between CoW and
+  full byte copy) so `.sst` files share inodes when CoW is unavailable, then
+  retire `db_cp.sh`; or (b) have `db_cp.sh` shell out to `trond snapshot
+  clone`; or (c) explicitly document them as distinct (CoW clone vs
+  hard-link backup) if the use cases really differ.
+- **Context:** flagged 2026-06-17 after #194 merged. `internal/fsclone`
+  owns the CoW primitive; `db_cp.sh` is a standalone shell script referenced
+  in `knowledge/snapshots.md`. Hard-links and CoW have different semantics
+  (hard-link shares the inode → a later in-place write to one copy corrupts
+  the other; CoW is independent), so reconciling needs care, not a blind
+  merge.
+- **Depends on / blocked by:** nothing; both already merged.
+
 ## Emit `chain_id` in `status` / `inspect` -o json
 
 - **What:** The ai-ops A1 ask lists `chain_id` in the per-node `status

--- a/cmd/inspect.go
+++ b/cmd/inspect.go
@@ -184,6 +184,15 @@ func manifestForNode(ctx context.Context, n *state.ManagedNode) map[string]any {
 		"logs": apply.LogsDescriptor(n),
 	}
 
+	// Build identity (B1): cache key + resolved git revision for
+	// source-built nodes, so an agent knows which commit is running.
+	if n.BuildCacheKey != "" {
+		entry["build_cache_key"] = n.BuildCacheKey
+		if rev := n.BuildRevision(); rev != "" {
+			entry["build_revision"] = rev
+		}
+	}
+
 	// Best-effort container IP + ID for docker nodes — only attempted if
 	// the node is local; SSH inspect would need a remote docker call which
 	// pulls in target resolution. The test harness usually runs on the

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -94,6 +94,17 @@ func runStatus(cmd *cobra.Command, args []string) error {
 		},
 	}
 
+	// Build identity (B1): when the node was built from source, surface the
+	// content-addressed cache key AND the resolved git revision, so an agent
+	// knows exactly which java-tron commit is running without assuming.
+	// Omitted entirely for nodes that consumed a pre-built image/jar.
+	if node.BuildCacheKey != "" {
+		statusInfo["build_cache_key"] = node.BuildCacheKey
+		if rev := node.BuildRevision(); rev != "" {
+			statusInfo["build_revision"] = rev
+		}
+	}
+
 	// Resolve the target at most once, and only when we actually need it.
 	// Resolving is cheap for a local target but opens an SSH connection for
 	// an ssh one — and SSHTarget.Connect() is NOT bound by the 3s context

--- a/cmd/status_build_test.go
+++ b/cmd/status_build_test.go
@@ -1,0 +1,79 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/tronprotocol/tron-deployment/internal/paths"
+	"github.com/tronprotocol/tron-deployment/internal/state"
+)
+
+// statusJSON seeds a single node, runs `status <name> -o json` (stopped jar
+// → no probe, no docker), and returns the parsed map.
+func statusJSON(t *testing.T, node state.ManagedNode) map[string]any {
+	t.Helper()
+	paths.SetBaseDir(t.TempDir())
+	t.Cleanup(func() { paths.SetBaseDir("") })
+	store, err := state.NewStore(paths.State())
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	if err := store.Save(&state.DeploymentState{Version: 1, Nodes: []state.ManagedNode{node}}); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	c := &cobra.Command{}
+	c.Flags().String("output", "json", "")
+	c.SetContext(context.Background())
+	old := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+	runErr := runStatus(c, []string{node.Name})
+	_ = w.Close()
+	os.Stdout = old
+	out, _ := io.ReadAll(r)
+	if runErr != nil {
+		t.Fatalf("runStatus: %v", runErr)
+	}
+	var m map[string]any
+	if err := json.Unmarshal(out, &m); err != nil {
+		t.Fatalf("status JSON: %v\n%s", err, out)
+	}
+	return m
+}
+
+// TestRunStatus_EmitsBuildIdentity is the B1 wire test: a source-built node
+// surfaces build_cache_key + a clean build_revision, so an agent knows which
+// commit is running.
+func TestRunStatus_EmitsBuildIdentity(t *testing.T) {
+	m := statusJSON(t, state.ManagedNode{
+		Name: "fn0", Status: "stopped", Runtime: "jar",
+		BuildCacheKey: "abc123def456-b1234abcd", LastApplied: time.Now().UTC(),
+	})
+	if m["build_cache_key"] != "abc123def456-b1234abcd" {
+		t.Errorf("build_cache_key = %v; want the full key", m["build_cache_key"])
+	}
+	if m["build_revision"] != "abc123def456" {
+		t.Errorf("build_revision = %v; want abc123def456 (the cache-key prefix)", m["build_revision"])
+	}
+}
+
+// TestRunStatus_OmitsBuildIdentityForPrebuilt: a node that consumed a
+// pre-built image/jar (no cache key) must not carry build fields at all.
+func TestRunStatus_OmitsBuildIdentityForPrebuilt(t *testing.T) {
+	m := statusJSON(t, state.ManagedNode{
+		Name: "fn0", Status: "stopped", Runtime: "jar",
+		LastApplied: time.Now().UTC(),
+	})
+	if _, ok := m["build_cache_key"]; ok {
+		t.Errorf("build_cache_key must be absent for a pre-built node; got %v", m["build_cache_key"])
+	}
+	if _, ok := m["build_revision"]; ok {
+		t.Errorf("build_revision must be absent for a pre-built node; got %v", m["build_revision"])
+	}
+}

--- a/internal/mcp/tools_inspection.go
+++ b/internal/mcp/tools_inspection.go
@@ -20,6 +20,19 @@ import (
 
 type emptyArgs struct{}
 
+// addBuildIdentity adds build_cache_key + the resolved build_revision (B1)
+// to a row when the node was built from source. No-op for pre-built
+// image/jar nodes. Shared by list/status/inspect so the shape is identical.
+func addBuildIdentity(row map[string]any, n *state.ManagedNode) {
+	if n.BuildCacheKey == "" {
+		return
+	}
+	row["build_cache_key"] = n.BuildCacheKey
+	if rev := n.BuildRevision(); rev != "" {
+		row["build_revision"] = rev
+	}
+}
+
 type nodeArg struct {
 	Name string `json:"name" jsonschema:"name of the managed node (must match intent.name)"`
 }
@@ -74,6 +87,7 @@ func listNodes(ctx context.Context, _ *mcp.CallToolRequest, _ emptyArgs) (*mcp.C
 			"network":      n.Network,
 			"is_private":   intent.IsPrivate(n.Network),
 		}
+		addBuildIdentity(row, &n)
 		if len(n.Labels) > 0 {
 			row["labels"] = n.Labels
 		}
@@ -113,6 +127,7 @@ func statusForNode(ctx context.Context, _ *mcp.CallToolRequest, args nodeArg) (*
 		"healthy": false,
 		"logs":    apply.LogsDescriptor(node),
 	}
+	addBuildIdentity(out, node)
 	// Live probe + container_id — best effort, resolving the target at most
 	// once. We must not open an SSH connection just to read container_id
 	// from a stopped remote node (mcpResolveTargetFromNode.Connect() isn't
@@ -181,6 +196,7 @@ func inspectAllNodes(ctx context.Context, _ *mcp.CallToolRequest, _ emptyArgs) (
 			// the `status` tool, which already resolves a target.
 			"logs": apply.LogsDescriptor(&n),
 		}
+		addBuildIdentity(row, &n)
 		// Endpoints: we have HTTPPort/GRPCPort persisted in state from
 		// apply; cmd/inspect.go's enrichment with container_ip
 		// requires a live docker query, skipped for the static MCP

--- a/internal/schema/embed.go
+++ b/internal/schema/embed.go
@@ -80,7 +80,12 @@ import (
 //	        are collected into the `trond schema` manifest, so the manifest
 //	        surface changes for every command (additive). The C1 safety
 //	        boundary now covers all single-node mutations.
-const SchemaVersion = "1.11.0"
+//	1.12.0 — status + inspect output gain `build_cache_key` and a clean
+//	        `build_revision` (short git SHA); list output documents
+//	        `build_cache_key`. Lets an agent learn which java-tron commit a
+//	        node runs without assuming (ai-ops B1: echo the resolved SHA).
+//	        Additive optional fields, source-built nodes only.
+const SchemaVersion = "1.12.0"
 
 // JSONSchemaURLBase is the canonical URL prefix for individual output
 // schema files. Embedded $id values inside each schema mirror this so

--- a/internal/schema/files/inspect.schema.json
+++ b/internal/schema/files/inspect.schema.json
@@ -42,7 +42,9 @@
             }
           },
           "labels":       { "type": "object", "additionalProperties": { "type": "string" } },
-          "network":      { "type": "string" }
+          "network":      { "type": "string" },
+          "build_cache_key": { "type": "string", "description": "Content-addressed build cache key (source-built nodes only)." },
+          "build_revision":  { "type": "string", "pattern": "^[0-9a-f]{12}$", "description": "Resolved source git revision (short) the node was built from (source-built nodes only)." }
         }
       }
     }

--- a/internal/schema/files/list.schema.json
+++ b/internal/schema/files/list.schema.json
@@ -15,7 +15,8 @@
       "network":      { "type": "string" },
       "last_applied": { "type": "string", "format": "date-time" },
       "labels":       { "type": "object", "additionalProperties": { "type": "string" } },
-      "target_type":  { "type": "string", "enum": ["local", "ssh"] }
+      "target_type":  { "type": "string", "enum": ["local", "ssh"] },
+      "build_cache_key": { "type": "string", "description": "Content-addressed build cache key (source-built nodes only); its 12-hex prefix is the source git revision. status/inspect -o json also surface a clean build_revision." }
     }
   }
 }

--- a/internal/schema/files/status.schema.json
+++ b/internal/schema/files/status.schema.json
@@ -57,6 +57,16 @@
       "type": "boolean",
       "description": "True when network is 'private' — a self-contained chain safe for an unattended agent to mutate. Lets an automated caller PROVE a rig is private before acting. False when network is empty/unknown (fail-safe)."
     },
+    "build_cache_key": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{12}-b[0-9a-f]{8}(\\+dirty-[0-9a-f]{8})?(-x[0-9a-f]{8})?$",
+      "description": "Content-addressed cache key of the source build that produced this node's artifact (`<gitrev:12>-b<digest>[+dirty-...][-x...]`). Present only when the node was built from source (intent build: block); absent for pre-built image/jar nodes."
+    },
+    "build_revision": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{12}$",
+      "description": "Resolved source git revision (short, 12-hex) the node was built from — the leading segment of build_cache_key, surfaced separately so an agent knows which java-tron commit is running without parsing the compound key. Present only for source-built nodes."
+    },
     "healthy": {
       "type": "boolean",
       "description": "Liveness only: true when status=running AND the live getnowblock probe returned a REAL block (non-zero block timestamp — an empty or error-shaped 200 does not count). It means 'the RPC is serving blocks', NOT that the node is fully synced — use is_synced and block_height for sync health (healthy can be true while is_synced is false on a node whose tip is stale). False when stopped, unreachable, or the probe was skipped (fail-safe). Always present."

--- a/internal/schema/version_baseline.json
+++ b/internal/schema/version_baseline.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": "1.11.0",
+  "schema_version": "1.12.0",
   "entries": [
     {
       "name": "apply",
@@ -59,11 +59,11 @@
     },
     {
       "name": "inspect",
-      "hash": "98903914b1f632a16f719576afbd39e98c43cce5b41139451ea8665de191512f"
+      "hash": "edd4971f93c5810ca6e42969a48ee7a13a256e51ed36d88b8b1bbaa0e2148046"
     },
     {
       "name": "list",
-      "hash": "180fd09cefb57c2c511e3b6157ed2cf2238307836ed03dc529b395f725230764"
+      "hash": "0d13e578d62cd50cff0f520ef3ed4325b181eeb96dd3b9965d4faf8d2d1418dc"
     },
     {
       "name": "network-create",
@@ -119,7 +119,7 @@
     },
     {
       "name": "status",
-      "hash": "d10f5c4ab65e7fa711d5fd4a725db82b5b8717f568b2e41431cebede4c629223"
+      "hash": "3eb693e6f168eace4bd2720913690a5c88482b2d249cf4b958cd62386f2119ba"
     },
     {
       "name": "verify",

--- a/internal/state/build_revision_test.go
+++ b/internal/state/build_revision_test.go
@@ -1,0 +1,28 @@
+package state
+
+import "testing"
+
+func TestManagedNode_BuildRevision(t *testing.T) {
+	cases := []struct {
+		name     string
+		cacheKey string
+		want     string
+	}{
+		{"clean build", "abc123def456-b1234abcd", "abc123def456"},
+		{"dirty build", "abc123def456-b1234abcd+dirty-deadbeef", "abc123def456"},
+		{"patched build", "0123456789ab-bcafef0012-xdeadbeef", "0123456789ab"},
+		{"no build (pre-built image/jar)", "", ""},
+		{"non-hex prefix rejected", "nothex123456-b1234abcd", ""},
+		{"short prefix rejected", "abc-b1234abcd", ""},
+		{"uppercase rejected", "ABC123DEF456-b1234abcd", ""},
+		{"prefix-only, no -b", "abc123def456", "abc123def456"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			n := ManagedNode{BuildCacheKey: tc.cacheKey}
+			if got := n.BuildRevision(); got != tc.want {
+				t.Errorf("BuildRevision(%q) = %q, want %q", tc.cacheKey, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/state/types.go
+++ b/internal/state/types.go
@@ -1,6 +1,9 @@
 package state
 
-import "time"
+import (
+	"strings"
+	"time"
+)
 
 // ManagedNode represents a deployed node tracked in the state file.
 type ManagedNode struct {
@@ -47,6 +50,27 @@ type ManagedNode struct {
 
 	// Monitoring tracks the deployed monitoring stack for this node.
 	Monitoring *MonitoringState `json:"monitoring,omitempty"`
+}
+
+// BuildRevision returns the resolved source git revision (short, 12-hex)
+// recorded in the build cache key, or "" when the node wasn't built from
+// source (consumed a pre-built image/jar). The cache key is constructed as
+// "<gitRevision[:12]>-b<digest>[+dirty-...][-x...]" (internal/build/key.go),
+// so the revision is the leading hex segment before the first '-'. Lets an
+// agent learn which java-tron commit a node is running without parsing the
+// compound cache key itself.
+func (n ManagedNode) BuildRevision() string {
+	if n.BuildCacheKey == "" {
+		return ""
+	}
+	rev := n.BuildCacheKey
+	if i := strings.IndexByte(rev, '-'); i >= 0 {
+		rev = rev[:i]
+	}
+	if len(rev) != 12 || strings.TrimLeft(rev, "0123456789abcdef") != "" {
+		return ""
+	}
+	return rev
 }
 
 // MonitoringState records the Prometheus + Grafana stack deployed

--- a/schemas/output/inspect.schema.json
+++ b/schemas/output/inspect.schema.json
@@ -42,7 +42,9 @@
             }
           },
           "labels":       { "type": "object", "additionalProperties": { "type": "string" } },
-          "network":      { "type": "string" }
+          "network":      { "type": "string" },
+          "build_cache_key": { "type": "string", "description": "Content-addressed build cache key (source-built nodes only)." },
+          "build_revision":  { "type": "string", "pattern": "^[0-9a-f]{12}$", "description": "Resolved source git revision (short) the node was built from (source-built nodes only)." }
         }
       }
     }

--- a/schemas/output/list.schema.json
+++ b/schemas/output/list.schema.json
@@ -15,7 +15,8 @@
       "network":      { "type": "string" },
       "last_applied": { "type": "string", "format": "date-time" },
       "labels":       { "type": "object", "additionalProperties": { "type": "string" } },
-      "target_type":  { "type": "string", "enum": ["local", "ssh"] }
+      "target_type":  { "type": "string", "enum": ["local", "ssh"] },
+      "build_cache_key": { "type": "string", "description": "Content-addressed build cache key (source-built nodes only); its 12-hex prefix is the source git revision. status/inspect -o json also surface a clean build_revision." }
     }
   }
 }

--- a/schemas/output/status.schema.json
+++ b/schemas/output/status.schema.json
@@ -57,6 +57,16 @@
       "type": "boolean",
       "description": "True when network is 'private' — a self-contained chain safe for an unattended agent to mutate. Lets an automated caller PROVE a rig is private before acting. False when network is empty/unknown (fail-safe)."
     },
+    "build_cache_key": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{12}-b[0-9a-f]{8}(\\+dirty-[0-9a-f]{8})?(-x[0-9a-f]{8})?$",
+      "description": "Content-addressed cache key of the source build that produced this node's artifact (`<gitrev:12>-b<digest>[+dirty-...][-x...]`). Present only when the node was built from source (intent build: block); absent for pre-built image/jar nodes."
+    },
+    "build_revision": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{12}$",
+      "description": "Resolved source git revision (short, 12-hex) the node was built from — the leading segment of build_cache_key, surfaced separately so an agent knows which java-tron commit is running without parsing the compound key. Present only for source-built nodes."
+    },
     "healthy": {
       "type": "boolean",
       "description": "Liveness only: true when status=running AND the live getnowblock probe returned a REAL block (non-zero block timestamp — an empty or error-shaped 200 does not count). It means 'the RPC is serving blocks', NOT that the node is fully synced — use is_synced and block_height for sync health (healthy can be true while is_synced is false on a node whose tip is stale). False when stopped, unreachable, or the probe was skipped (fail-safe). Always present."


### PR DESCRIPTION
## What

`status` and `inspect -o json` now surface the java-tron commit a **source-built** node is running, so an agent never has to assume which version is deployed — the ai-ops **B1** corollary ("pin to the exact commit SHA, and make `status --json` echo it").

```
trond status fn0 -o json
→ { ..., "build_cache_key": "deadbeef0123-bcafe0011", "build_revision": "deadbeef0123" }
```

- **`state.ManagedNode.BuildRevision()`** derives the short 12-hex git revision from the existing `build_cache_key` (`<gitrev:12>-b<digest>[+dirty-...][-x...]`, per `internal/build/key.go`). **No new state field, no change to the apply/deploy path** — smallest diff that cleanly answers the ask, and it works for every already-built node including legacy ones.
- **`status` + `inspect`** (CLI + MCP) emit `build_cache_key` + the clean `build_revision`. **`list`** emits/documents the raw `build_cache_key` (it marshals `ManagedNode` directly; the method-derived `build_revision` would require reshaping its output). All fields are omitted for nodes that consumed a pre-built image/jar.
- **Schemas:** `status`/`inspect` gain both fields; `list` documents the `build_cache_key` it already emitted. `SchemaVersion` 1.11.0 → **1.12.0** (additive); baseline regenerated.

## Also

Logs a TODO to reconcile `scripts/db_cp.sh` (#194's hard-link DB backup) with `trond snapshot clone` (#192's CoW clone) — two overlapping fast-local-DB-copy mechanisms. Flagged the key caveat: hard-links share an inode (a later in-place write corrupts both copies — unsafe for independent fixtures), whereas CoW is independent. Not merged blindly.

## Tests

`go vet` + `golangci-lint` clean. `BuildRevision` unit table (clean / dirty / patched / non-hex / short / uppercase / empty), plus `status` wire tests for **present** (source-built) and **absent** (pre-built) build identity. Live-binary smoke confirmed `status -o json` emits both fields.

## Context

This closes the one concrete ai-ops doc ask that was falling through the cracks (B1's "echo the resolved SHA in status"). Remaining ai-ops follow-ups are all tracked in TODOS.md (`chain_id`, proper `--from-node`, multi-node `--require-private`, the `db_cp.sh` reconciliation).