### PR TITLE
feat(snapshot): clone --from-node — fork a stopped local node's chain DB by name

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -304,6 +304,22 @@ free-space preflight (refused with `DISK_SPACE_ERROR` if the copy won't
 fit). CLI-only (not an MCP tool): it mutates the filesystem, so it stays
 out of the read-only agent fleet.
 
+Or fork a managed node's DB by name with `--from-node` (resolves the path
+from state, so you don't hand-type it):
+
+```bash
+trond snapshot clone --from-node fn0 ./rig-a/output-directory -o json
+```
+
+`--from-node` requires the node be **stopped** and on a **local** target,
+and clones the node's chain-DB dir verbatim into `<dst>`. It works for jar
+nodes (`<install_path>/output-directory`) and docker nodes that use
+**bind-mount** storage (`storage.path` / `storage.data`). A docker node on
+the **default named volume** is refused — a named volume isn't a host path
+and can't be copy-on-write cloned; redeploy with `storage.path`, or pass an
+explicit `<src>`. ssh-target nodes are refused (the clone runs locally;
+remote-side clone is a tracked TODO).
+
 The intent needs `storage.data: /srv/tron/<node>/output-directory` so
 the bind mount lines up with where the tarball extracts. See
 `examples/mainnet-fullnode-snapshot.yaml`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -173,8 +173,13 @@ trond status my-fullnode -o json
   12-hex) it's running, so an agent never has to assume which commit is
   deployed. Present in `status` / `inspect -o json`; `list` carries the
   raw `build_cache_key`. Absent for pre-built image/jar nodes.
-- `chain_id` is NOT yet emitted (TRON's chain id is genesis-derived, not
-  a single cheap RPC field) — tracked in TODOS.md.
+- `genesis_block_id` (status, live-only) — the chain's identity fingerprint:
+  the block-0 TRON block id (64-hex) from a live probe. Constant for the
+  chain's lifetime; use it to tell private rigs apart and correlate
+  on-chain. Absent when the node is stopped/unreachable (like block_height).
+  This is NOT `chain_id`: TRON's TVM `CHAINID` is the full block id unless
+  certain VM flags are on (then the last 4 bytes), so a flag-aware `chain_id`
+  is still deferred — tracked in TODOS.md.
 
 **Idempotency**: `apply` is hash-gated. Same intent → no-op. Changed
 intent without `--auto-approve` → exit 10. The agent should always

--- a/TODOS.md
+++ b/TODOS.md
@@ -3,26 +3,26 @@
 Deferred work captured during reviews. Each item carries enough context to pick
 up cold.
 
-## `trond snapshot clone --from-node <name>` (resolve a node's DB dir)
+## `snapshot clone --from-node` for SSH-target / named-volume nodes
 
-- **What:** Add a `--from-node <name>` source to `snapshot clone` that resolves a
-  managed node's chain-DB directory from state, for BOTH docker and jar runtimes,
-  and refuses to clone unless the node is stopped.
-- **Why:** Lets an agent fork a live rig's DB by node name instead of hand-typing
-  the on-disk path.
-- **Cons / why it was deferred from B3:** the existing `destFromNode`
-  (`cmd/snapshot/download.go`) is jar-only (rejects docker) and returns
-  `install_path`, NOT the chain-DB dir — so it can't be reused as-is. Docker
-  storage paths live in render logic, not `state.json`, so this needs a new
-  runtime-aware DB-path resolver. And `fsclone.CloneDir`'s contract requires a
-  *quiescent* source, so `--from-node` must hard-refuse a running node (or stop
-  it) to avoid a corrupt point-in-time clone.
-- **Context:** Deferred during the 2026-06-17 `/plan-eng-review` of B3 (the
-  outside-voice/Codex caught that the originally-planned `--from-node` was
-  jar-only + unsafe-on-running). B3 shipped positional-paths-only
-  (`clone <src> <dst>`); this is the by-node convenience layer on top.
-- **Depends on / blocked by:** B3 (`snapshot clone`) landing first; a
-  runtime-aware DB-path resolver (docker storage path is not in state today).
+- **What:** `snapshot clone --from-node <name>` now resolves jar + docker
+  **bind-mount** nodes on a **local** target (shipped). Two cases remain
+  refused and could be supported later:
+  1. **SSH-target nodes** — `fsclone.CloneDir` is local-filesystem code
+     (`os.Stat`/`sameFilesystem`/local disk-free), so a remote node's path
+     can't be cloned locally. Supporting it needs remote-side execution (run
+     the clone over `target.Exec`, or rsync the result back).
+  2. **Docker default named-volume nodes** — the chain DB lives in
+     docker-managed storage (inside the VM on macOS), not a host path, so
+     CoW can't fire. Would need `docker cp` extraction to a host dir first (a
+     full GB-scale copy, defeating the CoW point) — dubious value.
+- **Why:** completeness for rigs that don't use local bind-mount storage.
+- **Context:** the local jar + docker-bind path shipped 2026-06-18; these two
+  were deliberately refused (with guidance) per the `/plan-eng-review`
+  (Codex caught the SSH gap — `fsclone` is local-only). The resolver +
+  `dockerInspect` seam live in `cmd/snapshot/clone.go`.
+- **Depends on / blocked by:** a remote clone primitive (for SSH); nothing for
+  the named-volume case beyond deciding `docker cp` is worth it.
 
 ## Reconcile `scripts/db_cp.sh` with `trond snapshot clone`
 

