### PR TITLE
fix(monitoring): track real MetricsPort in state, expose monitoring via inspect

### DIFF
--- a/cmd/inspect.go
+++ b/cmd/inspect.go
@@ -142,6 +142,10 @@ func runInspect(cmd *cobra.Command, args []string) error {
 	if ip, ok := one["container_ip"].(string); ok && ip != "" {
 		fmt.Printf("Container IP: %s\n", ip)
 	}
+	if mon, ok := one["monitoring"].(map[string]any); ok {
+		fmt.Printf("Monitoring:   prometheus :%d, grafana :%d\n",
+			mon["prometheus_port"], mon["grafana_port"])
+	}
 	return nil
 }
 
@@ -203,6 +207,18 @@ func manifestForNode(ctx context.Context, n *state.ManagedNode) map[string]any {
 		}
 		if id := dockerContainerID(ctx, n.Name); id != "" {
 			entry["container_id"] = id
+		}
+	}
+
+	// Monitoring stack endpoints (ports only — host is always known to the
+	// caller: 127.0.0.1 for local targets, target.host for SSH). Surfacing
+	// this lets agents discover the deployed Prometheus/Grafana ports
+	// without re-parsing the apply result.
+	if n.Monitoring != nil && n.Monitoring.Enabled {
+		entry["monitoring"] = map[string]any{
+			"enabled":         true,
+			"prometheus_port": n.Monitoring.PrometheusPort,
+			"grafana_port":    n.Monitoring.GrafanaPort,
 		}
 	}
 

--- a/cmd/network/add.go
+++ b/cmd/network/add.go
@@ -204,6 +204,7 @@ func runAdd(cmd *cobra.Command, args []string) error {
 		HTTPPort:    node.Ports.HTTP,
 		GRPCPort:    node.Ports.GRPC,
 		P2PPort:     node.Ports.P2P,
+		MetricsPort: node.Ports.Metrics,
 		InstallPath: node.InstallPath,
 		Labels:      node.Labels,
 	})
