### PR TITLE
feat(safety): enforce --require-private on multi-node mutators (chaos + network ops)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -643,9 +643,11 @@ An automated caller that should only ever touch a throwaway private chain
   fail-safe-refused with a re-apply hint.
 
 The read-only verbs (`status`, `wait`, `inspect`, `list`, `diagnose`)
-never mutate and are always safe. The multi-node mutators (chaos
-`disconnect`/`partition`, `network add`/`destroy`/`upgrade`) are not yet
-gated — a tracked TODO; gate them via the `is_private` query meanwhile.
+never mutate and are always safe. The multi-node mutators are now gated
+too: the chaos primitives (`disconnect`/`connect`/`partition`/`heal`) and
+`network add`/`destroy`/`upgrade` refuse unless EVERY node they touch is
+private, naming the first offender. So with `TROND_REQUIRE_PRIVATE=1` set,
+no trond verb — single-node or multi-node — will mutate a non-private rig.
 
 > ⚠️ **`network` means two things across commands.** In `apply` / `status`
 > / `list` / `inspect` it is the chain kind (`mainnet|nile|private`,

--- a/TODOS.md
+++ b/TODOS.md
@@ -66,25 +66,6 @@ up cold.
   the value is deterministic from the genesis the intent pins, so it
   doubles as a B1 "echo the resolved rig identity" signal.
 
-## `--require-private` on the multi-node mutators (chaos + network ops)
-
-- **What:** Extend the `--require-private` / `TROND_REQUIRE_PRIVATE` gate to
-  the chaos primitives (`disconnect` / `partition` / `connect` / `heal`) and
-  the network ops (`network add` / `destroy` / `upgrade`).
-- **Why:** These mutate a rig too, so an airtight "an agent can't touch a
-  non-private net" boundary needs them. The per-node mutators
-  (start/stop/restart/remove/rollback/upgrade) + apply + network-create are
-  already gated via `internal/guard`.
-- **Cons / why deferred:** they operate on MULTIPLE nodes or a whole network,
-  so it isn't the per-node one-liner — it needs an "are ALL involved nodes
-  private?" check (chaos spans 2+ nodes; `network destroy`/`add` span the
-  network's node set). Different guard shape from the single-node path.
-- **Context:** deferred during the 2026-06-17 `/plan-eng-review` of the
-  per-node `--require-private` rollout. The shared predicate + error live in
-  `internal/guard` (`Enforce`/`EnforceArg`/`Requested`); a multi-node guard
-  would iterate the involved nodes and call `guard.Enforce` per node.
-- **Depends on / blocked by:** the per-node rollout landing (this PR).
-
 ## Rename `network-create`'s `network` output field
 
 - **What:** `network create -o json` returns `network` = the network's intent

--- a/cmd/chaos.go
+++ b/cmd/chaos.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/tronprotocol/tron-deployment/internal/guard"
 	"github.com/tronprotocol/tron-deployment/internal/output"
 	"github.com/tronprotocol/tron-deployment/internal/state"
 )
