### PR TITLE
feat(status): emit genesis_block_id (chain identity fingerprint)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -173,8 +173,13 @@ trond status my-fullnode -o json
   12-hex) it's running, so an agent never has to assume which commit is
   deployed. Present in `status` / `inspect -o json`; `list` carries the
   raw `build_cache_key`. Absent for pre-built image/jar nodes.
-- `chain_id` is NOT yet emitted (TRON's chain id is genesis-derived, not
-  a single cheap RPC field) — tracked in TODOS.md.
+- `genesis_block_id` (status, live-only) — the chain's identity fingerprint:
+  the block-0 TRON block id (64-hex) from a live probe. Constant for the
+  chain's lifetime; use it to tell private rigs apart and correlate
+  on-chain. Absent when the node is stopped/unreachable (like block_height).
+  This is NOT `chain_id`: TRON's TVM `CHAINID` is the full block id unless
+  certain VM flags are on (then the last 4 bytes), so a flag-aware `chain_id`
+  is still deferred — tracked in TODOS.md.
 
 **Idempotency**: `apply` is hash-gated. Same intent → no-op. Changed
 intent without `--auto-approve` → exit 10. The agent should always

--- a/TODOS.md
+++ b/TODOS.md
@@ -46,25 +46,29 @@ up cold.
   merge.
 - **Depends on / blocked by:** nothing; both already merged.
 
-## Emit `chain_id` in `status` / `inspect` -o json
+## Emit a flag-aware `chain_id` in `status` (TVM CHAINID match)
 
-- **What:** The ai-ops A1 ask lists `chain_id` in the per-node `status
-  --json` shape. The 2026-06 A1 increment shipped `healthy`,
-  `container_id`, and the `logs` locator but deferred `chain_id`.
-- **Why deferred:** TRON has no single cheap RPC that returns a tidy chain
-  id. It's derived from the genesis block (the genesis block ID / its
-  trailing bytes), so producing it means a `/wallet/getblockbynum?num=0`
-  probe + a documented derivation — more than the additive-field A1 scope.
-  The operational A1 definition ("expose rpc_endpoint + node-log paths")
-  does not require it; tron-toolkit/mcp-logs are unblocked without it.
-- **How to add:** in `internal/apply` add a best-effort probe that fetches
-  block 0 and derives the chain id (match java-tron's
-  `Wallet.getChainId()` / the genesis block-id convention), surface it in
-  `LiveStatus` or a sibling, wire into status/inspect + schemas, bump
-  SchemaVersion (additive → MINOR per the C1/A1 precedent).
-- **Context:** flagged while implementing A1 (2026-06). For a private net
-  the value is deterministic from the genesis the intent pins, so it
-  doubles as a B1 "echo the resolved rig identity" signal.
+- **What:** `status -o json` now emits `genesis_block_id` (the block-0 TRON
+  block id — see `internal/apply/probe.go`). The original ask also wanted a
+  `chain_id` that matches what on-chain contracts see via the TVM `CHAINID`
+  opcode. That was deferred because the derivation is **flag-dependent**.
+- **The verified semantics (don't re-derive wrong):** java-tron
+  `Program.getChainId()` starts from `getBlockByNum(0).getBlockId()` and
+  returns the **full 32-byte block id**, truncating to the **last 4 bytes
+  ONLY** when `allowTvmCompatibleEvm` OR `allowOptimizedReturnValueOfChainId`
+  is active. Both are off by default on a fresh private net. So a naive
+  "last 4 bytes" `chain_id` is wrong for the default rig.
+- **How to do it right:** probe `getchainparameters` for those two flags,
+  then derive `chain_id` = full `genesis_block_id` (flags off) or its last 4
+  bytes (flags on). Ideally verify once against a deployed contract reading
+  CHAINID. Surface in `status`; bump SchemaVersion (additive → PATCH).
+- **Cons / why deferred:** marginal value (TRON tx signing uses
+  `ref_block_hash`, not a chain id; `genesis_block_id` already distinguishes
+  rigs), plus the flag-probe + verification is more than a one-field add.
+- **Context:** deferred during the 2026-06-18 `/plan-eng-review`; the
+  outside-voice (Codex, web-verified) caught the flag-dependency that would
+  have shipped a wrong `chain_id`. `genesis_block_id` shipped as the
+  unambiguous anchor.
 
 ## `--require-private` on the multi-node mutators (chaos + network ops)
 

--- a/internal/apply/observe_test.go
+++ b/internal/apply/observe_test.go
@@ -125,6 +125,65 @@ func TestLiveStatus_SetsHealthy(t *testing.T) {
 	}
 }
 