@@ -234,6 +235,17 @@ func runAdd(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
+// metricsPort returns the Prometheus scrape port stored in state, falling
+// back to the default 9527 for nodes deployed before MetricsPort was tracked.
+// This allows network add to build correct scrape targets even when the user
+// overrides ports.metrics in the intent.
+func metricsPort(n state.ManagedNode) int {
+	if n.MetricsPort != 0 {
+		return n.MetricsPort
+	}
+	return 9527
+}
+
 // reloadNetworkMonitoring updates the Prometheus scrape config to include
 // a newly added node, then reloads Prometheus. Best-effort: failure is
 // silent (monitoring can be re-synced on next network create --monitor).
@@ -255,7 +267,7 @@ func reloadNetworkMonitoring(ctx context.Context, networkName string, deployStat
 		}
 		targets = append(targets, render.MonitoringTarget{
 			Name:    n.Name,
-			Address: fmt.Sprintf("%s:9527", n.Name),
+			Address: fmt.Sprintf("%s:%d", n.Name, metricsPort(n)),
 			Labels: map[string]string{
 				"group":    "group-tron",
 				"instance": n.Name,

--- a/cmd/network/create.go
+++ b/cmd/network/create.go
@@ -180,6 +180,7 @@ func runCreate(cmd *cobra.Command, args []string) error {
 			HTTPPort:    node.Ports.HTTP,
 			GRPCPort:    node.Ports.GRPC,
 			P2PPort:     node.Ports.P2P,
+			MetricsPort: node.Ports.Metrics,
 			Labels:      node.Labels,
 		}
 		store.UpsertNode(deployState, mn)

--- a/internal/apply/apply.go
+++ b/internal/apply/apply.go
@@ -325,6 +325,7 @@ func Apply(ctx context.Context, opts Options) (*Result, error) {
 		LastApplied: time.Now().UTC(),
 		HTTPPort:    node.Ports.HTTP,
 		GRPCPort:    node.Ports.GRPC,
+		MetricsPort: node.Ports.Metrics,
 		Labels:      node.Labels,
 		InstallPath: node.InstallPath,
 		Monitoring:  monRes.managed,

--- a/internal/schema/embed.go
+++ b/internal/schema/embed.go
@@ -92,7 +92,13 @@ import (
 //	        MINOR were over-versioned). `chain_id` itself is deferred — it's
 //	        flag-dependent in java-tron (TVM CHAINID = full block id unless
 //	        certain VM flags are on); see TODOS.md.
-const SchemaVersion = "1.12.1"
+//	1.12.2 — inspect output gains `monitoring` (enabled +
+//	        prometheus_port + grafana_port) so agents can discover the
+//	        deployed Prometheus/Grafana stack. ManagedNode state gains
+//	        `metrics_port` so `network add` rebuilds scrape targets with
+//	        the node's real metrics port (instead of hardcoded 9527).
+//	        Additive optional fields throughout — PATCH.
+const SchemaVersion = "1.12.2"
 
 // JSONSchemaURLBase is the canonical URL prefix for individual output
 // schema files. Embedded $id values inside each schema mirror this so

--- a/internal/schema/files/inspect.schema.json
+++ b/internal/schema/files/inspect.schema.json
@@ -44,7 +44,17 @@
           "labels":       { "type": "object", "additionalProperties": { "type": "string" } },
           "network":      { "type": "string" },
           "build_cache_key": { "type": "string", "description": "Content-addressed build cache key (source-built nodes only)." },
-          "build_revision":  { "type": "string", "pattern": "^[0-9a-f]{12}$", "description": "Resolved source git revision (short) the node was built from (source-built nodes only)." }
+          "build_revision":  { "type": "string", "pattern": "^[0-9a-f]{12}$", "description": "Resolved source git revision (short) the node was built from (source-built nodes only)." },
+          "monitoring": {
+            "type": "object",
+            "description": "Prometheus + Grafana stack ports for nodes deployed with --monitor. Host is implicit: 127.0.0.1 for local targets, target.host for SSH.",
+            "required": ["enabled", "prometheus_port", "grafana_port"],
+            "properties": {
+              "enabled":         { "type": "boolean" },
+              "prometheus_port": { "type": "integer", "description": "Host port the Prometheus container is bound to. 0 means Prometheus is reachable only inside the docker network (not exposed)." },
+              "grafana_port":    { "type": "integer", "description": "Host port the Grafana container is bound to." }
+            }
+          }
         }
       }
     }

--- a/internal/schema/version_baseline.json
+++ b/internal/schema/version_baseline.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": "1.12.1",
+  "schema_version": "1.12.2",
   "entries": [
     {
       "name": "apply",
@@ -59,7 +59,7 @@
     },
     {
       "name": "inspect",
-      "hash": "edd4971f93c5810ca6e42969a48ee7a13a256e51ed36d88b8b1bbaa0e2148046"
+      "hash": "9e200ee43a9fa62b29f43d576672af6a4c033cd1fee07a410b5d012229786482"
     },
     {
       "name": "list",

--- a/internal/state/types.go
+++ b/internal/state/types.go
@@ -34,6 +34,10 @@ type ManagedNode struct {
 	// `network add` reads it from every existing entry to populate the new
 	// node's active_peers so it can immediately join the P2P mesh.
 	P2PPort int `json:"p2p_port,omitempty"`
+	// MetricsPort is the Prometheus scrape target port (node.metrics.prometheus.port,
+	// default 9527). Stored so network add's monitoring reload can build correct
+	// scrape targets even when the user overrides ports.metrics in the intent.
+	MetricsPort int `json:"metrics_port,omitempty"`
 	// Labels mirror intent.NodeSpec.Labels and survive across CLI sessions
 	// so test harnesses can filter via `trond list --label key=value`
 	// without touching the original intent file.

--- a/schemas/output/inspect.schema.json
+++ b/schemas/output/inspect.schema.json
@@ -44,7 +44,17 @@
           "labels":       { "type": "object", "additionalProperties": { "type": "string" } },
           "network":      { "type": "string" },
           "build_cache_key": { "type": "string", "description": "Content-addressed build cache key (source-built nodes only)." },
-          "build_revision":  { "type": "string", "pattern": "^[0-9a-f]{12}$", "description": "Resolved source git revision (short) the node was built from (source-built nodes only)." }
+          "build_revision":  { "type": "string", "pattern": "^[0-9a-f]{12}$", "description": "Resolved source git revision (short) the node was built from (source-built nodes only)." },
+          "monitoring": {
+            "type": "object",
+            "description": "Prometheus + Grafana stack ports for nodes deployed with --monitor. Host is implicit: 127.0.0.1 for local targets, target.host for SSH.",
+            "required": ["enabled", "prometheus_port", "grafana_port"],
+            "properties": {
+              "enabled":         { "type": "boolean" },
+              "prometheus_port": { "type": "integer", "description": "Host port the Prometheus container is bound to. 0 means Prometheus is reachable only inside the docker network (not exposed)." },
+              "grafana_port":    { "type": "integer", "description": "Host port the Grafana container is bound to." }
+            }
+          }
         }
       }
     }

--- a/tools/txgen/falcon.go
+++ b/tools/txgen/falcon.go
@@ -172,6 +172,9 @@ func GenerateFalconKeypair() (*FalconKeypair, error) {
 	// Strip the 0x09 serialization header: liboqs pk = 0x09 ‖ h_polynomial.
 	// BouncyCastle's FalconPublicKeyParameters(PARAMS, getH()) takes the
 	// 896-byte h polynomial without the header.
+	if pkBuf[0] != 0x09 {
+		return nil, fmt.Errorf("liboqs: unexpected Falcon public-key header 0x%02x, want 0x09", pkBuf[0])
+	}
 	hPoly := pkBuf[1:] // 896 bytes
 
 	hexAddr, b58 := addressFromPubBytes(hPoly)

--- a/tools/txgen/generate.go
+++ b/tools/txgen/generate.go
@@ -55,6 +55,7 @@ func runGenerate(ctx context.Context, cfg *Config) error {
 	if err != nil {
 		return err
 	}
+	defer signers.Close()
 
 	node := NewNodeClient(cfg.Node, 10*time.Second)
 
@@ -125,6 +126,7 @@ type signFunc func(unsigned *UnsignedTx) ([]byte, error)
 type signer struct {
 	senderHex string
 	sign      signFunc
+	close     func() // optional cleanup (e.g. liboqs native memory)
 }
 
 // signerSet selects a signer per transaction. When pqRatio is in (0,100)
@@ -145,6 +147,20 @@ func (s *signerSet) pick(roll int) *signer {
 	return s.ecdsa
 }
 
+// Close releases any native resources held by the signers (e.g. liboqs
+// OQS_SIG contexts). It is safe to call on a zero-value signerSet.
+func (s *signerSet) Close() {
+	if s == nil {
+		return
+	}
+	if s.ecdsa != nil && s.ecdsa.close != nil {
+		s.ecdsa.close()
+	}
+	if s.pq != nil && s.pq.close != nil {
+		s.pq.close()
+	}
+}
+
 // buildSigners wires up the signer(s) from config. The ECDSA signer is built
 // whenever any tx is ECDSA-signed (PQ disabled, or PQ ratio < 100); the PQ
 // signer is built when PQ is enabled.
@@ -159,6 +175,7 @@ func buildSigners(cfg *Config) (*signerSet, error) {
 			HexAddress() string
 			Base58Address() string
 			Sign(txIDHex string) ([]byte, error)
+			Close()
 		}
 
 		var ps pqSigner
@@ -190,6 +207,7 @@ func buildSigners(cfg *Config) (*signerSet, error) {
 				return AttachPQSignature(u.Raw, ps.SchemeName(),
 					ps.PublicKeyHex(), hex.EncodeToString(sig))
 			},
+			close: ps.Close,
 		}
 		log.Printf("generate: pq scheme = %s, ratio = %d%%, pq sender = %s (%s)",
 			ps.SchemeName(), set.pqRatio, ps.Base58Address(), ps.HexAddress())

--- a/tools/txgen/generate_test.go
+++ b/tools/txgen/generate_test.go
@@ -59,6 +59,9 @@ func TestBuildSignersMixed(t *testing.T) {
 	if set.pq.senderHex == set.ecdsa.senderHex {
 		t.Fatal("pq and ecdsa senders should differ")
 	}
+	// Close must not panic and should be idempotent.
+	set.Close()
+	set.Close()
 
 	// ratio 100 → no ECDSA signer needed.
 	full, err := buildSigners(newPQConfig(100, false))

--- a/tools/txgen/pq.go
+++ b/tools/txgen/pq.go
@@ -114,3 +114,8 @@ func (s *PQSigner) HexAddress() string { return s.hexAddr }
 
 // Base58Address returns the PQ-derived TRON address ("T..." form).
 func (s *PQSigner) Base58Address() string { return s.b58Addr }
+
+// Close is a no-op for the pure-Go ML-DSA signer. It exists so PQSigner
+// satisfies the same signer interface as FalconSigner, letting generate.go
+// clean up both paths uniformly.
+func (s *PQSigner) Close() {}


### PR DESCRIPTION
**What does this PR do?**

Two monitoring follow-ups identified during review of PR #185:

1. **Fix hardcoded metrics port in `network add`.** `reloadNetworkMonitoring` was hardcoding `:9527` as the scrape target when rebuilding `prometheus.yml` for a newly added node. If the user overrode `ports.metrics` in the intent, the reloaded config would point at the wrong port and Prometheus would never scrape the new node — silently empty dashboards. This PR stores `MetricsPort` in `ManagedNode` state (same pattern as `HTTPPort`/`GRPCPort`/`P2PPort`) and adds a `metricsPort()` helper that falls back to 9527 for legacy state entries.

2. **Expose monitoring stack via `trond inspect`.** When a node was deployed with `--monitor`, `inspect` output now includes an optional `monitoring` block (`enabled`, `prometheus_port`, `grafana_port`) so agents can discover the Prometheus/Grafana stack without re-parsing the apply result. Host is implicit — 127.0.0.1 for local targets, target.host for SSH — so only ports are needed.

3. **Schema bump.** `inspect.schema.json` gains the `monitoring` object (additive optional field). SchemaVersion bumped 1.12.1 → 1.12.2 (PATCH), following the same convention used in #197 which makes an identical class of change.

4. **txgen Falcon resource leak fix** (included on this branch, same module boundary).

**Test plan**

- [x] `go build ./...` passes
- [x] `go test ./...` passes (baseline re-snapshot at 1.12.2)
- [x] Rebased onto current develop (which now includes #197 at 1.12.1); SchemaVersion conflict resolved by sequencing 1.12.0 → 1.12.1 (#197) → 1.12.2 (this PR).

**Extra details**

Follow-up to PR #185 review feedback: "have `trond inspect` surface the Prometheus/Grafana endpoints so agents can discover them without parsing the apply result." The `MetricsPort` fix was a bug discovered while implementing this — `reloadNetworkMonitoring` was hardcoding 9527, which silently broke when a user customised `ports.metrics` in their intent.