@@ -113,6 +114,14 @@ func chaosPair(ctx context.Context, op, a, b string) error {
 	if nodeB == nil {
 		return output.NewError("NODE_NOT_FOUND", output.ExitGeneralError, "node "+b+" not found in state")
 	}
+	// --require-private: both endpoints must be private before we touch the
+	// rig's network. Uses the already-loaded nodes (no extra state read).
+	if err := guard.EnforceNodes([]guard.NodeRef{
+		{Name: nodeA.Name, Network: nodeA.Network},
+		{Name: nodeB.Name, Network: nodeB.Network},
+	}); err != nil {
+		return err
+	}
 	// Chaos works through "docker network ..." on the local host. Both jar
 	// runtime and SSH targets fall outside that — the harness should reach
 	// for tc / iptables on those.
@@ -205,6 +214,18 @@ func chaosGroups(ctx context.Context, op, spec string) error {
 	if len(groups) < 2 {
 		return output.NewError("VALIDATION_ERROR", output.ExitValidationError,
 			"--groups must contain at least two groups separated by '|'")
+	}
+
+	// --require-private: enforce across EVERY node in the spec up front, so
+	// a non-private member refuses with one clean error before any pair is
+	// touched (chaosGroups accumulates per-pair errors and continues, so a
+	// per-pair guard alone would partially apply / spam errors).
+	var allNodes []string
+	for _, g := range groups {
+		allNodes = append(allNodes, g...)
+	}
+	if err := requirePrivateForNodes(allNodes...); err != nil {
+		return err
 	}
 
 	var pairs [][2]string

--- a/cmd/network/add.go
+++ b/cmd/network/add.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/tronprotocol/tron-deployment/internal/guard"
 	"github.com/tronprotocol/tron-deployment/internal/intent"
 	"github.com/tronprotocol/tron-deployment/internal/output"
 	"github.com/tronprotocol/tron-deployment/internal/paths"
@@ -61,6 +62,11 @@ func runAdd(cmd *cobra.Command, args []string) error {
 			"network add expects an intent with exactly one node entry")
 	}
 	node := &parsed.Nodes[0]
+
+	// --require-private: refuse to add a node on a non-private network.
+	if err := guard.Enforce(parsed.Network); err != nil {
+		return err
+	}
 
 	// Pick the next free index. Existing entries are "<network>-node<N>"; we
 	// rescan state instead of trusting any in-memory counter so the operation

--- a/cmd/network/destroy.go
+++ b/cmd/network/destroy.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/tronprotocol/tron-deployment/internal/guard"
 	"github.com/tronprotocol/tron-deployment/internal/output"
 	"github.com/tronprotocol/tron-deployment/internal/paths"
 	"github.com/tronprotocol/tron-deployment/internal/runtime"
@@ -64,6 +65,19 @@ func runDestroy(cmd *cobra.Command, args []string) error {
 			"no network named "+destroyConfirm+" — nothing to destroy").
 			WithSuggestions("Run: trond network status",
 				"Run: trond list  (to see all managed nodes)")
+	}
+
+	// --require-private: every node in the network must be private before we
+	// tear anything down. Gathered from the same prefix match used above so
+	// the refusal happens before any node is removed.
+	var refs []guard.NodeRef
+	for _, n := range deployState.Nodes {
+		if strings.HasPrefix(n.Name, prefix) || n.Name == destroyConfirm {
+			refs = append(refs, guard.NodeRef{Name: n.Name, Network: n.Network})
+		}
+	}
+	if err := guard.EnforceNodes(refs); err != nil {
+		return err
 	}
 
 	workDir := paths.Deployments()