--- a/TODOS.md
+++ b/TODOS.md
@@ -46,25 +46,29 @@ up cold.
   merge.
 - **Depends on / blocked by:** nothing; both already merged.
 
-## Emit `chain_id` in `status` / `inspect` -o json
+## Emit a flag-aware `chain_id` in `status` (TVM CHAINID match)
 
-- **What:** The ai-ops A1 ask lists `chain_id` in the per-node `status
-  --json` shape. The 2026-06 A1 increment shipped `healthy`,
-  `container_id`, and the `logs` locator but deferred `chain_id`.
-- **Why deferred:** TRON has no single cheap RPC that returns a tidy chain
-  id. It's derived from the genesis block (the genesis block ID / its
-  trailing bytes), so producing it means a `/wallet/getblockbynum?num=0`
-  probe + a documented derivation — more than the additive-field A1 scope.
-  The operational A1 definition ("expose rpc_endpoint + node-log paths")
-  does not require it; tron-toolkit/mcp-logs are unblocked without it.
-- **How to add:** in `internal/apply` add a best-effort probe that fetches
-  block 0 and derives the chain id (match java-tron's
-  `Wallet.getChainId()` / the genesis block-id convention), surface it in
-  `LiveStatus` or a sibling, wire into status/inspect + schemas, bump
-  SchemaVersion (additive → MINOR per the C1/A1 precedent).
-- **Context:** flagged while implementing A1 (2026-06). For a private net
-  the value is deterministic from the genesis the intent pins, so it
-  doubles as a B1 "echo the resolved rig identity" signal.
+- **What:** `status -o json` now emits `genesis_block_id` (the block-0 TRON
+  block id — see `internal/apply/probe.go`). The original ask also wanted a
+  `chain_id` that matches what on-chain contracts see via the TVM `CHAINID`
+  opcode. That was deferred because the derivation is **flag-dependent**.
+- **The verified semantics (don't re-derive wrong):** java-tron
+  `Program.getChainId()` starts from `getBlockByNum(0).getBlockId()` and
+  returns the **full 32-byte block id**, truncating to the **last 4 bytes
+  ONLY** when `allowTvmCompatibleEvm` OR `allowOptimizedReturnValueOfChainId`
+  is active. Both are off by default on a fresh private net. So a naive
+  "last 4 bytes" `chain_id` is wrong for the default rig.
+- **How to do it right:** probe `getchainparameters` for those two flags,
+  then derive `chain_id` = full `genesis_block_id` (flags off) or its last 4
+  bytes (flags on). Ideally verify once against a deployed contract reading
+  CHAINID. Surface in `status`; bump SchemaVersion (additive → PATCH).
+- **Cons / why deferred:** marginal value (TRON tx signing uses
+  `ref_block_hash`, not a chain id; `genesis_block_id` already distinguishes
+  rigs), plus the flag-probe + verification is more than a one-field add.
+- **Context:** deferred during the 2026-06-18 `/plan-eng-review`; the
+  outside-voice (Codex, web-verified) caught the flag-dependency that would
+  have shipped a wrong `chain_id`. `genesis_block_id` shipped as the
+  unambiguous anchor.
 
 ## `--require-private` on the multi-node mutators (chaos + network ops)
 

--- a/cmd/snapshot/clone.go
+++ b/cmd/snapshot/clone.go
@@ -1,8 +1,11 @@
 package snapshot
 
 import (
+	"context"
+	"encoding/json"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"syscall"
@@ -12,6 +15,8 @@ import (
 
 	"github.com/tronprotocol/tron-deployment/internal/fsclone"
 	"github.com/tronprotocol/tron-deployment/internal/output"
+	"github.com/tronprotocol/tron-deployment/internal/paths"
+	"github.com/tronprotocol/tron-deployment/internal/state"
 	"github.com/tronprotocol/tron-deployment/internal/target"
 )
 
@@ -27,35 +32,76 @@ import (
 //
 // Mutating (creates dst) so it is CLI-only — deliberately NOT an MCP tool,
 // keeping filesystem-mutating capability out of the read-only agent fleet.
+// containerDataDir is where compose mounts the chain DB inside a docker
+// node (mirrors internal/render/compose.go). --from-node finds the host
+// path by matching this mount Destination.
+const containerDataDir = "/java-tron/output-directory"
+
+var cloneFromNode string
+
 var cloneCmd = &cobra.Command{
-	Use:   "clone <src> <dst>",
+	Use:   "clone <src> <dst>  |  clone --from-node <name> <dst>",
 	Short: "Copy-on-write clone a chain-DB directory into a fresh path",
-	Long: `Clone an existing chain database directory (a downloaded snapshot, or a
-STOPPED node's data dir) into a new, independent directory. When source
-and destination live on the same filesystem this is a copy-on-write
-clone (APFS clonefile / Linux FICLONE): seconds and near-zero extra disk
-even for a 30-90GB store. Across filesystems (or on a filesystem without
-CoW) it falls back to a full byte copy — a warning is printed and the
-"method" field reports "copy".
+	Long: `Clone an existing chain database directory into a new, independent
+directory. When source and destination live on the same filesystem this
+is a copy-on-write clone (APFS clonefile / Linux FICLONE): seconds and
+near-zero extra disk even for a 30-90GB store. Across filesystems (or on a
+filesystem without CoW) it falls back to a full byte copy — a warning is
+printed and the "method" field reports "copy".
 
-<src> is cloned verbatim: point it at whatever level you want
-materialised (the snapshot's output-directory, or its parent). <dst>
-must not already exist — clone refuses rather than overwrite.
+Two source modes:
+  <src>               an explicit directory (a downloaded snapshot, etc.),
+                      cloned verbatim.
+  --from-node <name>  resolve a managed node's chain-DB dir from state. The
+                      node must be STOPPED and on a LOCAL target. jar nodes
+                      resolve to <install_path>/output-directory; docker
+                      nodes must use bind-mount storage (storage.path /
+                      storage.data) — a default named docker volume is not a
+                      host path and cannot be cloned (redeploy with
+                      storage.path, or pass the path directly).
 
-The source must be QUIESCENT. Cloning a running node's live database
-yields an undefined point-in-time view; stop the node first.`,
+<dst> must not already exist — clone refuses rather than overwrite. The
+source must be QUIESCENT: cloning a running node's live DB yields an
+undefined point-in-time view.`,
 	Example: `  # Fork a cached snapshot into an isolated fixture (instant on APFS/btrfs/xfs)
   trond snapshot clone ./output-directory ./rig-a/output-directory
 
-  # Clone a stopped node's data dir, JSON output
-  trond snapshot clone ~/.trond/deployments/fn0/output-directory ./fixture -o json`,
-	Args: cobra.ExactArgs(2),
+  # Fork a stopped managed node's chain DB by name
+  trond snapshot clone --from-node fn0 ./rig-a/output-directory -o json`,
+	Args: cobra.RangeArgs(1, 2),
 	RunE: runClone,
+}
+
+func init() {
+	cloneCmd.Flags().StringVar(&cloneFromNode, "from-node", "",
+		"Resolve <src> from a STOPPED local managed node's chain-DB dir (then only <dst> is positional)")
 }
 
 func runClone(cmd *cobra.Command, args []string) error {
 	outputFmt, _ := cmd.Flags().GetString("output")
-	src, dst := args[0], args[1]
+
+	// Source comes either from --from-node (resolved from state) or from a
+	// positional <src>. The two are mutually exclusive; the positional arity
+	// differs (1 vs 2), so validate explicitly rather than via cobra.
+	var src, dst string
+	if cloneFromNode != "" {
+		if len(args) != 1 {
+			return output.NewError("VALIDATION_ERROR", output.ExitValidationError,
+				"with --from-node, pass exactly one positional argument: the destination")
+		}
+		dst = args[0]
+		resolved, err := resolveNodeDBDir(cmd.Context(), cloneFromNode)
+		if err != nil {
+			return err
+		}
+		src = resolved
+	} else {
+		if len(args) != 2 {
+			return output.NewError("VALIDATION_ERROR", output.ExitValidationError,
+				"expected two arguments: <src> <dst> (or use --from-node <name> <dst>)")
+		}
+		src, dst = args[0], args[1]
+	}
 
 	// Source must exist and be a directory. CloneDir re-checks, but we
 	// want a clean VALIDATION_ERROR before any staging work.
@@ -247,4 +293,124 @@ func dirSize(root string) (uint64, error) {
 		return nil
 	})
 	return total, err
+}
+
+// resolveNodeDBDir resolves a managed node's chain-DB host directory for
+// --from-node, enforcing the narrow-scope guards from the eng-review:
+//
+//	ssh target        → refuse (fsclone is local-only; remote clone unsupported)
+//	not stopped       → refuse (cloning a live DB is an undefined snapshot)
+//	jar               → <install_path>/output-directory (+ live is-active check)
+//	docker bind-mount → the host Source of the /java-tron/output-directory mount
+//	docker named vol  → refuse (not a host path; redeploy with storage.path)
+//
+// The docker path + liveness both come from a single `docker inspect`.
+func resolveNodeDBDir(ctx context.Context, name string) (string, error) {
+	store, err := state.NewStore(paths.State())
+	if err != nil {
+		return "", err
+	}
+	st, err := store.Load()
+	if err != nil {
+		return "", err
+	}
+	node := store.GetNode(st, name)
+	if node == nil {
+		return "", output.NewError("NODE_NOT_FOUND", output.ExitGeneralError,
+			fmt.Sprintf("node %q not found in state", name)).
+			WithSuggestions("Run: trond list", "Pass an explicit <src> path instead of --from-node")
+	}
+	if node.Target.Type == "ssh" {
+		return "", output.NewError("VALIDATION_ERROR", output.ExitValidationError,
+			fmt.Sprintf("--from-node supports local-target nodes only; %q is on an ssh target", name)).
+			WithSuggestions("Clone on the remote host, or copy the DB over and pass an explicit <src> path")
+	}
+	if node.Status != "stopped" {
+		return "", output.NewError("VALIDATION_ERROR", output.ExitValidationError,
+			fmt.Sprintf("node %q is %q, not stopped; stop it before cloning (a live DB yields an undefined point-in-time view)", name, node.Status)).
+			WithSuggestions(fmt.Sprintf("Run: trond stop %s", name))
+	}
+
+	switch node.Runtime {
+	case "jar":
+		if node.InstallPath == "" {
+			return "", output.NewError("VALIDATION_ERROR", output.ExitValidationError,
+				fmt.Sprintf("node %q has no recorded install_path; pass an explicit <src> path", name))
+		}
+		if jarActive(ctx, name) {
+			return "", output.NewError("VALIDATION_ERROR", output.ExitValidationError,
+				fmt.Sprintf("node %q is still active (systemd); stop it before cloning", name)).
+				WithSuggestions(fmt.Sprintf("Run: trond stop %s", name))
+		}
+		return filepath.Join(node.InstallPath, "output-directory"), nil
+	case "docker":
+		return dockerNodeDBDir(ctx, name)
+	default:
+		return "", output.NewError("VALIDATION_ERROR", output.ExitValidationError,
+			fmt.Sprintf("node %q has unsupported runtime %q for --from-node", name, node.Runtime))
+	}
+}
+
+// dockerNodeDBDir inspects a stopped docker container to find the host bind
+// path backing its chain DB, refusing if it's still running or if the DB is
+// on a named volume (not a host path).
+// dockerInspect returns raw `docker inspect <name>` JSON. A package var so
+// tests can swap it for canned output without a live docker daemon.
+var dockerInspect = func(ctx context.Context, name string) ([]byte, error) {
+	return exec.CommandContext(ctx, "docker", "inspect", name).Output()
+}
+
+func dockerNodeDBDir(ctx context.Context, name string) (string, error) {
+	out, err := dockerInspect(ctx, name)
+	if err != nil {
+		return "", output.NewError("VALIDATION_ERROR", output.ExitValidationError,
+			fmt.Sprintf("docker inspect %q failed (container removed?): %v", name, err)).
+			WithSuggestions("The container must still exist (a stopped, not removed, node)",
+				"Or pass an explicit <src> path")
+	}
+	var inspected []struct {
+		State struct {
+			Running bool `json:"Running"`
+		} `json:"State"`
+		Mounts []struct {
+			Type        string `json:"Type"`
+			Source      string `json:"Source"`
+			Destination string `json:"Destination"`
+		} `json:"Mounts"`
+	}
+	if err := json.Unmarshal(out, &inspected); err != nil || len(inspected) == 0 {
+		return "", output.NewError("VALIDATION_ERROR", output.ExitValidationError,
+			fmt.Sprintf("could not parse docker inspect output for %q", name))
+	}
+	c := inspected[0]
+	if c.State.Running {
+		return "", output.NewError("VALIDATION_ERROR", output.ExitValidationError,
+			fmt.Sprintf("node %q is still running; stop it before cloning", name)).
+			WithSuggestions(fmt.Sprintf("Run: trond stop %s", name))
+	}
+	for _, m := range c.Mounts {
+		if m.Destination != containerDataDir {
+			continue
+		}
+		// Reject by mount TYPE, not by sniffing Source: a Linux named volume
+		// can expose a host-ish path, but it's still docker-managed storage.
+		if m.Type != "bind" {
+			return "", output.NewError("VALIDATION_ERROR", output.ExitValidationError,
+				fmt.Sprintf("node %q stores its chain DB in a %s (not a host bind-mount); it cannot be copy-on-write cloned", name, m.Type)).
+				WithSuggestions("Redeploy the node with storage.path set to a host directory",
+					"Or extract the volume manually and pass an explicit <src> path")
+		}
+		return m.Source, nil
+	}
+	return "", output.NewError("VALIDATION_ERROR", output.ExitValidationError,
+		fmt.Sprintf("node %q has no chain-DB mount at %s", name, containerDataDir))
+}
+
+// jarActive reports whether the node's systemd unit is currently active. A
+// missing/erroring systemctl (e.g. non-systemd host) is treated as "not
+// active" — the state.Status==stopped gate already ran; this is the live
+// belt-and-suspenders check, and only an explicit "active" blocks the clone.
+func jarActive(ctx context.Context, name string) bool {
+	out, _ := exec.CommandContext(ctx, "systemctl", "is-active", "tron-"+name+".service").Output()
+	return strings.TrimSpace(string(out)) == "active"
 }

--- a/cmd/snapshot/clone_fromnode_test.go
+++ b/cmd/snapshot/clone_fromnode_test.go
@@ -1,0 +1,146 @@
+package snapshot
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/tronprotocol/tron-deployment/internal/output"
+	"github.com/tronprotocol/tron-deployment/internal/paths"
+	"github.com/tronprotocol/tron-deployment/internal/state"
+)
+
+func seedNode(t *testing.T, n state.ManagedNode) {
+	t.Helper()
+	paths.SetBaseDir(t.TempDir())
+	t.Cleanup(func() { paths.SetBaseDir("") })
+	store, err := state.NewStore(paths.State())
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	if err := store.Save(&state.DeploymentState{Version: 1, Nodes: []state.ManagedNode{n}}); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+}
+
+func wantValErr(t *testing.T, err error, mustContain string) {
+	t.Helper()
+	if err == nil {
+		t.Fatal("expected an error, got nil")
+	}
+	var se *output.StructuredError
+	if !errors.As(err, &se) {
+		t.Fatalf("expected *output.StructuredError, got %T: %v", err, err)
+	}
+	if se.ExitCode != output.ExitValidationError && se.Code != "NODE_NOT_FOUND" {
+		t.Errorf("unexpected error envelope: code=%q exit=%d", se.Code, se.ExitCode)
+	}
+	if mustContain != "" && !strings.Contains(strings.ToLower(err.Error()), strings.ToLower(mustContain)) {
+		t.Errorf("error %q should mention %q", err.Error(), mustContain)
+	}
+}
+
+func TestResolveNodeDBDir_Jar(t *testing.T) {
+	seedNode(t, state.ManagedNode{
+		Name: "sr0", Status: "stopped", Runtime: "jar", InstallPath: "/srv/tron/sr0",
+		Target: state.NodeTarget{Type: "local"}, LastApplied: time.Now().UTC(),
+	})
+	dir, err := resolveNodeDBDir(context.Background(), "sr0")
+	if err != nil {
+		t.Fatalf("resolveNodeDBDir: %v", err)
+	}
+	if dir != filepath.Join("/srv/tron/sr0", "output-directory") {
+		t.Errorf("dir = %q; want /srv/tron/sr0/output-directory", dir)
+	}
+}
+
+func TestResolveNodeDBDir_NotFound(t *testing.T) {
+	seedNode(t, state.ManagedNode{Name: "sr0", Status: "stopped", Runtime: "jar"})
+	_, err := resolveNodeDBDir(context.Background(), "ghost")
+	wantValErr(t, err, "not found")
+}
+
+func TestResolveNodeDBDir_RefusesSSH(t *testing.T) {
+	seedNode(t, state.ManagedNode{
+		Name: "fn0", Status: "stopped", Runtime: "jar", InstallPath: "/x",
+		Target: state.NodeTarget{Type: "ssh", Host: "h"}, LastApplied: time.Now().UTC(),
+	})
+	_, err := resolveNodeDBDir(context.Background(), "fn0")
+	wantValErr(t, err, "local-target")
+}
+
+func TestResolveNodeDBDir_RefusesRunning(t *testing.T) {
+	seedNode(t, state.ManagedNode{
+		Name: "fn0", Status: "running", Runtime: "jar", InstallPath: "/x",
+		Target: state.NodeTarget{Type: "local"}, LastApplied: time.Now().UTC(),
+	})
+	_, err := resolveNodeDBDir(context.Background(), "fn0")
+	wantValErr(t, err, "stopped")
+}
+
+// docker cases swap the dockerInspect seam for canned output.
+func withDockerInspect(t *testing.T, fn func(context.Context, string) ([]byte, error)) {
+	t.Helper()
+	old := dockerInspect
+	dockerInspect = fn
+	t.Cleanup(func() { dockerInspect = old })
+}
+
+func TestResolveNodeDBDir_DockerBind(t *testing.T) {
+	seedNode(t, state.ManagedNode{
+		Name: "fn0", Status: "stopped", Runtime: "docker",
+		Target: state.NodeTarget{Type: "local"}, LastApplied: time.Now().UTC(),
+	})
+	withDockerInspect(t, func(_ context.Context, _ string) ([]byte, error) {
+		return []byte(`[{"State":{"Running":false},"Mounts":[
+			{"Type":"bind","Source":"/host/rig/fn0/output-directory","Destination":"/java-tron/output-directory"}]}]`), nil
+	})
+	dir, err := resolveNodeDBDir(context.Background(), "fn0")
+	if err != nil {
+		t.Fatalf("resolveNodeDBDir: %v", err)
+	}
+	if dir != "/host/rig/fn0/output-directory" {
+		t.Errorf("dir = %q; want the bind Source verbatim", dir)
+	}
+}
+
+func TestResolveNodeDBDir_DockerNamedVolumeRefused(t *testing.T) {
+	seedNode(t, state.ManagedNode{
+		Name: "fn0", Status: "stopped", Runtime: "docker",
+		Target: state.NodeTarget{Type: "local"}, LastApplied: time.Now().UTC(),
+	})
+	withDockerInspect(t, func(_ context.Context, _ string) ([]byte, error) {
+		return []byte(`[{"State":{"Running":false},"Mounts":[
+			{"Type":"volume","Source":"/var/lib/docker/volumes/fn0-data/_data","Destination":"/java-tron/output-directory"}]}]`), nil
+	})
+	_, err := resolveNodeDBDir(context.Background(), "fn0")
+	wantValErr(t, err, "volume")
+}
+
+func TestResolveNodeDBDir_DockerStillRunningRefused(t *testing.T) {
+	seedNode(t, state.ManagedNode{
+		Name: "fn0", Status: "stopped", Runtime: "docker", // state stale; live says running
+		Target: state.NodeTarget{Type: "local"}, LastApplied: time.Now().UTC(),
+	})
+	withDockerInspect(t, func(_ context.Context, _ string) ([]byte, error) {
+		return []byte(`[{"State":{"Running":true},"Mounts":[
+			{"Type":"bind","Source":"/host/fn0","Destination":"/java-tron/output-directory"}]}]`), nil
+	})
+	_, err := resolveNodeDBDir(context.Background(), "fn0")
+	wantValErr(t, err, "running")
+}
+
+func TestResolveNodeDBDir_DockerRemovedRefused(t *testing.T) {
+	seedNode(t, state.ManagedNode{
+		Name: "fn0", Status: "stopped", Runtime: "docker",
+		Target: state.NodeTarget{Type: "local"}, LastApplied: time.Now().UTC(),
+	})
+	withDockerInspect(t, func(_ context.Context, _ string) ([]byte, error) {
+		return nil, errors.New("Error: No such object: fn0")
+	})
+	_, err := resolveNodeDBDir(context.Background(), "fn0")
+	wantValErr(t, err, "removed")
+}

--- a/internal/apply/observe_test.go
+++ b/internal/apply/observe_test.go
@@ -125,6 +125,65 @@ func TestLiveStatus_SetsHealthy(t *testing.T) {
 	}
 }
 
+const genesisBlockID = "0000000000000000957dc2d350daecc7bb6a38f3938ebde0a0c1cedafe15f0ed" // 64 hex, block-0 shape
+
+func TestIsHex64(t *testing.T) {
+	if !isHex64(genesisBlockID) {
+		t.Errorf("isHex64(%q) = false, want true", genesisBlockID)
+	}
+	for _, bad := range []string{"", "abc", strings.ToUpper(genesisBlockID), genesisBlockID + "0", "g" + genesisBlockID[1:]} {
+		if isHex64(bad) {
+			t.Errorf("isHex64(%q) = true, want false", bad)
+		}
+	}
+}
+
+// TestLiveStatus_GenesisBlockID covers the block-0 probe: a valid blockID
+// becomes genesis_block_id; a malformed or failed probe omits it (it's
+// optional metadata, never starving the primary signals).
+func TestLiveStatus_GenesisBlockID(t *testing.T) {
+	blockJSON := `{"block_header":{"raw_data":{"number":3,"timestamp":1}}}`
+
+	mk := func(genesisBody string, genesisErr bool) *execTarget {
+		return newExecTarget(func(_ context.Context, _ string, args ...string) ([]byte, error) {
+			url := args[len(args)-1]
+			switch {
+			case strings.Contains(url, "/wallet/getblockbynum"):
+				if genesisErr {
+					return nil, context.DeadlineExceeded
+				}
+				return []byte(genesisBody), nil
+			case strings.Contains(url, "/wallet/getnowblock"):
+				return []byte(blockJSON), nil
+			}
+			return nil, context.DeadlineExceeded
+		})
+	}
+	node := &state.ManagedNode{Name: "fn0", Runtime: "jar", HTTPPort: 8090}
+
+	// Valid blockID → surfaced.
+	out := LiveStatus(context.Background(), mk(`{"blockID":"`+genesisBlockID+`","block_header":{}}`, false), node)
+	if out["genesis_block_id"] != genesisBlockID {
+		t.Errorf("genesis_block_id = %v, want %s", out["genesis_block_id"], genesisBlockID)
+	}
+
+	// Malformed blockID (not 64-hex) → absent.
+	out = LiveStatus(context.Background(), mk(`{"blockID":"nope"}`, false), node)
+	if _, ok := out["genesis_block_id"]; ok {
+		t.Errorf("genesis_block_id must be absent for a malformed blockID; got %v", out["genesis_block_id"])
+	}
+
+	// Probe failed (node down) → absent, but the primary healthy signal
+	// (from getnowblock) is unaffected — proves it doesn't starve them.
+	out = LiveStatus(context.Background(), mk("", true), node)
+	if _, ok := out["genesis_block_id"]; ok {
+		t.Errorf("genesis_block_id must be absent when the probe fails; got %v", out["genesis_block_id"])
+	}
+	if out["healthy"] != true {
+		t.Errorf("a failed genesis probe must not break healthy; got %v", out["healthy"])
+	}
+}
+
 func TestLiveStatus_NoHealthyOnProbeFailure(t *testing.T) {
 	node := &state.ManagedNode{Name: "fn0", Runtime: "jar", HTTPPort: 8090}
 	tgt := newExecTarget(func(_ context.Context, _ string, _ ...string) ([]byte, error) {

--- a/internal/apply/probe.go
+++ b/internal/apply/probe.go
@@ -35,15 +35,23 @@ func LiveStatus(ctx context.Context, tgt target.Target, node *state.ManagedNode)
 		port = 8090
 	}
 
-	probe := func(path string) ([]byte, error) {
+	// probe issues a curl against the node's HTTP API. body=="" is a GET
+	// (TRON endpoints that take no params, e.g. getnowblock); a non-empty
+	// body is POSTed as JSON (e.g. getblockbynum needs {"num":N}).
+	probe := func(path, body string) ([]byte, error) {
 		url := fmt.Sprintf("http://127.0.0.1:%d%s", port, path)
-		if node.Runtime == "jar" {
-			return tgt.Exec(ctx, "curl", "-fsS", "--max-time", "2", url)
+		args := []string{"-fsS", "--max-time", "2"}
+		if body != "" {
+			args = append(args, "-X", "POST", "-H", "Content-Type: application/json", "-d", body)
 		}
-		return tgt.Exec(ctx, "docker", "exec", node.Name, "curl", "-fsS", "--max-time", "2", url)
+		args = append(args, url)
+		if node.Runtime == "jar" {
+			return tgt.Exec(ctx, "curl", args...)
+		}
+		return tgt.Exec(ctx, "docker", append([]string{"exec", node.Name, "curl"}, args...)...)
 	}
 
-	if data, err := probe("/wallet/getnowblock"); err == nil {
+	if data, err := probe("/wallet/getnowblock", ""); err == nil {
 		var block struct {
 			BlockHeader struct {
 				RawData struct {
@@ -75,12 +83,32 @@ func LiveStatus(ctx context.Context, tgt target.Target, node *state.ManagedNode)
 		}
 	}
 
-	if data, err := probe("/wallet/listnodes"); err == nil {
+	if data, err := probe("/wallet/listnodes", ""); err == nil {
 		var nodes struct {
 			Nodes []any `json:"nodes"`
 		}
 		if json.Unmarshal(data, &nodes) == nil {
 			out["peer_count"] = len(nodes.Nodes)
+		}
+	}
+
+	// genesis_block_id — the chain's identity fingerprint (the block-0 TRON
+	// block id). Probed LAST and treated as optional metadata: if the 3s
+	// budget is already spent on the primary signals above, this drops
+	// rather than starving healthy/block_height. The genesis never changes,
+	// so the value is stable for the node's lifetime.
+	//
+	// NB: this is the TRON *block id* (the first 8 bytes are the block
+	// number — zero for block 0 — not the raw header hash), and it is NOT
+	// the TVM CHAINID value: CHAINID returns the full id only when certain
+	// VM flags are off, the last 4 bytes when on. We deliberately expose the
+	// unambiguous full id, not a flag-dependent chain_id (see TODOS.md).
+	if data, err := probe("/wallet/getblockbynum", `{"num":0}`); err == nil {
+		var block struct {
+			BlockID string `json:"blockID"`
+		}
+		if json.Unmarshal(data, &block) == nil && isHex64(block.BlockID) {
+			out["genesis_block_id"] = block.BlockID
 		}
 	}
 
@@ -102,6 +130,13 @@ func ContainerID(ctx context.Context, tgt target.Target, node *state.ManagedNode
 		return ""
 	}
 	return NormalizeContainerID(string(out))
+}
+
+// isHex64 reports whether s is exactly 64 lowercase hex chars — the shape of
+// a TRON block id (and a docker container id). Rejects empty/error-shaped
+// responses so a malformed getblockbynum reply doesn't set genesis_block_id.
+func isHex64(s string) bool {
+	return len(s) == 64 && strings.TrimLeft(s, "0123456789abcdef") == ""
 }
 
 // NormalizeContainerID trims and validates raw `docker inspect -f {{.Id}}`

--- a/internal/schema/embed.go
+++ b/internal/schema/embed.go
@@ -85,7 +85,14 @@ import (
 //	        `build_cache_key`. Lets an agent learn which java-tron commit a
 //	        node runs without assuming (ai-ops B1: echo the resolved SHA).
 //	        Additive optional fields, source-built nodes only.
-const SchemaVersion = "1.12.0"
+//	1.12.1 — status output gains `genesis_block_id` (the block-0 TRON block
+//	        id, the chain's identity fingerprint, from a live probe). A
+//	        single existing schema gaining one additive optional field is a
+//	        PATCH per the rule above (the earlier additive bumps that took a
+//	        MINOR were over-versioned). `chain_id` itself is deferred — it's
+//	        flag-dependent in java-tron (TVM CHAINID = full block id unless
+//	        certain VM flags are on); see TODOS.md.
+const SchemaVersion = "1.12.1"
 
 // JSONSchemaURLBase is the canonical URL prefix for individual output
 // schema files. Embedded $id values inside each schema mirror this so

--- a/internal/schema/files/status.schema.json
+++ b/internal/schema/files/status.schema.json
@@ -49,6 +49,11 @@
       "type": "boolean",
       "description": "True if block_height >= the network's perceived head. Derived from the same probe; absent if the probe failed."
     },
+    "genesis_block_id": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$",
+      "description": "The chain's identity fingerprint: the TRON block id of block 0 (64-hex), from a live getblockbynum probe. Constant for the chain's lifetime; lets an agent tell private rigs apart and correlate on-chain. NOTE: this is the TRON block id (its first 8 bytes encode the block number, 0 for genesis — not the raw header hash), and it is NOT the TVM CHAINID value (which is flag-dependent). Live-only: absent when the node is stopped/unreachable, like block_height."
+    },
     "network": {
       "type": "string",
       "description": "The network this node was deployed on (mainnet | nile | private). Empty for nodes deployed before this field was recorded."

--- a/internal/schema/version_baseline.json
+++ b/internal/schema/version_baseline.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": "1.12.0",
+  "schema_version": "1.12.1",
   "entries": [
     {
       "name": "apply",
@@ -119,7 +119,7 @@
     },
     {
       "name": "status",
-      "hash": "3eb693e6f168eace4bd2720913690a5c88482b2d249cf4b958cd62386f2119ba"
+      "hash": "cf12a8dd02e89813be667a722c2295466c830483a4f2ad547314fda3f096556f"
     },
     {
       "name": "verify",

--- a/schemas/output/status.schema.json
+++ b/schemas/output/status.schema.json
@@ -49,6 +49,11 @@
       "type": "boolean",
       "description": "True if block_height >= the network's perceived head. Derived from the same probe; absent if the probe failed."
     },
+    "genesis_block_id": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$",
+      "description": "The chain's identity fingerprint: the TRON block id of block 0 (64-hex), from a live getblockbynum probe. Constant for the chain's lifetime; lets an agent tell private rigs apart and correlate on-chain. NOTE: this is the TRON block id (its first 8 bytes encode the block number, 0 for genesis — not the raw header hash), and it is NOT the TVM CHAINID value (which is flag-dependent). Live-only: absent when the node is stopped/unreachable, like block_height."
+    },
     "network": {
       "type": "string",
       "description": "The network this node was deployed on (mainnet | nile | private). Empty for nodes deployed before this field was recorded."


### PR DESCRIPTION
> **Stacked on #197** (`genesis_block_id`). Until #197 merges, this PR's diff includes its commit; I'll rebase onto `develop` once #197 lands so only the `--from-node` change remains.

## What

`trond snapshot clone --from-node <name> <dst>` resolves a managed node's chain-DB host directory from state and clones it (CoW) into `<dst>` **verbatim** — so an agent can fork a rig's DB by name instead of hand-typing the path.

## Scope (narrow, by physical reality)

`fsclone` does copy-on-write of a **host directory**, which constrains what's cloneable:

- **jar** → `<install_path>/output-directory`
- **docker bind-mount** → the host `Source` of the `/java-tron/output-directory` mount, found via `docker inspect`. Rejected by **`Mount.Type != "bind"`**, so a **default named-volume** docker node is refused (a named volume isn't a host path; redeploy with `storage.path`) — not by sniffing the source string.
- **ssh-target nodes are REFUSED**: `fsclone` is local-only, so a remote path can't be cloned locally. Remote-side clone is a tracked TODO.
- **Quiesce**: refuse unless `state.Status == "stopped"` **AND** the live check agrees (docker `.State.Running == false` from the same inspect; jar `systemctl is-active`) — state alone can be stale.

`--from-node` is mutually exclusive with the positional `<src>` (Args relaxed to `RangeArgs(1,2)` with explicit arity validation).

## No SchemaVersion bump

Clone's **output** shape is unchanged (`--from-node` is an input flag); `TestSchemaVersionShape` (which tracks output schemas) stays green.

## Tests

Resolver unit cases via a swappable `dockerInspect` seam (no live daemon): jar, docker-bind, named-volume refused, still-running refused, container-removed refused, ssh refused, not-found. `go vet` + `golangci-lint` clean; live-binary smoke confirmed the ssh / not-found / mutual-exclusion guards.

## Review

`/plan-eng-review` + Codex outside-voice, which **verified the repo assumptions** (docker-stop keeps the container so `inspect` works; DB dest = `/java-tron/output-directory`; bind `Source` IS the output-directory — clone directly; jar DB = `install_path/output-directory`) and caught the **SSH gap** (fsclone is local-only) and the jar live-quiesce need — both folded in.