+const genesisBlockID = "0000000000000000957dc2d350daecc7bb6a38f3938ebde0a0c1cedafe15f0ed" // 64 hex, block-0 shape
+
+func TestIsHex64(t *testing.T) {
+	if !isHex64(genesisBlockID) {
+		t.Errorf("isHex64(%q) = false, want true", genesisBlockID)
+	}
+	for _, bad := range []string{"", "abc", strings.ToUpper(genesisBlockID), genesisBlockID + "0", "g" + genesisBlockID[1:]} {
+		if isHex64(bad) {
+			t.Errorf("isHex64(%q) = true, want false", bad)
+		}
+	}
+}
+
+// TestLiveStatus_GenesisBlockID covers the block-0 probe: a valid blockID
+// becomes genesis_block_id; a malformed or failed probe omits it (it's
+// optional metadata, never starving the primary signals).
+func TestLiveStatus_GenesisBlockID(t *testing.T) {
+	blockJSON := `{"block_header":{"raw_data":{"number":3,"timestamp":1}}}`
+
+	mk := func(genesisBody string, genesisErr bool) *execTarget {
+		return newExecTarget(func(_ context.Context, _ string, args ...string) ([]byte, error) {
+			url := args[len(args)-1]
+			switch {
+			case strings.Contains(url, "/wallet/getblockbynum"):
+				if genesisErr {
+					return nil, context.DeadlineExceeded
+				}
+				return []byte(genesisBody), nil
+			case strings.Contains(url, "/wallet/getnowblock"):
+				return []byte(blockJSON), nil
+			}
+			return nil, context.DeadlineExceeded
+		})
+	}
+	node := &state.ManagedNode{Name: "fn0", Runtime: "jar", HTTPPort: 8090}
+
+	// Valid blockID → surfaced.
+	out := LiveStatus(context.Background(), mk(`{"blockID":"`+genesisBlockID+`","block_header":{}}`, false), node)
+	if out["genesis_block_id"] != genesisBlockID {
+		t.Errorf("genesis_block_id = %v, want %s", out["genesis_block_id"], genesisBlockID)
+	}
+
+	// Malformed blockID (not 64-hex) → absent.
+	out = LiveStatus(context.Background(), mk(`{"blockID":"nope"}`, false), node)
+	if _, ok := out["genesis_block_id"]; ok {
+		t.Errorf("genesis_block_id must be absent for a malformed blockID; got %v", out["genesis_block_id"])
+	}
+
+	// Probe failed (node down) → absent, but the primary healthy signal
+	// (from getnowblock) is unaffected — proves it doesn't starve them.
+	out = LiveStatus(context.Background(), mk("", true), node)
+	if _, ok := out["genesis_block_id"]; ok {
+		t.Errorf("genesis_block_id must be absent when the probe fails; got %v", out["genesis_block_id"])
+	}
+	if out["healthy"] != true {
+		t.Errorf("a failed genesis probe must not break healthy; got %v", out["healthy"])
+	}
+}
+
 func TestLiveStatus_NoHealthyOnProbeFailure(t *testing.T) {
 	node := &state.ManagedNode{Name: "fn0", Runtime: "jar", HTTPPort: 8090}
 	tgt := newExecTarget(func(_ context.Context, _ string, _ ...string) ([]byte, error) {

--- a/internal/apply/probe.go
+++ b/internal/apply/probe.go
@@ -35,15 +35,23 @@ func LiveStatus(ctx context.Context, tgt target.Target, node *state.ManagedNode)
 		port = 8090
 	}
 
-	probe := func(path string) ([]byte, error) {
+	// probe issues a curl against the node's HTTP API. body=="" is a GET
+	// (TRON endpoints that take no params, e.g. getnowblock); a non-empty
+	// body is POSTed as JSON (e.g. getblockbynum needs {"num":N}).
+	probe := func(path, body string) ([]byte, error) {
 		url := fmt.Sprintf("http://127.0.0.1:%d%s", port, path)
-		if node.Runtime == "jar" {
-			return tgt.Exec(ctx, "curl", "-fsS", "--max-time", "2", url)
+		args := []string{"-fsS", "--max-time", "2"}
+		if body != "" {
+			args = append(args, "-X", "POST", "-H", "Content-Type: application/json", "-d", body)
 		}
-		return tgt.Exec(ctx, "docker", "exec", node.Name, "curl", "-fsS", "--max-time", "2", url)
+		args = append(args, url)
+		if node.Runtime == "jar" {
+			return tgt.Exec(ctx, "curl", args...)
+		}
+		return tgt.Exec(ctx, "docker", append([]string{"exec", node.Name, "curl"}, args...)...)
 	}
 
-	if data, err := probe("/wallet/getnowblock"); err == nil {
+	if data, err := probe("/wallet/getnowblock", ""); err == nil {
 		var block struct {
 			BlockHeader struct {
 				RawData struct {
@@ -75,12 +83,32 @@ func LiveStatus(ctx context.Context, tgt target.Target, node *state.ManagedNode)
 		}
 	}
 
-	if data, err := probe("/wallet/listnodes"); err == nil {
+	if data, err := probe("/wallet/listnodes", ""); err == nil {
 		var nodes struct {
 			Nodes []any `json:"nodes"`
 		}
 		if json.Unmarshal(data, &nodes) == nil {
 			out["peer_count"] = len(nodes.Nodes)
+		}
+	}
+
+	// genesis_block_id — the chain's identity fingerprint (the block-0 TRON
+	// block id). Probed LAST and treated as optional metadata: if the 3s
+	// budget is already spent on the primary signals above, this drops
+	// rather than starving healthy/block_height. The genesis never changes,
+	// so the value is stable for the node's lifetime.
+	//
+	// NB: this is the TRON *block id* (the first 8 bytes are the block
+	// number — zero for block 0 — not the raw header hash), and it is NOT
+	// the TVM CHAINID value: CHAINID returns the full id only when certain
+	// VM flags are off, the last 4 bytes when on. We deliberately expose the
+	// unambiguous full id, not a flag-dependent chain_id (see TODOS.md).
+	if data, err := probe("/wallet/getblockbynum", `{"num":0}`); err == nil {
+		var block struct {
+			BlockID string `json:"blockID"`
+		}
+		if json.Unmarshal(data, &block) == nil && isHex64(block.BlockID) {
+			out["genesis_block_id"] = block.BlockID
 		}
 	}
 
@@ -102,6 +130,13 @@ func ContainerID(ctx context.Context, tgt target.Target, node *state.ManagedNode
 		return ""
 	}
 	return NormalizeContainerID(string(out))
+}
+
+// isHex64 reports whether s is exactly 64 lowercase hex chars — the shape of
+// a TRON block id (and a docker container id). Rejects empty/error-shaped
+// responses so a malformed getblockbynum reply doesn't set genesis_block_id.
+func isHex64(s string) bool {
+	return len(s) == 64 && strings.TrimLeft(s, "0123456789abcdef") == ""
 }
 
 // NormalizeContainerID trims and validates raw `docker inspect -f {{.Id}}`

--- a/internal/schema/embed.go
+++ b/internal/schema/embed.go
@@ -85,7 +85,14 @@ import (
 //	        `build_cache_key`. Lets an agent learn which java-tron commit a
 //	        node runs without assuming (ai-ops B1: echo the resolved SHA).
 //	        Additive optional fields, source-built nodes only.
-const SchemaVersion = "1.12.0"
+//	1.12.1 — status output gains `genesis_block_id` (the block-0 TRON block
+//	        id, the chain's identity fingerprint, from a live probe). A
+//	        single existing schema gaining one additive optional field is a
+//	        PATCH per the rule above (the earlier additive bumps that took a
+//	        MINOR were over-versioned). `chain_id` itself is deferred — it's
+//	        flag-dependent in java-tron (TVM CHAINID = full block id unless
+//	        certain VM flags are on); see TODOS.md.
+const SchemaVersion = "1.12.1"
 
 // JSONSchemaURLBase is the canonical URL prefix for individual output
 // schema files. Embedded $id values inside each schema mirror this so

--- a/internal/schema/files/status.schema.json
+++ b/internal/schema/files/status.schema.json
@@ -49,6 +49,11 @@
       "type": "boolean",
       "description": "True if block_height >= the network's perceived head. Derived from the same probe; absent if the probe failed."
     },
+    "genesis_block_id": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$",
+      "description": "The chain's identity fingerprint: the TRON block id of block 0 (64-hex), from a live getblockbynum probe. Constant for the chain's lifetime; lets an agent tell private rigs apart and correlate on-chain. NOTE: this is the TRON block id (its first 8 bytes encode the block number, 0 for genesis — not the raw header hash), and it is NOT the TVM CHAINID value (which is flag-dependent). Live-only: absent when the node is stopped/unreachable, like block_height."
+    },
     "network": {
       "type": "string",
       "description": "The network this node was deployed on (mainnet | nile | private). Empty for nodes deployed before this field was recorded."

--- a/internal/schema/version_baseline.json
+++ b/internal/schema/version_baseline.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": "1.12.0",
+  "schema_version": "1.12.1",
   "entries": [
     {
       "name": "apply",
@@ -119,7 +119,7 @@
     },
     {
       "name": "status",
-      "hash": "3eb693e6f168eace4bd2720913690a5c88482b2d249cf4b958cd62386f2119ba"
+      "hash": "cf12a8dd02e89813be667a722c2295466c830483a4f2ad547314fda3f096556f"
     },
     {
       "name": "verify",

--- a/schemas/output/status.schema.json
+++ b/schemas/output/status.schema.json
@@ -49,6 +49,11 @@
       "type": "boolean",
       "description": "True if block_height >= the network's perceived head. Derived from the same probe; absent if the probe failed."
     },
+    "genesis_block_id": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$",
+      "description": "The chain's identity fingerprint: the TRON block id of block 0 (64-hex), from a live getblockbynum probe. Constant for the chain's lifetime; lets an agent tell private rigs apart and correlate on-chain. NOTE: this is the TRON block id (its first 8 bytes encode the block number, 0 for genesis — not the raw header hash), and it is NOT the TVM CHAINID value (which is flag-dependent). Live-only: absent when the node is stopped/unreachable, like block_height."
+    },
     "network": {
       "type": "string",
       "description": "The network this node was deployed on (mainnet | nile | private). Empty for nodes deployed before this field was recorded."


### PR DESCRIPTION
## What

`status -o json` now surfaces **`genesis_block_id`** — the block-0 TRON block id (64-hex) from a live probe — so an agent can tell private rigs apart and correlate on-chain, without assuming a chain id. (Closes the genesis-identity half of the deferred `chain_id` ai-ops ask.)

- `internal/apply/probe.go`: the probe helper now supports a POST body (`getblockbynum` needs `{"num":0}`). The genesis probe runs **last** in `LiveStatus`, so this optional metadata never starves the primary `healthy`/`block_height` signals under the 3s budget. The `blockID` is validated as 64-hex (`isHex64`); **live-only** (absent when the node is stopped/unreachable, like `block_height`). `status` + the MCP `status` tool surface it automatically via the existing `maps.Copy` of `LiveStatus`.

## Why no `chain_id` (yet)

The outside-voice review (Codex, web-verified against java-tron source) confirmed that TVM `CHAINID` (`Program.getChainId()`) returns the **full 32-byte block id** unless `allowTvmCompatibleEvm` / `allowOptimizedReturnValueOfChainId` is active — only then is it the **last 4 bytes**. Both are off by default on a fresh private net, so a naive "last 4 bytes" `chain_id` would be **wrong** for the default rig. `genesis_block_id` is the unambiguous anchor; a flag-aware `chain_id` (probe `getchainparameters` for those flags) is tracked in TODOS.md with the verified semantics.

## Versioning

`SchemaVersion` 1.12.0 → **1.12.1**. A single existing schema gaining one additive optional field is a **PATCH** per `embed.go`'s own rule — the earlier additive bumps that took a MINOR were over-versioned (caught in this review). Baseline regenerated.

## Tests

`go vet` + `golangci-lint` clean. `isHex64` unit; `LiveStatus` genesis probe (valid blockID → set, malformed → absent, failed probe → absent **without** breaking `healthy`, proving it doesn't starve the primaries). `AGENTS.md` documents the field and why `chain_id` is deferred.