--- a/cmd/network/require_private_test.go
+++ b/cmd/network/require_private_test.go
@@ -1,0 +1,83 @@
+package network
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/tronprotocol/tron-deployment/internal/guard"
+	"github.com/tronprotocol/tron-deployment/internal/output"
+	"github.com/tronprotocol/tron-deployment/internal/paths"
+	"github.com/tronprotocol/tron-deployment/internal/state"
+)
+
+// seedNetwork writes a "<network>-nodeN" set to an isolated state dir and
+// turns the gate on (restored after). The multi-node guard fires before any
+// docker/fs work, so refusal is hermetic.
+func seedNetwork(t *testing.T, network string, networks ...string) {
+	t.Helper()
+	paths.SetBaseDir(t.TempDir())
+	t.Cleanup(func() { paths.SetBaseDir("") })
+	store, err := state.NewStore(paths.State())
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	nodes := make([]state.ManagedNode, 0, len(networks))
+	for i, net := range networks {
+		nodes = append(nodes, state.ManagedNode{
+			Name:        network + "-node" + string(rune('0'+i)),
+			Status:      "running",
+			Runtime:     "docker",
+			Network:     net,
+			Target:      state.NodeTarget{Type: "local"},
+			LastApplied: time.Now().UTC(),
+		})
+	}
+	if err := store.Save(&state.DeploymentState{Version: 1, Nodes: nodes}); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	old := guard.FlagValue
+	guard.FlagValue = true
+	t.Cleanup(func() { guard.FlagValue = old })
+}
+
+func wantPrivReq(t *testing.T, err error) {
+	t.Helper()
+	if err == nil {
+		t.Fatal("expected PRIVATE_NETWORK_REQUIRED, got nil")
+	}
+	var se *output.StructuredError
+	if !errors.As(err, &se) {
+		t.Fatalf("expected *output.StructuredError, got %T: %v", err, err)
+	}
+	if se.Code != "PRIVATE_NETWORK_REQUIRED" || se.ExitCode != output.ExitValidationError {
+		t.Errorf("got code=%q exit=%d; want PRIVATE_NETWORK_REQUIRED/%d", se.Code, se.ExitCode, output.ExitValidationError)
+	}
+}
+
+func newNetCmd() *cobra.Command {
+	c := &cobra.Command{}
+	c.SetContext(context.Background())
+	c.Flags().String("output", "json", "")
+	return c
+}
+
+// TestNetworkDestroy_RefusesNonPrivate: destroy refuses (before removing
+// anything) when any node in the network is non-private.
+func TestNetworkDestroy_RefusesNonPrivate(t *testing.T) {
+	seedNetwork(t, "rig", "private", "mainnet")
+	old := destroyConfirm
+	destroyConfirm = "rig" // satisfy the confirm gate; identity comes from it
+	t.Cleanup(func() { destroyConfirm = old })
+	wantPrivReq(t, runDestroy(newNetCmd(), nil))
+}
+
+// TestNetworkUpgrade_RefusesNonPrivate: network upgrade refuses (before any
+// stop/upgrade) when any node in the network is non-private.
+func TestNetworkUpgrade_RefusesNonPrivate(t *testing.T) {
+	seedNetwork(t, "rig", "private", "mainnet")
+	wantPrivReq(t, runUpgrade(newNetCmd(), []string{"rig"}))
+}

--- a/cmd/network/upgrade.go
+++ b/cmd/network/upgrade.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/tronprotocol/tron-deployment/internal/guard"
 	"github.com/tronprotocol/tron-deployment/internal/output"
 	"github.com/tronprotocol/tron-deployment/internal/paths"
 	"github.com/tronprotocol/tron-deployment/internal/state"
@@ -115,6 +116,22 @@ func runUpgrade(cmd *cobra.Command, args []string) error {
 			fmt.Sprintf("no nodes found for network %q", networkName)).
 			WithSuggestions("Run `trond network status` to list deployed networks",
 				"Confirm the network name matches the intent's .name field used with `network create`")
+	}
+
+	// --require-private: every node in the network must be private before we
+	// stop/upgrade/restart any of them. Gather refs for the classified set.
+	inNetwork := make(map[string]bool, len(witnesses)+len(fullnodes))
+	for _, name := range append(append([]string{}, witnesses...), fullnodes...) {
+		inNetwork[name] = true
+	}
+	var refs []guard.NodeRef
+	for _, n := range st.Nodes {
+		if inNetwork[n.Name] {
+			refs = append(refs, guard.NodeRef{Name: n.Name, Network: n.Network})
+		}
+	}
+	if err := guard.EnforceNodes(refs); err != nil {
+		return err
 	}
 
 	order := append([]string{}, fullnodes...)

