### PR TITLE
fix(txgen): build-txgen-falcon graceful liboqs skip; document Falcon …

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -225,13 +225,14 @@ build-txgen-falcon: $(GO_BOOTSTRAP)
 		echo "   Install with: brew install liboqs  (macOS)"; \
 		echo "   or build from source: https://github.com/open-quantum-safe/liboqs"; \
 		exit 0; \
-	fi
-	@mkdir -p bin
+	fi; \
+	mkdir -p bin; \
+	echo "building bin/txgen with Falcon-512 (liboqs)..."; \
 	CGO_ENABLED=1 \
 	CGO_CFLAGS="$(LIBOQS_CFLAGS)" \
 	CGO_LDFLAGS="$(LIBOQS_LDFLAGS) $(OPENSSL_LDFLAGS)" \
-	$(GO) build -tags falcon -ldflags "$(LDFLAGS)" -o bin/txgen ./tools/txgen
-	@echo "✓ bin/txgen (with Falcon-512 via liboqs) built"
+	$(GO) build -tags falcon -ldflags "$(LDFLAGS)" -o bin/txgen ./tools/txgen && \
+	echo "✓ bin/txgen (with Falcon-512 via liboqs) built"
 
 ## install-txgen-falcon: Build + copy Falcon-enabled txgen into $(GOBIN).
 install-txgen-falcon: build-txgen-falcon

--- a/tools/txgen/README.md
+++ b/tools/txgen/README.md
@@ -212,6 +212,44 @@ transactions that should be PQ-signed (the rest are ECDSA-signed):
   before generating; txgen does not perform the permission update. The same
   `seed` always derives the same keypair/address, so provision once and reuse.
 
+The config example above uses `ML_DSA_44` (seed-derived, default build). `FN_DSA_512`
+is set up differently — see below.
+
+### Falcon-512 (FN_DSA_512) setup
+
+`FN_DSA_512` needs the falcon build and an explicit keypair (it is **not** seed-derived):
+
+1. **Build with liboqs** (see [Build variants](#build-variants)):
+   ```bash
+   brew install liboqs          # macOS (Linux: build liboqs from source)
+   make build-txgen-falcon      # → bin/txgen with Falcon-512
+   ```
+2. **Generate a keypair** with the `keygen` subcommand (falcon build only):
+   ```bash
+   txgen keygen --scheme FN_DSA_512 --out falcon-keypair.json
+   ```
+   It prints the derived TRON address plus a ready-to-paste `pq` block, and writes
+   `privateKey` (1281-byte liboqs secret key, 2562 hex chars) and `publicKey`
+   (896-byte h polynomial, 1792 hex chars) to the file.
+3. **Configure** `generate.pq` with those keys (use `privateKey` + `publicKey`
+   instead of `seed`):
+   ```json
+   "pq": {
+     "enabled": true,
+     "scheme": "FN_DSA_512",
+     "privateKey": "<2562-hex liboqs SK from keygen>",
+     "publicKey":  "<1792-hex h polynomial from keygen>",
+     "ratio": 30
+   }
+   ```
+4. **Provision the account**: fund the printed address with TRX (activation +
+   transfer amounts) **and** register the Falcon public key on the account via
+   `AccountPermissionUpdate` — `keygen` prints the exact steps.
+
+> Recap: `ML_DSA_44` → `seed` (default build, no liboqs). `FN_DSA_512` → `privateKey`
+> + `publicKey` from `keygen` (falcon build). `pq.ratio` and the two-senders rule
+> apply to both schemes.
+
 ---
 
 ## Prerequisites


### PR DESCRIPTION
…keygen + config

- Makefile: the liboqs-absent branch called `exit 0` in a separate recipe line, so Make still ran the build line and hard-failed when liboqs was missing — contrary to the documented "skip with exit 0 so CI won't fail". Join the liboqs check, mkdir, and build into one shell command so the skip exits the whole recipe; build path unchanged when liboqs is present.
- README: add "Falcon-512 (FN_DSA_512) setup" — the `txgen keygen` command, an FN_DSA_512 config example (privateKey/publicKey instead of seed), and per-scheme provisioning. Previously the README named FN_DSA_512 but never said how to obtain its keys.