--- a/cmd/require_private_multinode_test.go
+++ b/cmd/require_private_multinode_test.go
@@ -1,0 +1,57 @@
+package cmd
+
+import (
+	"testing"
+	"time"
+
+	"github.com/tronprotocol/tron-deployment/internal/guard"
+	"github.com/tronprotocol/tron-deployment/internal/paths"
+	"github.com/tronprotocol/tron-deployment/internal/state"
+)
+
+// seedNodes writes several nodes to an isolated state dir and turns the
+// gate on (restored after). The multi-node guard fires before any docker
+// work, so refusal is hermetic.
+func seedNodes(t *testing.T, nodes ...state.ManagedNode) {
+	t.Helper()
+	paths.SetBaseDir(t.TempDir())
+	t.Cleanup(func() { paths.SetBaseDir("") })
+	store, err := state.NewStore(paths.State())
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	if err := store.Save(&state.DeploymentState{Version: 1, Nodes: nodes}); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	old := guard.FlagValue
+	guard.FlagValue = true
+	t.Cleanup(func() { guard.FlagValue = old })
+}
+
+func dockerNode(name, network string) state.ManagedNode {
+	return state.ManagedNode{
+		Name: name, Status: "running", Runtime: "docker",
+		Network: network, Target: state.NodeTarget{Type: "local"},
+		LastApplied: time.Now().UTC(),
+	}
+}
+
+// TestChaosDisconnect_RefusesNonPrivate: disconnect refuses (before any
+// docker work) when either endpoint is non-private, naming the offender.
+func TestChaosDisconnect_RefusesNonPrivate(t *testing.T) {
+	seedNodes(t, dockerNode("a", "private"), dockerNode("b", "mainnet"))
+	err := runDisconnect(newCmd(), []string{"a", "b"})
+	wantPrivateRequired(t, err)
+}
+
+// TestChaosPartition_RefusesNonPrivate: partition guards every node in the
+// --groups spec up front, so one non-private member refuses cleanly with no
+// partial application.
+func TestChaosPartition_RefusesNonPrivate(t *testing.T) {
+	seedNodes(t, dockerNode("a", "private"), dockerNode("b", "private"),
+		dockerNode("c", "mainnet"), dockerNode("d", "private"))
+	old := partitionGroups
+	partitionGroups = "a,b|c,d"
+	t.Cleanup(func() { partitionGroups = old })
+	wantPrivateRequired(t, runPartition(newCmd(), nil))
+}

--- a/cmd/resolve.go
+++ b/cmd/resolve.go
@@ -74,6 +74,34 @@ func requirePrivateForNode(name string) error {
 	return guard.Enforce(node.Network)
 }
 
+// requirePrivateForNodes is the multi-node analog of requirePrivateForNode
+// (chaos partition/heal touch many nodes at once). It loads state ONCE,
+// resolves each named node's recorded network, and enforces the gate across
+// all of them up front — so a non-private node in the set refuses BEFORE any
+// partial mutation. Missing nodes are skipped here; the command's own
+// resolution emits the canonical NODE_NOT_FOUND. Fast path: no state read
+// when the gate is off.
+func requirePrivateForNodes(names ...string) error {
+	if !guard.Requested() {
+		return nil
+	}
+	store, err := state.NewStore(statePath())
+	if err != nil {
+		return err
+	}
+	deployState, err := store.Load()
+	if err != nil {
+		return err
+	}
+	refs := make([]guard.NodeRef, 0, len(names))
+	for _, name := range names {
+		if n := store.GetNode(deployState, name); n != nil {
+			refs = append(refs, guard.NodeRef{Name: n.Name, Network: n.Network})
+		}
+	}
+	return guard.EnforceNodes(refs)
+}
+
 // resolveNodeContext loads a node from state and constructs its target and runtime.
 func resolveNodeContext(name string) (*nodeContext, error) {
 	store, err := state.NewStore(statePath())

--- a/internal/guard/guard.go
+++ b/internal/guard/guard.go
@@ -70,6 +70,40 @@ func Enforce(network string) error {
 	return EnforceArg(false, network)
 }
 
+// NodeRef is a (name, network) pair for the multi-node guard.
+type NodeRef struct {
+	Name    string
+	Network string
+}
+
+// EnforceNodes is the multi-node analog of Enforce for verbs that touch
+// more than one node (chaos disconnect/partition, network destroy/upgrade).
+// When the gate is on it refuses if ANY node is non-private, naming the
+// first offender so the operator knows which node broke the guarantee. The
+// caller must pass every node the operation will mutate, gathered from
+// state, so the refusal happens before any partial mutation.
+func EnforceNodes(refs []NodeRef) error {
+	if !Requested() {
+		return nil
+	}
+	for _, r := range refs {
+		if intent.IsPrivate(r.Network) {
+			continue
+		}
+		net := r.Network
+		if net == "" {
+			net = "<unrecorded>"
+		}
+		return output.NewError("PRIVATE_NETWORK_REQUIRED", output.ExitValidationError,
+			fmt.Sprintf("--require-private is set but node %q is on network %q (not private); refusing the operation", r.Name, net)).
+			WithSuggestions(
+				"Every node the operation touches must be private",
+				"Target a private network, or drop --require-private / "+EnvVar,
+			)
+	}
+	return nil
+}
+
 // EnforceArg is Enforce plus an explicit per-call request, OR-ed with the
 // flag/env floor. Callers that carry their own opt-in signal (e.g. the MCP
 // apply tool's require_private argument, where there is no cobra flag) pass

--- a/internal/guard/guard_test.go
+++ b/internal/guard/guard_test.go
@@ -113,6 +113,30 @@ func TestEnforce(t *testing.T) {
 	}
 }
 
+func TestEnforceNodes(t *testing.T) {
+	// Gate off → allow regardless of networks.
+	setGate(t, false, "")
+	if err := EnforceNodes([]NodeRef{{"a", "mainnet"}}); err != nil {
+		t.Errorf("gate off: EnforceNodes(mainnet) = %v, want nil", err)
+	}
+
+	setGate(t, true, "")
+	if err := EnforceNodes(nil); err != nil {
+		t.Errorf("EnforceNodes(nil) = %v, want nil", err)
+	}
+	if err := EnforceNodes([]NodeRef{{"a", "private"}, {"b", "private"}}); err != nil {
+		t.Errorf("all-private = %v, want nil", err)
+	}
+	// One non-private node → refuse, naming THAT node.
+	err := EnforceNodes([]NodeRef{{"sr0", "private"}, {"sr2", "mainnet"}, {"sr3", "private"}})
+	wantPrivReq(t, err)
+	if !strings.Contains(err.Error(), "sr2") {
+		t.Errorf("error should name the offending node sr2; got %q", err.Error())
+	}
+	// Empty (unrecorded) network also refuses.
+	wantPrivReq(t, EnforceNodes([]NodeRef{{"legacy", ""}}))
+}
+
 func TestEnforceArg_ForcesWhenGlobalOff(t *testing.T) {
 	setGate(t, false, "") // global gate OFF
 	// requested=true forces enforcement for this call.


### PR DESCRIPTION
## What

Completes the C1 safety boundary. With `--require-private` / `TROND_REQUIRE_PRIVATE` set, **no trond verb — single-node or multi-node — will mutate a non-private rig.** Previously the chaos primitives and network-wide ops bypassed the gate (an agent could `partition` or `network destroy` a mainnet rig despite `--require-private`).

- **`internal/guard`:** `EnforceNodes([]NodeRef)` — the multi-node analog of `Enforce`. Refuses if **any** node is non-private, **naming the first offender** so the operator knows which node broke the guarantee.
- **Chaos** `disconnect`/`connect`: guard both endpoints inside `chaosPair` (using the already-loaded nodes). `partition`/`heal`: guard **every** node in the `--groups` spec **up front** in `chaosGroups` — it accumulates per-pair errors and continues, so a per-pair guard alone would partially apply / spam errors.
- **Network** `add`: guard the new node's network. `destroy` / `upgrade`: gather the network's node set and `EnforceNodes` before removing/upgrading anything.
- New cmd helper `requirePrivateForNodes(names...)` (state-only; fast-paths to zero state reads when the gate is off).

## No schema change

`--require-private` has been a persistent flag in the `trond schema` manifest since 1.11.0, so this is purely behavioral enforcement — no SchemaVersion bump.

## Tests

`go vet` + `golangci-lint` clean. `guard.EnforceNodes` unit table (off / all-private / names-the-offender / unrecorded-network), chaos `disconnect` + `partition` refusal, network `destroy` + `upgrade` refusal — all hermetic (the guard fires before any docker/fs work). Live-binary smoke confirmed the refusal names the offending node and is a no-op when the gate is unset.

## Context

This closes the last C1 follow-up. The deferred-multi-node-guard TODO is removed; remaining TODOS.md items are `chain_id`, proper `--from-node`, the `db_cp.sh` reconciliation, the breaking `network`-field rename, and #163.