### PR TITLE
fix(security): stop leaking the witness private key through output and file modes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,8 @@ CLAUDE.md
 shadow-fork-data/
 shadow-fork.conf
 shadow-fork-intent.yaml
+
+# txgen output — generate.outputDir defaults here. receivers.csv holds
+# one cleartext secp256k1 private key per receiver and MUST never be
+# committed.
+txgen-output/

--- a/cmd/config/diff.go
+++ b/cmd/config/diff.go
@@ -39,10 +39,14 @@ func runDiff(cmd *cobra.Command, args []string) error {
 	templateDir := findTemplateDir()
 	node := &parsed.Nodes[0]
 
-	newConfig, err := render.RenderHOCON(templateDir, parsed, node)
+	rendered, err := render.RenderHOCONWithSecrets(templateDir, parsed, node)
 	if err != nil {
 		return output.NewError("RENDER_ERROR", output.ExitGeneralError, err.Error())
 	}
+	// Compare the REAL bytes against the deployed file so a rotated
+	// witness key still shows up as a difference; simpleDiff redacts
+	// each line as it emits it, so no key reaches stdout or the JSON.
+	newConfig := rendered.Deployable()
 
 	// Load deployed config from state
 	store, err := state.NewStore(paths.State())
@@ -110,6 +114,13 @@ func runDiff(cmd *cobra.Command, args []string) error {
 }
 
 // simpleDiff does a basic line-by-line comparison.
+//
+// Secret handling: comparison uses the raw lines so genuine drift is
+// still reported, but every emitted line goes through
+// render.RedactWitnessLine first. The comparison is positional and
+// LCS-free, so any line-count change above the `localwitness`
+// assignment misaligns the tail and would otherwise print the SR
+// private key into `diffs[]`.
 func simpleDiff(old, new []string) []string {
 	var diffs []string
 
@@ -128,10 +139,10 @@ func simpleDiff(old, new []string) []string {
 		}
 		if oldLine != newLine {
 			if oldLine != "" {
-				diffs = append(diffs, fmt.Sprintf("- %s", oldLine))
+				diffs = append(diffs, fmt.Sprintf("- %s", render.RedactWitnessLine(oldLine)))
 			}
 			if newLine != "" {
-				diffs = append(diffs, fmt.Sprintf("+ %s", newLine))
+				diffs = append(diffs, fmt.Sprintf("+ %s", render.RedactWitnessLine(newLine)))
 			}
 		}
 	}

--- a/cmd/config/render.go
+++ b/cmd/config/render.go
@@ -50,6 +50,12 @@ type renderedNode struct {
 	Compose  string `json:"compose,omitempty"`
 	Systemd  string `json:"systemd,omitempty"`
 	JVMArgs  string `json:"jvm_args"`
+	// Redacted marks a node whose witness private key was replaced by
+	// a `<REDACTED:ENV_NAME>` placeholder in HOCON. The rendered config
+	// is then a PREVIEW: java-tron rejects the placeholder, so the file
+	// written by --output-dir must not be deployed as-is. Deploy with
+	// `trond apply`, which inlines the real key without printing it.
+	Redacted bool `json:"redacted,omitempty"`
 }
 
 func runRender(cmd *cobra.Command, args []string) error {
@@ -71,15 +77,23 @@ func runRender(cmd *cobra.Command, args []string) error {
 	templateDir := findTemplateDir()
 
 	rendered := make([]renderedNode, 0, len(parsed.Nodes))
+	anyRedacted := false
 
 	for i, node := range parsed.Nodes {
 		if renderNodeFilter >= 0 && i != renderNodeFilter {
 			continue
 		}
-		// Render HOCON config
-		hocon, err := render.RenderHOCON(templateDir, parsed, &node)
+		// Render HOCON config. This is a PREVIEW surface — the result
+		// is printed to stdout, inlined into the JSON payload and
+		// written to --output-dir — so we take the redacted display
+		// form, never the deployable one.
+		r, err := render.RenderHOCONWithSecrets(templateDir, parsed, &node)
 		if err != nil {
 			return output.NewError("RENDER_ERROR", output.ExitGeneralError, err.Error())
+		}
+		hocon := r.Config
+		if r.Redacted {
+			anyRedacted = true
 		}
 
 		// Render JVM args. Without a live target we can't probe JDK or real
@@ -109,6 +123,7 @@ func runRender(cmd *cobra.Command, args []string) error {
 			Compose:  composeYAML,
 			Systemd:  systemdUnit,
 			JVMArgs:  jvmArgs,
+			Redacted: r.Redacted,
 		})
 
 		// --output-dir is an explicit "write to disk" request — we
@@ -126,12 +141,31 @@ func runRender(cmd *cobra.Command, args []string) error {
 		}
 	}
 
+	// A redacted render is a preview, not a deployable artifact:
+	// java-tron rejects the `<REDACTED:...>` placeholder. Say so on
+	// stderr (which never mixes with the stdout payload) so an operator
+	// or agent piping render → docker compose up isn't left wondering
+	// why the witness refuses to sign.
+	if anyRedacted {
+		fmt.Fprintln(os.Stderr,
+			"warning: witness private key redacted from the rendered config — "+
+				"this output is a PREVIEW and java-tron will reject it. "+
+				"Use `trond apply` to deploy, which inlines the real key without printing it.")
+	}
+
 	if outputFmt == "json" {
-		return output.WriteJSON(os.Stdout, map[string]any{
+		payload := map[string]any{
 			"name":    parsed.Name,
 			"network": parsed.Network,
 			"nodes":   rendered,
-		})
+		}
+		if anyRedacted {
+			// Machine-readable twin of the stderr warning, so agents
+			// parsing only stdout still see that the artifact is a
+			// preview.
+			payload["redacted"] = true
+		}
+		return output.WriteJSON(os.Stdout, payload)
 	}
 
 	if renderOutputDir != "" {

--- a/cmd/config/render.go
+++ b/cmd/config/render.go
@@ -194,15 +194,28 @@ func runRender(cmd *cobra.Command, args []string) error {
 }
 
 func writeRenderedFiles(dir, name string, hocon, compose, systemd string) error {
-	if err := os.MkdirAll(dir, 0755); err != nil {
+	// 0700, not 0755: the .conf we are about to drop in here carries the
+	// witness signing key inlined by render.RenderHOCON (typesafe-config
+	// does no ${ENV} substitution, so the raw key ends up in the body).
+	// An existing directory keeps whatever mode it already has — a 0755
+	// directory holding a 0600 file is not an exposure, and silently
+	// tightening a path the operator chose is not ours to do.
+	if err := os.MkdirAll(dir, 0700); err != nil {
 		return fmt.Errorf("create output dir: %w", err)
 	}
 
 	configName := fmt.Sprintf("%s.conf", name)
-	if err := os.WriteFile(filepath.Join(dir, configName), []byte(hocon), 0644); err != nil {
+	if err := writeSecretFile(filepath.Join(dir, configName), []byte(hocon)); err != nil {
 		return fmt.Errorf("write hocon: %w", err)
 	}
 
+	// compose / systemd stay 0644, matching what the deploy path already
+	// writes for the same artifacts. trond never *resolves* a secret into
+	// them: the keystore password is emitted as the literal ${NAME}
+	// placeholder and the witness key fields are never referenced here.
+	// (An operator who types a literal secret into intent.extra_env has it
+	// copied verbatim into both — that is their own value, handled exactly
+	// as the deploy path handles it, and not what this finding is about.)
 	if compose != "" {
 		if err := os.WriteFile(filepath.Join(dir, "docker-compose.yaml"), []byte(compose), 0644); err != nil {
 			return fmt.Errorf("write compose: %w", err)
@@ -216,6 +229,37 @@ func writeRenderedFiles(dir, name string, hocon, compose, systemd string) error 
 		}
 	}
 
+	return nil
+}
+
+// writeSecretFile writes data to path with mode 0600, enforcing that mode
+// even when path already exists.
+//
+// os.WriteFile's perm argument applies only when it creates the file, so a
+// re-render into a stable --output-dir would otherwise keep a mode left
+// behind by an earlier run (0644 for anything written before this change)
+// and publish the witness key again. The chmod runs on the open descriptor
+// (fchmod), so it can only ever affect the inode we just opened, never a
+// path an attacker swapped in behind us; and it runs *before* the body is
+// written, so the secret bytes never exist in a loosely-moded file even
+// momentarily, and a failed write leaves an empty 0600 file rather than a
+// truncated world-readable one.
+func writeSecretFile(path string, data []byte) (err error) {
+	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if cerr := f.Close(); err == nil {
+			err = cerr
+		}
+	}()
+	if err := f.Chmod(0600); err != nil {
+		return err
+	}
+	if _, err := f.Write(data); err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/cmd/config/render_perms_test.go
+++ b/cmd/config/render_perms_test.go
@@ -1,0 +1,187 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+// The rendered HOCON carries the witness signing key inlined by
+// render.RenderHOCON, so `config render --output-dir` must never leave it
+// group/world readable. These tests pin the modes of every artifact
+// writeRenderedFiles produces, and — crucially — pin them for the
+// re-render case too: os.WriteFile's perm argument applies only on
+// creation, so writing over a .conf an earlier run left at 0644 has to
+// actively tighten the mode.
+
+const (
+	testHOCON   = "# rendered\nlocalwitness = [\"deadbeef\"]\n"
+	testCompose = "services:\n  node:\n    image: x\n"
+	testSystemd = "[Unit]\nDescription=x\n"
+)
+
+func skipIfNoUnixModes(t *testing.T) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX file modes are not meaningful on Windows")
+	}
+}
+
+func mode(t *testing.T, path string) os.FileMode {
+	t.Helper()
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat %s: %v", path, err)
+	}
+	return info.Mode().Perm()
+}
+
+func mustRead(t *testing.T, path string) string {
+	t.Helper()
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	return string(b)
+}
+
+// A fresh output dir: the directory is created 0700 and the secret-bearing
+// .conf 0600, while the non-secret runtime artifacts keep 0644.
+func TestWriteRenderedFiles_FreshDirModes(t *testing.T) {
+	skipIfNoUnixModes(t)
+	dir := filepath.Join(t.TempDir(), "out")
+
+	if err := writeRenderedFiles(dir, "my-witness", testHOCON, testCompose, testSystemd); err != nil {
+		t.Fatalf("writeRenderedFiles: %v", err)
+	}
+
+	if got := mode(t, dir); got != 0700 {
+		t.Errorf("output dir mode = %04o; want 0700", got)
+	}
+	conf := filepath.Join(dir, "my-witness.conf")
+	if got := mode(t, conf); got != 0600 {
+		t.Errorf("%s mode = %04o; want 0600", conf, got)
+	}
+	for _, name := range []string{"docker-compose.yaml", "tron-my-witness.service"} {
+		if got := mode(t, filepath.Join(dir, name)); got != 0644 {
+			t.Errorf("%s mode = %04o; want 0644", name, got)
+		}
+	}
+
+	// The bodies must be byte-identical to what was rendered.
+	if got := mustRead(t, conf); got != testHOCON {
+		t.Errorf("hocon body = %q; want %q", got, testHOCON)
+	}
+	if got := mustRead(t, filepath.Join(dir, "docker-compose.yaml")); got != testCompose {
+		t.Errorf("compose body = %q; want %q", got, testCompose)
+	}
+	if got := mustRead(t, filepath.Join(dir, "tron-my-witness.service")); got != testSystemd {
+		t.Errorf("systemd body = %q; want %q", got, testSystemd)
+	}
+}
+
+// The regression this fix is really about: an operator re-renders into a
+// stable --output-dir that already holds a .conf left world-readable by an
+// earlier (pre-fix) run. The mode argument to a create-if-missing write is
+// ignored for an existing file, so the write must tighten it explicitly.
+func TestWriteRenderedFiles_PreExistingConfIsTightened(t *testing.T) {
+	skipIfNoUnixModes(t)
+	dir := t.TempDir()
+	conf := filepath.Join(dir, "my-witness.conf")
+
+	// Simulate the artifact a pre-fix trond left behind: 0644, and longer
+	// than the new body so a missing truncate would show up as leftovers.
+	stale := "# stale render\nlocalwitness = [\"0000\"]\n" + string(make([]byte, 512))
+	if err := os.WriteFile(conf, []byte(stale), 0644); err != nil {
+		t.Fatalf("seed conf: %v", err)
+	}
+	if got := mode(t, conf); got != 0644 {
+		t.Fatalf("seeded conf mode = %04o; want 0644 (umask interfered)", got)
+	}
+
+	if err := writeRenderedFiles(dir, "my-witness", testHOCON, "", ""); err != nil {
+		t.Fatalf("writeRenderedFiles: %v", err)
+	}
+
+	if got := mode(t, conf); got != 0600 {
+		t.Fatalf("re-rendered conf mode = %04o; want 0600 — the witness key is still readable by other local accounts", got)
+	}
+	if got := mustRead(t, conf); got != testHOCON {
+		t.Errorf("re-rendered body = %q; want %q (stale content must be truncated)", got, testHOCON)
+	}
+}
+
+// Even a conf that somehow ended up group/world *writable* is brought back
+// to 0600 by a re-render.
+func TestWriteRenderedFiles_PreExistingConfWorldWritable(t *testing.T) {
+	skipIfNoUnixModes(t)
+	dir := t.TempDir()
+	conf := filepath.Join(dir, "n.conf")
+	if err := os.WriteFile(conf, []byte("old"), 0666); err != nil {
+		t.Fatalf("seed conf: %v", err)
+	}
+	if err := os.Chmod(conf, 0666); err != nil { // defeat the umask
+		t.Fatalf("chmod seed: %v", err)
+	}
+
+	if err := writeRenderedFiles(dir, "n", testHOCON, "", ""); err != nil {
+		t.Fatalf("writeRenderedFiles: %v", err)
+	}
+	if got := mode(t, conf); got != 0600 {
+		t.Errorf("conf mode = %04o; want 0600", got)
+	}
+}
+
+// Rendering twice in a row keeps the tight mode (and does not, e.g., widen
+// it on the second pass).
+func TestWriteRenderedFiles_ReRenderKeepsTightMode(t *testing.T) {
+	skipIfNoUnixModes(t)
+	dir := filepath.Join(t.TempDir(), "out")
+
+	for i := 0; i < 2; i++ {
+		if err := writeRenderedFiles(dir, "w", testHOCON, testCompose, ""); err != nil {
+			t.Fatalf("writeRenderedFiles pass %d: %v", i, err)
+		}
+	}
+	if got := mode(t, filepath.Join(dir, "w.conf")); got != 0600 {
+		t.Errorf("conf mode after re-render = %04o; want 0600", got)
+	}
+	if got := mode(t, filepath.Join(dir, "docker-compose.yaml")); got != 0644 {
+		t.Errorf("compose mode after re-render = %04o; want 0644", got)
+	}
+}
+
+// A directory the operator already created keeps its own mode — we only
+// promise that the file inside it is 0600. Changing a path the caller
+// chose (and may share deliberately) is not this function's business.
+func TestWriteRenderedFiles_ExistingDirModeUntouched(t *testing.T) {
+	skipIfNoUnixModes(t)
+	dir := filepath.Join(t.TempDir(), "out")
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.Chmod(dir, 0755); err != nil { // defeat the umask
+		t.Fatalf("chmod: %v", err)
+	}
+
+	if err := writeRenderedFiles(dir, "w", testHOCON, "", ""); err != nil {
+		t.Fatalf("writeRenderedFiles: %v", err)
+	}
+	if got := mode(t, dir); got != 0755 {
+		t.Errorf("existing dir mode = %04o; want it left at 0755", got)
+	}
+	if got := mode(t, filepath.Join(dir, "w.conf")); got != 0600 {
+		t.Errorf("conf mode = %04o; want 0600", got)
+	}
+}
+
+// writeSecretFile reports errors instead of silently leaving a file at a
+// loose mode; the unwritable-path case is the cheapest way to exercise it.
+func TestWriteSecretFile_ErrorPropagates(t *testing.T) {
+	skipIfNoUnixModes(t)
+	dir := t.TempDir()
+	if err := writeSecretFile(filepath.Join(dir, "missing-subdir", "x.conf"), []byte("x")); err == nil {
+		t.Fatal("writeSecretFile into a nonexistent directory: want error, got nil")
+	}
+}

--- a/cmd/config/witness_redaction_test.go
+++ b/cmd/config/witness_redaction_test.go
@@ -1,0 +1,203 @@
+package config
+
+import (
+	"encoding/json"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+const (
+	cfgKeyA = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	cfgKeyB = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+)
+
+// TestSimpleDiff_RedactsWitnessKey is the F3 regression for `trond
+// config diff`. It compares the deployed .conf (which carries the real
+// SR key) against a fresh render (which also carries it, so that
+// genuine drift is still detected) with a positional, LCS-free walk —
+// so any line-count change above the assignment misaligns the tail and
+// would otherwise print the key to stdout and into diffs[].
+func TestSimpleDiff_RedactsWitnessKey(t *testing.T) {
+	cases := []struct {
+		name         string
+		old, new     []string
+		wantDiffs    int
+		wantRedacted int
+	}{
+		{
+			name:         "key-rotation",
+			old:          []string{"a = 1", `localwitness = ["` + cfgKeyA + `"]`},
+			new:          []string{"a = 1", `localwitness = ["` + cfgKeyB + `"]`},
+			wantDiffs:    2,
+			wantRedacted: 2,
+		},
+		{
+			name:         "line-shift-same-key",
+			old:          []string{"a = 1", `localwitness = ["` + cfgKeyA + `"]`},
+			new:          []string{"a = 1", "seed.node.ip.list = []", `localwitness = ["` + cfgKeyA + `"]`},
+			wantDiffs:    3,
+			wantRedacted: 2,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			diffs := simpleDiff(tc.old, tc.new)
+			for _, d := range diffs {
+				if strings.Contains(d, cfgKeyA) || strings.Contains(d, cfgKeyB) {
+					t.Errorf("simpleDiff leaked a witness private key: %q", d)
+				}
+			}
+			if len(diffs) != tc.wantDiffs {
+				t.Errorf("drift reporting changed: got %d lines, want %d: %v",
+					len(diffs), tc.wantDiffs, diffs)
+			}
+			n := 0
+			for _, d := range diffs {
+				if strings.Contains(d, `localwitness = ["<REDACTED>"]`) {
+					n++
+				}
+			}
+			if n != tc.wantRedacted {
+				t.Errorf("expected %d redacted markers, got %d: %v", tc.wantRedacted, n, diffs)
+			}
+		})
+	}
+
+	// Redacting before comparing would swallow real drift; redacting
+	// after must not.
+	same := []string{`localwitness = ["` + cfgKeyA + `"]`}
+	if diffs := simpleDiff(same, same); len(diffs) != 0 {
+		t.Errorf("unchanged key must not be reported as drift: %v", diffs)
+	}
+}
+
+// TestRunRender_WitnessRedactionIsSignalled covers objection 2: the
+// artifact `--output-dir` writes is a preview java-tron rejects, so the
+// caller has to be told — on stderr and in the JSON envelope.
+func TestRunRender_WitnessRedactionIsSignalled(t *testing.T) {
+	t.Setenv("PROBE_SR_KEY", cfgKeyA)
+
+	dir := t.TempDir()
+	intentPath := filepath.Join(dir, "witness.yaml")
+	if err := os.WriteFile(intentPath, []byte(`name: probe-witness
+target:
+  type: local
+  runtime: docker
+network: mainnet
+nodes:
+  - type: witness
+    version: latest
+    witness_key:
+      private_key_env: PROBE_SR_KEY
+`), 0o600); err != nil {
+		t.Fatalf("write intent: %v", err)
+	}
+
+	outDir := filepath.Join(dir, "out")
+	stdout, stderr := runRenderCapture(t, intentPath, outDir, "json")
+
+	if strings.Contains(stdout, cfgKeyA) {
+		t.Fatal("config render -o json emitted the raw witness private key on stdout")
+	}
+	if !strings.Contains(stderr, "PREVIEW") {
+		t.Errorf("expected a preview warning on stderr, got %q", stderr)
+	}
+
+	var payload struct {
+		Redacted bool `json:"redacted"`
+		Nodes    []struct {
+			Redacted bool `json:"redacted"`
+		} `json:"nodes"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &payload); err != nil {
+		t.Fatalf("stdout is not JSON: %v", err)
+	}
+	if !payload.Redacted {
+		t.Error("JSON envelope must carry redacted: true")
+	}
+	if len(payload.Nodes) != 1 || !payload.Nodes[0].Redacted {
+		t.Error("the rendered node must carry redacted: true")
+	}
+
+	// The file on disk fails closed: placeholder, never the key.
+	written, err := os.ReadFile(filepath.Join(outDir, "probe-witness.conf"))
+	if err != nil {
+		t.Fatalf("read written conf: %v", err)
+	}
+	if strings.Contains(string(written), cfgKeyA) {
+		t.Fatal("--output-dir wrote the raw witness private key to disk")
+	}
+	if !strings.Contains(string(written), `localwitness = ["<REDACTED:PROBE_SR_KEY>"]`) {
+		t.Error("written conf is missing the redaction placeholder")
+	}
+}
+
+// TestRunRender_NoWitnessNoSignal keeps the flag and the warning off
+// the overwhelmingly common non-witness path.
+func TestRunRender_NoWitnessNoSignal(t *testing.T) {
+	dir := t.TempDir()
+	intentPath := filepath.Join(dir, "fullnode.yaml")
+	if err := os.WriteFile(intentPath, []byte(`name: probe-fullnode
+target:
+  type: local
+  runtime: docker
+network: nile
+nodes:
+  - type: fullnode
+    version: latest
+`), 0o600); err != nil {
+		t.Fatalf("write intent: %v", err)
+	}
+
+	stdout, stderr := runRenderCapture(t, intentPath, "", "json")
+	if stderr != "" {
+		t.Errorf("no redaction happened, so stderr must stay quiet, got %q", stderr)
+	}
+	if strings.Contains(stdout, `"redacted"`) {
+		t.Error("redacted must be omitted entirely when nothing was redacted")
+	}
+}
+
+// runRenderCapture invokes runRender with os.Stdout / os.Stderr piped,
+// returning what each stream received.
+func runRenderCapture(t *testing.T, intentPath, outputDir, format string) (string, string) {
+	t.Helper()
+
+	prevOutDir, prevOverlay, prevFilter := renderOutputDir, renderOverlay, renderNodeFilter
+	renderOutputDir, renderOverlay, renderNodeFilter = outputDir, "", -1
+	t.Cleanup(func() {
+		renderOutputDir, renderOverlay, renderNodeFilter = prevOutDir, prevOverlay, prevFilter
+	})
+
+	cmd := &cobra.Command{}
+	cmd.Flags().String("output", format, "")
+
+	outR, outW, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	errR, errW, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	origOut, origErr := os.Stdout, os.Stderr
+	os.Stdout, os.Stderr = outW, errW
+
+	runErr := runRender(cmd, []string{intentPath})
+
+	os.Stdout, os.Stderr = origOut, origErr
+	outW.Close()
+	errW.Close()
+	outBytes, _ := io.ReadAll(outR)
+	errBytes, _ := io.ReadAll(errR)
+
+	if runErr != nil {
+		t.Fatalf("runRender: %v", runErr)
+	}
+	return string(outBytes), string(errBytes)
+}

--- a/cmd/network/add.go
+++ b/cmd/network/add.go
@@ -157,10 +157,12 @@ func runAdd(cmd *cobra.Command, args []string) error {
 	}
 
 	templateDir := findTemplatesDir()
-	hocon, err := render.RenderHOCON(templateDir, parsed, node)
+	rendered, err := render.RenderHOCONWithSecrets(templateDir, parsed, node)
 	if err != nil {
 		return fmt.Errorf("render config: %w", err)
 	}
+	// Deploy path — needs the real witness key inlined.
+	hocon := rendered.Deployable()
 
 	memGB := render.ParseMemoryGB(node.Resources.Memory)
 	if memGB == 0 {

--- a/cmd/network/create.go
+++ b/cmd/network/create.go
@@ -131,10 +131,12 @@ func runCreate(cmd *cobra.Command, args []string) error {
 	for i, node := range parsed.Nodes {
 		nodeName := fmt.Sprintf("%s-node%d", parsed.Name, i)
 
-		hocon, err := render.RenderHOCON(templateDir, parsed, &node)
+		rendered, err := render.RenderHOCONWithSecrets(templateDir, parsed, &node)
 		if err != nil {
 			return fmt.Errorf("render config for node %d: %w", i, err)
 		}
+		// Deploy path — needs the real witness key inlined.
+		hocon := rendered.Deployable()
 
 		memGB := render.ParseMemoryGB(node.Resources.Memory)
 		if memGB == 0 {

--- a/cmd/plan.go
+++ b/cmd/plan.go
@@ -80,10 +80,15 @@ func runPlan(cmd *cobra.Command, args []string) error {
 	templateDir := findTemplatesDir()
 	node := &parsed.Nodes[0]
 
-	hoconConfig, err := render.RenderHOCON(templateDir, parsed, node)
+	rendered, err := render.RenderHOCONWithSecrets(templateDir, parsed, node)
 	if err != nil {
 		return exitWithError("RENDER_ERROR", output.ExitGeneralError, err.Error())
 	}
+	// The REAL bytes: config_hash must match what apply deploys, and the
+	// diff below must compare real values so a rotated witness key is
+	// still detected. Nothing from here reaches the output un-redacted —
+	// simpleHOCONDiff redacts every line at the point it emits it.
+	hoconConfig := rendered.Deployable()
 	configHash := apply.IntentHashFromBytes([]byte(hoconConfig))
 
 	// 5. Diff
@@ -186,6 +191,14 @@ func runPlan(cmd *cobra.Command, args []string) error {
 // shape as cmd/config/diff.go::simpleDiff but private to plan to
 // avoid coupling — both could call into a shared internal/diff
 // helper later if a third caller appears.
+//
+// Secret handling: the comparison runs on the raw lines (so a witness
+// key that actually changed is still reported as drift), but every
+// line is passed through render.RedactWitnessLine before it is
+// emitted. This differ is positional and LCS-free, so a line-count
+// change anywhere above the `localwitness` assignment misaligns the
+// tail and would otherwise push the SR private key straight into
+// stdout and into result["config_diff"].
 func simpleHOCONDiff(old, new []string) []string {
 	var diffs []string
 	maxLen := len(old)
@@ -202,10 +215,10 @@ func simpleHOCONDiff(old, new []string) []string {
 		}
 		if oldLine != newLine {
 			if oldLine != "" {
-				diffs = append(diffs, "- "+oldLine)
+				diffs = append(diffs, "- "+render.RedactWitnessLine(oldLine))
 			}
 			if newLine != "" {
-				diffs = append(diffs, "+ "+newLine)
+				diffs = append(diffs, "+ "+render.RedactWitnessLine(newLine))
 			}
 		}
 	}

--- a/cmd/verify_config.go
+++ b/cmd/verify_config.go
@@ -89,11 +89,15 @@ func runVerifyConfig(cmd *cobra.Command, args []string) error {
 			"Confirm the runtime: trond inspect "+name)
 	}
 
-	// Render what trond *would* produce from the current intent.
-	desired, err := render.RenderHOCON(findTemplatesDir(), parsed, &parsed.Nodes[0])
+	// Render what trond *would* produce from the current intent. The
+	// comparison runs against the REAL bytes (redacting here would make
+	// every witness node report permanent false drift against its live
+	// conf); lineDiff redacts each line as it emits it.
+	renderedDesired, err := render.RenderHOCONWithSecrets(findTemplatesDir(), parsed, &parsed.Nodes[0])
 	if err != nil {
 		return exitWithError("RENDER_ERROR", output.ExitGeneralError, err.Error())
 	}
+	desired := renderedDesired.Deployable()
 
 	diffs := lineDiff(live, desired, verifyConfigContext)
 	result := map[string]any{
@@ -152,6 +156,13 @@ func readLiveConfig(ctx context.Context, nc *nodeContext, name string) (string, 
 // of this output are agents that key off `in_sync`/`diff_count`,
 // not humans diffing big patches. The unified-diff formatting is
 // precise enough for the operator-friendly text path.
+//
+// Secret handling: BOTH sides carry the real witness key — `live` is
+// read off the deployed host and `desired` is the deployable render —
+// so every emitted line, including the --context neighbours (which are
+// emitted even when they match), is passed through
+// render.RedactWitnessLine. Comparison still uses the raw lines, so a
+// rotated key is still counted in diff_count and flips in_sync.
 func lineDiff(live, desired string, contextLines int) []string {
 	a := strings.Split(strings.TrimRight(live, "\n"), "\n")
 	b := strings.Split(strings.TrimRight(desired, "\n"), "\n")
@@ -181,17 +192,17 @@ func lineDiff(live, desired string, contextLines int) []string {
 			}
 			for j := lo; j < i; j++ {
 				if j < len(a) {
-					diffs = append(diffs, "  "+a[j])
+					diffs = append(diffs, "  "+render.RedactWitnessLine(a[j]))
 				}
 			}
 		}
 		switch {
 		case i < len(a) && i >= len(b):
-			diffs = append(diffs, "- "+aLine)
+			diffs = append(diffs, "- "+render.RedactWitnessLine(aLine))
 		case i >= len(a) && i < len(b):
-			diffs = append(diffs, "+ "+bLine)
+			diffs = append(diffs, "+ "+render.RedactWitnessLine(bLine))
 		default:
-			diffs = append(diffs, "- "+aLine, "+ "+bLine)
+			diffs = append(diffs, "- "+render.RedactWitnessLine(aLine), "+ "+render.RedactWitnessLine(bLine))
 		}
 	}
 	return diffs

--- a/cmd/witness_redaction_test.go
+++ b/cmd/witness_redaction_test.go
@@ -1,0 +1,150 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+)
+
+// F3 regression tests for the two positional, LCS-free differs that
+// live in package cmd: simpleHOCONDiff (plan --diff, whose output goes
+// into result["config_diff"] and out through output.WriteJSON) and
+// lineDiff (verify-config, whose output goes into diffs[]).
+//
+// Both compare a live/deployed .conf — which carries the real SR key —
+// against a freshly rendered one. Because neither differ aligns lines,
+// ANY line-count change above the `localwitness` assignment misaligns
+// the whole tail and pushes the key into the emitted diff.
+
+const (
+	keyA = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	keyB = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+)
+
+func assertNoKeys(t *testing.T, where string, lines []string) {
+	t.Helper()
+	for _, l := range lines {
+		for _, k := range []string{keyA, keyB} {
+			if strings.Contains(l, k) {
+				t.Errorf("%s leaked a witness private key: %q", where, l)
+			}
+		}
+	}
+}
+
+func countRedactedMarkers(lines []string) int {
+	n := 0
+	for _, l := range lines {
+		if strings.Contains(l, `localwitness = ["<REDACTED>"]`) {
+			n++
+		}
+	}
+	return n
+}
+
+func TestSimpleHOCONDiff_RedactsWitnessKey(t *testing.T) {
+	cases := []struct {
+		name         string
+		old, new     []string
+		wantDiffs    int
+		wantRedacted int
+	}{
+		{
+			// Key rotated in the environment: the assignment genuinely
+			// differs and must still be reported, redacted on both sides.
+			name:         "key-rotation",
+			old:          []string{"a = 1", `localwitness = ["` + keyA + `"]`},
+			new:          []string{"a = 1", `localwitness = ["` + keyB + `"]`},
+			wantDiffs:    2,
+			wantRedacted: 2,
+		},
+		{
+			// Operator added network_overrides.seeds: one extra line
+			// above the assignment misaligns the positional differ, so
+			// the (unchanged) key lands on both sides of a diff pair.
+			name:         "line-shift-same-key",
+			old:          []string{"a = 1", `localwitness = ["` + keyA + `"]`},
+			new:          []string{"a = 1", "seed.node.ip.list = []", `localwitness = ["` + keyA + `"]`},
+			wantDiffs:    3,
+			wantRedacted: 2,
+		},
+		{
+			// Tail truncation: the key line only exists on the old side.
+			name:         "old-side-only",
+			old:          []string{"a = 1", `localwitness = ["` + keyA + `"]`},
+			new:          []string{"a = 1"},
+			wantDiffs:    1,
+			wantRedacted: 1,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			diffs := simpleHOCONDiff(tc.old, tc.new)
+			assertNoKeys(t, "simpleHOCONDiff", diffs)
+			if len(diffs) != tc.wantDiffs {
+				t.Errorf("drift reporting changed: got %d diff lines, want %d: %v",
+					len(diffs), tc.wantDiffs, diffs)
+			}
+			if got := countRedactedMarkers(diffs); got != tc.wantRedacted {
+				t.Errorf("expected %d redacted markers, got %d: %v", tc.wantRedacted, got, diffs)
+			}
+		})
+	}
+}
+
+// TestSimpleHOCONDiff_StillDetectsRotation guards against the opposite
+// failure: redacting BEFORE comparing would make a rotated key look
+// identical and silently swallow real drift.
+func TestSimpleHOCONDiff_StillDetectsRotation(t *testing.T) {
+	old := []string{`localwitness = ["` + keyA + `"]`}
+	new := []string{`localwitness = ["` + keyB + `"]`}
+	if diffs := simpleHOCONDiff(old, new); len(diffs) != 2 {
+		t.Fatalf("a rotated witness key must still be reported as drift, got %v", diffs)
+	}
+	if diffs := simpleHOCONDiff(old, old); len(diffs) != 0 {
+		t.Fatalf("an unchanged witness key must not be reported as drift, got %v", diffs)
+	}
+}
+
+func TestLineDiff_RedactsWitnessKey(t *testing.T) {
+	live := "a = 1\n" + `localwitness = ["` + keyA + `"]` + "\nz = 9\n"
+
+	t.Run("key-rotation", func(t *testing.T) {
+		desired := "a = 1\n" + `localwitness = ["` + keyB + `"]` + "\nz = 9\n"
+		diffs := lineDiff(live, desired, 0)
+		assertNoKeys(t, "lineDiff", diffs)
+		if len(diffs) != 2 {
+			t.Errorf("rotated key must still be reported: %v", diffs)
+		}
+		if got := countRedactedMarkers(diffs); got != 2 {
+			t.Errorf("expected 2 redacted markers, got %d: %v", got, diffs)
+		}
+	})
+
+	t.Run("line-shift", func(t *testing.T) {
+		desired := "a = 1\nseed.node.ip.list = []\n" + `localwitness = ["` + keyA + `"]` + "\nz = 9\n"
+		diffs := lineDiff(live, desired, 0)
+		assertNoKeys(t, "lineDiff", diffs)
+		if len(diffs) == 0 {
+			t.Error("a line shift must still be reported as drift")
+		}
+	})
+
+	// --context > 0 emits neighbouring lines that MATCH. Those come
+	// from the live side and carry the real key, so they need the same
+	// treatment as the changed lines.
+	t.Run("context-lines", func(t *testing.T) {
+		desired := "a = 1\n" + `localwitness = ["` + keyA + `"]` + "\nz = CHANGED\n"
+		diffs := lineDiff(live, desired, 2)
+		assertNoKeys(t, "lineDiff --context", diffs)
+		joined := strings.Join(diffs, "\n")
+		if !strings.Contains(joined, `  localwitness = ["<REDACTED>"]`) {
+			t.Errorf("context line should be emitted redacted, got:\n%s", joined)
+		}
+	})
+
+	t.Run("identical-is-in-sync", func(t *testing.T) {
+		if diffs := lineDiff(live, live, 0); len(diffs) != 0 {
+			t.Errorf("identical configs must stay in_sync, got %v", diffs)
+		}
+	})
+}

--- a/internal/apply/apply.go
+++ b/internal/apply/apply.go
@@ -228,10 +228,14 @@ func Apply(ctx context.Context, opts Options) (*Result, error) {
 		return noChangeResult(opts, buildSummary, start), nil
 	}
 
-	hocon, err := render.RenderHOCON(opts.TemplateDir, opts.Intent, node)
+	rendered, err := render.RenderHOCONWithSecrets(opts.TemplateDir, opts.Intent, node)
 	if err != nil {
 		return nil, fmt.Errorf("render hocon: %w", err)
 	}
+	// Deploy path: java-tron needs the real witness key inlined, and
+	// config_hash must stay computed over those same bytes so
+	// idempotency is unaffected by redaction on the preview paths.
+	hocon := rendered.Deployable()
 	configHash := sha256hex([]byte(hocon))
 
 	jdk := opts.JDKVersion

--- a/internal/apply/witness_deploy_test.go
+++ b/internal/apply/witness_deploy_test.go
@@ -1,0 +1,88 @@
+package apply
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/tronprotocol/tron-deployment/internal/intent"
+)
+
+// recordingTarget captures every file the runtime writes so a test can
+// assert on the exact bytes that would land on the deployed host.
+type recordingTarget struct {
+	fakeTarget
+	files map[string][]byte
+}
+
+func (r *recordingTarget) WriteFile(_ context.Context, path string, data []byte, _ os.FileMode) error {
+	if r.files == nil {
+		r.files = map[string][]byte{}
+	}
+	r.files[path] = append([]byte(nil), data...)
+	return nil
+}
+
+// TestApply_DeploysRealWitnessKeyAndHashesIt is the other half of F3:
+// redacting the preview surfaces must not touch what java-tron
+// receives. The bytes handed to runtime.Deploy still carry the real
+// key, and config_hash is still the SHA-256 of exactly those bytes —
+// so idempotency (`apply` → `no_change`) is unaffected.
+func TestApply_DeploysRealWitnessKeyAndHashesIt(t *testing.T) {
+	const key = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	t.Setenv("PROBE_SR_KEY", key)
+
+	parsed := &intent.Intent{
+		Name:    "witness-node",
+		Network: "mainnet",
+		Target:  intent.Target{Type: "local", Runtime: "docker"},
+		Nodes: []intent.NodeSpec{{
+			Type:       "witness",
+			Version:    "4.8.1",
+			Resources:  intent.Resources{Memory: "8GB"},
+			Ports:      intent.PortMapping{HTTP: 8090, GRPC: 50051},
+			WitnessKey: &intent.WitnessKey{PrivateKeyEnv: "PROBE_SR_KEY"},
+		}},
+	}
+	store, st := freshStore(t)
+	tgt := &recordingTarget{}
+
+	res, err := Apply(context.Background(), Options{
+		Intent:         parsed,
+		Target:         tgt,
+		Store:          store,
+		State:          st,
+		IntentHash:     "deadbeef",
+		DeploymentsDir: t.TempDir(),
+		JDKVersion:     17,
+	})
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+
+	var conf []byte
+	for path, data := range tgt.files {
+		if strings.HasSuffix(path, "witness-node.conf") {
+			conf = data
+		}
+	}
+	if conf == nil {
+		t.Fatal("no .conf was written to the target")
+	}
+
+	if !strings.Contains(string(conf), `localwitness = ["`+key+`"]`) {
+		t.Fatal("deployed config lost the real witness key — java-tron would refuse to sign")
+	}
+	if strings.Contains(string(conf), "<REDACTED") {
+		t.Fatal("deployed config carries a redaction placeholder")
+	}
+
+	sum := sha256.Sum256(conf)
+	if res.ConfigHash != hex.EncodeToString(sum[:]) {
+		t.Errorf("config_hash must be the SHA-256 of the deployed bytes\n got: %s\nwant: %s",
+			res.ConfigHash, hex.EncodeToString(sum[:]))
+	}
+}

--- a/internal/knowledge/files/shadow-fork-poc.md
+++ b/internal/knowledge/files/shadow-fork-poc.md
@@ -100,8 +100,10 @@ The `observe` step below is the actual readiness check.
 **Security note — rendered HOCON contains the private key.**
 trond inlines the witness's hex private key into the per-node
 HOCON config at `~/.trond/deployments/shadow-fork-poc/shadow-fork-poc.conf`
-(java-tron requires the key in-config for production). Mode
-defaults to 0644. Treat that file like the keypair stash —
+(java-tron requires the key in-config for production). It is
+written 0600 inside a 0700 deployment directory (the container
+reads it through a read-only bind mount as root, so nothing else
+needs access). Treat that file like the keypair stash —
 remove with the `teardown` recipe at the bottom of this doc
 once finished.
 

--- a/internal/mcp/drift_redaction_test.go
+++ b/internal/mcp/drift_redaction_test.go
@@ -1,0 +1,134 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// F3 regression test for mcpLineDiff. Its output is returned as an MCP
+// tool result, i.e. straight into an LLM transcript held by a
+// third-party model provider — the worst-case disclosure path for an
+// SR signing key. Both sides carry the real key (the live conf is read
+// off the deployed host, the desired side is the deployable render),
+// and the differ is positional and LCS-free, so any line-count change
+// above the assignment misaligns the tail and emits it.
+
+const (
+	mcpKeyA = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	mcpKeyB = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+)
+
+func assertNoMCPKeys(t *testing.T, diffs []string) {
+	t.Helper()
+	for _, l := range diffs {
+		for _, k := range []string{mcpKeyA, mcpKeyB} {
+			if strings.Contains(l, k) {
+				t.Errorf("mcpLineDiff leaked a witness private key over MCP: %q", l)
+			}
+		}
+	}
+}
+
+func TestMCPLineDiff_RedactsWitnessKey(t *testing.T) {
+	live := "a = 1\n" + `localwitness = ["` + mcpKeyA + `"]` + "\nz = 9\n"
+
+	t.Run("key-rotation", func(t *testing.T) {
+		desired := "a = 1\n" + `localwitness = ["` + mcpKeyB + `"]` + "\nz = 9\n"
+		diffs := mcpLineDiff(live, desired, 0)
+		assertNoMCPKeys(t, diffs)
+		if len(diffs) != 2 {
+			t.Errorf("a rotated witness key must still be reported as drift: %v", diffs)
+		}
+		for _, d := range diffs {
+			if !strings.Contains(d, `localwitness = ["<REDACTED>"]`) {
+				t.Errorf("expected a redacted marker, got %q", d)
+			}
+		}
+	})
+
+	t.Run("line-shift", func(t *testing.T) {
+		desired := "a = 1\nseed.node.ip.list = []\n" + `localwitness = ["` + mcpKeyA + `"]` + "\nz = 9\n"
+		diffs := mcpLineDiff(live, desired, 0)
+		assertNoMCPKeys(t, diffs)
+		if len(diffs) == 0 {
+			t.Error("a line shift must still be reported as drift")
+		}
+	})
+
+	t.Run("context-lines", func(t *testing.T) {
+		desired := "a = 1\n" + `localwitness = ["` + mcpKeyA + `"]` + "\nz = CHANGED\n"
+		diffs := mcpLineDiff(live, desired, 2)
+		assertNoMCPKeys(t, diffs)
+		if !strings.Contains(strings.Join(diffs, "\n"), `  localwitness = ["<REDACTED>"]`) {
+			t.Errorf("matching --context lines must be redacted too, got:\n%s", strings.Join(diffs, "\n"))
+		}
+	})
+
+	t.Run("identical-is-in-sync", func(t *testing.T) {
+		if diffs := mcpLineDiff(live, live, 0); len(diffs) != 0 {
+			t.Errorf("identical configs must stay in_sync, got %v", diffs)
+		}
+	})
+}
+
+// TestRenderTool_RedactsWitnessKey covers the other MCP surface named
+// by F3: config_render returns the whole rendered HOCON inline, so an
+// un-redacted witness key would be handed straight to the model
+// provider. The result must also flag itself as a preview.
+func TestRenderTool_RedactsWitnessKey(t *testing.T) {
+	t.Setenv("PROBE_SR_KEY", mcpKeyA)
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "witness.yaml")
+	body := `name: probe-witness
+target:
+  type: local
+  runtime: docker
+network: mainnet
+nodes:
+  - type: witness
+    version: latest
+    witness_key:
+      private_key_env: PROBE_SR_KEY
+`
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatalf("write intent: %v", err)
+	}
+
+	res, _, err := renderTool(context.Background(), nil, renderArg{Path: path})
+	if err != nil {
+		t.Fatalf("renderTool: %v", err)
+	}
+	// The wire body is what actually reaches the model provider.
+	if strings.Contains(extractText(t, res), mcpKeyA) {
+		t.Fatal("config_render returned the raw witness private key over MCP")
+	}
+
+	var payload struct {
+		Redacted bool `json:"redacted"`
+		Nodes    []struct {
+			HOCON    string `json:"hocon"`
+			Redacted bool   `json:"redacted"`
+		} `json:"nodes"`
+	}
+	if err := json.Unmarshal([]byte(extractText(t, res)), &payload); err != nil {
+		t.Fatalf("tool body is not JSON: %v", err)
+	}
+	if len(payload.Nodes) != 1 {
+		t.Fatalf("expected 1 rendered node, got %d", len(payload.Nodes))
+	}
+	if strings.Contains(payload.Nodes[0].HOCON, mcpKeyA) {
+		t.Fatal("rendered hocon carries the raw witness private key")
+	}
+	if !strings.Contains(payload.Nodes[0].HOCON, `localwitness = ["<REDACTED:PROBE_SR_KEY>"]`) {
+		t.Error("rendered hocon is missing the redaction placeholder")
+	}
+	if !payload.Redacted || !payload.Nodes[0].Redacted {
+		t.Errorf("result must flag itself as a redacted preview (envelope=%t node=%t)",
+			payload.Redacted, payload.Nodes[0].Redacted)
+	}
+}

--- a/internal/mcp/tools_config.go
+++ b/internal/mcp/tools_config.go
@@ -34,7 +34,7 @@ func registerConfigTools(s *mcp.Server) {
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "config_render",
 		Title:       "Render intent to HOCON + compose/systemd",
-		Description: "Render the intent.yaml into the final java-tron HOCON config plus the compose / systemd file that would be written. Useful for previewing what apply would produce. Equivalent to `trond config render <path> -o json`.",
+		Description: "Render the intent.yaml into the final java-tron HOCON config plus the compose / systemd file that would be written. Useful for previewing what apply would produce. A witness node's private key is never returned — it is replaced by a `<REDACTED:ENV_NAME>` placeholder and `redacted: true` is set, so the HOCON is a preview java-tron would reject; deploy with the apply tool instead. Equivalent to `trond config render <path> -o json`.",
 		Annotations: &mcp.ToolAnnotations{ReadOnlyHint: true, IdempotentHint: true},
 	}, renderTool)
 }
@@ -70,6 +70,7 @@ func renderTool(ctx context.Context, _ *mcp.CallToolRequest, args renderArg) (*m
 	templateDir := ""
 
 	rendered := make([]map[string]any, 0, len(parsed.Nodes))
+	anyRedacted := false
 	for i := range parsed.Nodes {
 		// args.Node uses 0 for "all" (default); 1-based index for filter.
 		// So args.Node=2 → render only the second node (i=1).
@@ -77,7 +78,10 @@ func renderTool(ctx context.Context, _ *mcp.CallToolRequest, args renderArg) (*m
 			continue
 		}
 		node := &parsed.Nodes[i]
-		hocon, err := render.RenderHOCON(templateDir, parsed, node)
+		// Preview surface returned to the MCP client (and therefore to
+		// a third-party model provider): take the redacted display
+		// form, never the deployable one.
+		r, err := render.RenderHOCONWithSecrets(templateDir, parsed, node)
 		if err != nil {
 			return errResult(err)
 		}
@@ -91,8 +95,14 @@ func renderTool(ctx context.Context, _ *mcp.CallToolRequest, args renderArg) (*m
 			"index":    i,
 			"name":     parsed.Name,
 			"type":     node.Type,
-			"hocon":    hocon,
+			"hocon":    r.Config,
 			"jvm_args": jvmArgs,
+		}
+		if r.Redacted {
+			// Flags the HOCON as a preview: the witness key was
+			// replaced by a placeholder java-tron will reject.
+			row["redacted"] = true
+			anyRedacted = true
 		}
 		runtime := parsed.Target.Runtime
 		if runtime == "" {
@@ -106,9 +116,13 @@ func renderTool(ctx context.Context, _ *mcp.CallToolRequest, args renderArg) (*m
 		}
 		rendered = append(rendered, row)
 	}
-	return jsonResult(map[string]any{
+	payload := map[string]any{
 		"name":    parsed.Name,
 		"network": parsed.Network,
 		"nodes":   rendered,
-	})
+	}
+	if anyRedacted {
+		payload["redacted"] = true
+	}
+	return jsonResult(payload)
 }

--- a/internal/mcp/tools_drift.go
+++ b/internal/mcp/tools_drift.go
@@ -75,10 +75,14 @@ func verifyConfigTool(ctx context.Context, _ *mcp.CallToolRequest, args verifyCo
 		return errResult(err)
 	}
 
-	desired, err := render.RenderHOCON("", parsed, &parsed.Nodes[0])
+	// Compare against the REAL bytes so a rotated witness key still
+	// registers as drift; mcpLineDiff redacts every line it emits, so
+	// nothing secret leaves over the MCP transport.
+	renderedDesired, err := render.RenderHOCONWithSecrets("", parsed, &parsed.Nodes[0])
 	if err != nil {
 		return errResult(err)
 	}
+	desired := renderedDesired.Deployable()
 
 	diffs := mcpLineDiff(live, desired, args.Context)
 	return jsonResult(map[string]any{
@@ -93,7 +97,12 @@ func verifyConfigTool(ctx context.Context, _ *mcp.CallToolRequest, args verifyCo
 	})
 }
 
-// mcpLineDiff mirrors cmd.lineDiff. Same simplicity rationale.
+// mcpLineDiff mirrors cmd.lineDiff. Same simplicity rationale — and
+// the same secret handling: comparison on the raw lines, every emitted
+// line (including --context neighbours) through
+// render.RedactWitnessLine. This result is returned to a third-party
+// model provider, so an un-redacted `localwitness` line here is the
+// worst-case disclosure path in the whole tool surface.
 func mcpLineDiff(live, desired string, ctxLines int) []string {
 	a := strings.Split(strings.TrimRight(live, "\n"), "\n")
 	b := strings.Split(strings.TrimRight(desired, "\n"), "\n")
@@ -120,18 +129,18 @@ func mcpLineDiff(live, desired string, ctxLines int) []string {
 			}
 			for j := lo; j < i; j++ {
 				if j < len(a) {
-					diffs = append(diffs, "  "+a[j])
+					diffs = append(diffs, "  "+render.RedactWitnessLine(a[j]))
 				}
 			}
 		}
 		switch {
 		case i < len(a) && i >= len(b):
-			diffs = append(diffs, "- "+aLine)
+			diffs = append(diffs, "- "+render.RedactWitnessLine(aLine))
 		case i >= len(a) && i < len(b):
-			diffs = append(diffs, "+ "+bLine)
+			diffs = append(diffs, "+ "+render.RedactWitnessLine(bLine))
 		default:
-			diffs = append(diffs, "- "+aLine)
-			diffs = append(diffs, "+ "+bLine)
+			diffs = append(diffs, "- "+render.RedactWitnessLine(aLine))
+			diffs = append(diffs, "+ "+render.RedactWitnessLine(bLine))
 		}
 	}
 	return diffs

--- a/internal/render/hocon.go
+++ b/internal/render/hocon.go
@@ -3,10 +3,12 @@ package render
 import (
 	"fmt"
 	"os"
+	"slices"
 	"sort"
 	"strings"
 
 	"github.com/tronprotocol/tron-deployment/internal/intent"
+	"github.com/tronprotocol/tron-deployment/internal/security"
 )
 
 // NetworkTemplate maps network names to their base config template file.
@@ -14,6 +16,117 @@ var NetworkTemplate = map[string]string{
 	"mainnet": "main_net_config.conf",
 	"nile":    "test_net_config.conf",
 	"private": "private_net_config.conf",
+}
+
+// witnessKeyName is the exact java-tron config key that carries the
+// super-representative signing key.
+const witnessKeyName = "localwitness"
+
+// redactedWitnessAssignment is what every text / JSON / diff surface
+// prints in place of a `localwitness` assignment.
+const redactedWitnessAssignment = witnessKeyName + ` = ["<REDACTED>"]`
+
+// Rendered carries a rendered java-tron HOCON config in two forms.
+//
+// Config is the DISPLAY form and is the only one safe to print to
+// stdout, serialise into JSON, hand to an MCP client or write into a
+// diff: a resolved witness (SR) private key has been replaced by a
+// `<REDACTED:ENV_NAME>` placeholder. The placeholder names only the
+// environment variable, which is already public in the intent file.
+//
+// The DEPLOY form — the byte stream java-tron actually needs, with the
+// real key inlined — is unexported and reachable only through
+// Deployable(). Keeping it unexported means the secret cannot escape
+// through an accidental fmt / encoding-json / log call: a caller has
+// to spell out Deployable() to obtain it.
+type Rendered struct {
+	// Config is the redacted display form. Byte-identical to the
+	// deploy form whenever no witness private key was resolved.
+	Config string
+
+	// WitnessKey holds the resolved witness private key, wrapped so
+	// String / MarshalJSON / MarshalText all render "[REDACTED]".
+	// Zero value when the node is not a witness, uses a keystore, or
+	// the referenced env var is unset.
+	WitnessKey security.PrivateKey
+
+	// Redacted reports whether Config had a real witness private key
+	// removed from it — i.e. whether Config is a preview that
+	// java-tron would reject rather than a deployable artifact.
+	Redacted bool
+
+	// deploy is the real config bytes. Unexported on purpose.
+	deploy string
+}
+
+// Deployable returns the config bytes to hand to runtime.Deploy (and
+// to hash for idempotency). This is the ONLY accessor that yields the
+// real witness private key; every caller that prints, serialises or
+// diffs the result must use Config instead.
+func (r Rendered) Deployable() string { return r.deploy }
+
+// String returns the redacted display form so that %v / %s / %+v on a
+// Rendered can never spill the key. Without this, fmt would reflect
+// over the unexported deploy field and print the secret verbatim.
+func (r Rendered) String() string { return r.Config }
+
+// GoString keeps %#v away from the deploy field for the same reason.
+func (r Rendered) GoString() string {
+	return fmt.Sprintf("render.Rendered{Config: %q, Redacted: %t}", r.Config, r.Redacted)
+}
+
+// IsWitnessKeyLine reports whether one line of HOCON is the
+// `localwitness = ...` assignment that carries the SR signing key.
+//
+// The match is a deliberately stateless, exact single-line key match:
+// the line is trimmed, must begin with the literal key `localwitness`,
+// and the next non-blank character must be `=`. No state is carried
+// between lines and no bracket / quote scanning is done, so the
+// predicate is safe to apply to any line of any config in any order.
+// `localwitnesskeystore` (a file path) and `localWitnessAccountAddress`
+// (a public address) both fail the match, which is what we want.
+//
+// Known limits, accepted deliberately: a key sitting on a CONTINUATION
+// line of a hand-written multi-line block
+//
+//	localwitness = [
+//	  <key>
+//	]
+//
+// or inside a commented-out line is not matched. Detecting those needs
+// a stateful, delimiter-scanning parser over the whole file, which is
+// exactly the fragile machinery this fix is required to avoid. trond
+// itself only ever renders the single-line form, so every config trond
+// produces is fully covered.
+func IsWitnessKeyLine(line string) bool {
+	rest, ok := strings.CutPrefix(strings.TrimSpace(line), witnessKeyName)
+	if !ok {
+		return false
+	}
+	return strings.HasPrefix(strings.TrimLeft(rest, " \t"), "=")
+}
+
+// RedactWitnessLine returns line unchanged unless it is a witness
+// private-key assignment, in which case the entire assignment is
+// replaced by a fixed marker that carries no key material.
+//
+// Every surface that emits raw config lines — the `plan --diff`,
+// `config diff`, `verify-config` and MCP verify_config differs — runs
+// each line through this immediately before emitting it. Comparison
+// still happens on the raw lines, so a rotated or drifted key is still
+// reported as a change; the reader just sees the marker on both sides
+// instead of the two keys.
+//
+// Over-inclusive by design: a bare `localwitness = [` opening line
+// (the shape the shipped templates use) is also rewritten. That costs
+// nothing but a slightly blunter diff line and keeps us on the safe
+// side of any unquoted / oddly-spaced value an operator may have
+// hand-written into a live conf.
+func RedactWitnessLine(line string) string {
+	if !IsWitnessKeyLine(line) {
+		return line
+	}
+	return lineIndent(line) + redactedWitnessAssignment
 }
 
 // RenderHOCON loads the base template for the network and applies intent-driven overrides.
@@ -32,10 +145,28 @@ var NetworkTemplate = map[string]string{
 // Two layers exist because some keys (ports) need to stay in their original
 // place to keep the file diff-friendly, while bulk overrides are simpler
 // and safer to express as a final-section append.
+//
+// RenderHOCON returns the DISPLAY form (see Rendered): any resolved
+// witness private key is replaced by a `<REDACTED:ENV_NAME>`
+// placeholder, because this string ends up on stdout, in JSON payloads
+// and in MCP tool results. Callers that need the deployable bytes must
+// use RenderHOCONWithSecrets and ask for Deployable().
 func RenderHOCON(templateDir string, i *intent.Intent, node *intent.NodeSpec) (string, error) {
-	data, err := LoadTemplate(templateDir, i.Network)
+	r, err := RenderHOCONWithSecrets(templateDir, i, node)
 	if err != nil {
 		return "", err
+	}
+	return r.Config, nil
+}
+
+// RenderHOCONWithSecrets renders the same config as RenderHOCON but
+// returns both forms: Rendered.Config for anything that is printed,
+// serialised or diffed, and Rendered.Deployable() for the bytes handed
+// to runtime.Deploy and hashed into config_hash.
+func RenderHOCONWithSecrets(templateDir string, i *intent.Intent, node *intent.NodeSpec) (Rendered, error) {
+	data, err := LoadTemplate(templateDir, i.Network)
+	if err != nil {
+		return Rendered{}, err
 	}
 
 	config := string(data)
@@ -50,31 +181,57 @@ func RenderHOCON(templateDir string, i *intent.Intent, node *intent.NodeSpec) (s
 	}
 
 	// 2. Trailing override block (network_overrides + witness_key + config_overrides).
-	if appendix := renderHOCONAppendix(node); appendix != "" {
-		if !strings.HasSuffix(config, "\n") {
-			config += "\n"
-		}
-		config += "\n" + appendix
+	ap := renderHOCONAppendix(node)
+	if ap.deploy == "" {
+		// Nothing appended: both forms are the same bytes.
+		return Rendered{Config: config, deploy: config}, nil
 	}
-
-	return config, nil
+	if !strings.HasSuffix(config, "\n") {
+		config += "\n"
+	}
+	return Rendered{
+		Config:     config + "\n" + ap.display,
+		WitnessKey: ap.key,
+		Redacted:   ap.redacted,
+		deploy:     config + "\n" + ap.deploy,
+	}, nil
 }
 
-// renderHOCONAppendix produces the "trond overrides" block. Returns an
-// empty string when nothing is configured so the rendered HOCON stays
-// identical to today's output for users who don't use the new fields.
+// hoconAppendix is the "trond overrides" block in its two forms. The
+// two differ in at most one line — the `localwitness` assignment.
+type hoconAppendix struct {
+	deploy   string
+	display  string
+	key      security.PrivateKey
+	redacted bool
+}
+
+// renderHOCONAppendix produces the "trond overrides" block. Returns the
+// zero hoconAppendix (empty forms) when nothing is configured so the
+// rendered HOCON stays identical to today's output for users who don't
+// use the new fields.
 //
 // Witness-key handling: java-tron parses HOCON via typesafe-config but
 // does NOT enable environment-variable substitution — `${VAR}` is treated
 // as an internal config-reference and fails when the referenced key
 // doesn't exist (the witness silently shuts down with "private key must
 // be 64 hex string, actual: 9", that 9 being the literal length of
-// `${SR_KEY}`). So we inline the env value at render time. The resulting
-// .conf file holds the secret in cleartext; we protect it via the
-// existing 0600 perms on the deployment dir and don't echo it back to
-// stdout.
-func renderHOCONAppendix(node *intent.NodeSpec) string {
+// `${SR_KEY}`). So we inline the env value at render time.
+//
+// The inlined secret goes ONLY into the deploy form. The display form
+// gets a `<REDACTED:ENV_NAME>` placeholder, so the string that trond
+// prints, JSON-encodes and returns over MCP never carries the key —
+// only the env var's name, which the intent file already states in
+// cleartext.
+func renderHOCONAppendix(node *intent.NodeSpec) hoconAppendix {
 	var lines []string
+
+	// Index of the `localwitness` line inside lines, and the redacted
+	// replacement for it. -1 means "no secret was inlined", in which
+	// case both rendered forms are the same bytes.
+	witnessIdx := -1
+	witnessDisplayLine := ""
+	var witnessKey security.PrivateKey
 
 	// --- network_overrides ---
 	no := &node.NetworkOverrides
@@ -127,9 +284,15 @@ func renderHOCONAppendix(node *intent.NodeSpec) string {
 			// silently rendering an empty key.
 			val := os.Getenv(envName)
 			if val == "" {
-				val = "<UNSET:" + envName + ">"
+				// No secret to protect: the loud placeholder is
+				// identical in both forms, exactly as before.
+				lines = append(lines, fmt.Sprintf(`%s = [%q]`, witnessKeyName, "<UNSET:"+envName+">"))
+				break
 			}
-			lines = append(lines, fmt.Sprintf(`localwitness = [%q]`, val))
+			witnessKey = security.NewPrivateKey(val)
+			witnessIdx = len(lines)
+			witnessDisplayLine = fmt.Sprintf(`%s = [%q]`, witnessKeyName, "<REDACTED:"+envName+">")
+			lines = append(lines, fmt.Sprintf(`%s = [%q]`, witnessKeyName, val))
 		case keystore != "":
 			lines = append(lines, fmt.Sprintf("localwitnesskeystore = [%q]", keystore))
 		}
@@ -151,9 +314,27 @@ func renderHOCONAppendix(node *intent.NodeSpec) string {
 	}
 
 	if len(lines) == 0 {
-		return ""
+		return hoconAppendix{}
 	}
 
+	deploy := joinAppendixLines(lines)
+	if witnessIdx < 0 {
+		return hoconAppendix{deploy: deploy, display: deploy}
+	}
+	displayLines := slices.Clone(lines)
+	displayLines[witnessIdx] = witnessDisplayLine
+	return hoconAppendix{
+		deploy:   deploy,
+		display:  joinAppendixLines(displayLines),
+		key:      witnessKey,
+		redacted: true,
+	}
+}
+
+// joinAppendixLines wraps the override lines in the block header. Split
+// out so the deploy and display forms are assembled by identical code —
+// they must not drift in anything but the witness line.
+func joinAppendixLines(lines []string) string {
 	var sb strings.Builder
 	sb.WriteString("# === trond overrides (last-write-wins) ===\n")
 	for _, l := range lines {

--- a/internal/render/witness_redaction_test.go
+++ b/internal/render/witness_redaction_test.go
@@ -1,0 +1,272 @@
+package render
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/tronprotocol/tron-deployment/internal/intent"
+)
+
+// A stand-in SR signing key. Distinctive enough that a substring
+// search over any output surface is conclusive.
+const probeWitnessKey = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+
+func witnessIntent(t *testing.T, envName string) (*intent.Intent, *intent.NodeSpec) {
+	t.Helper()
+	seeds := []string{"1.2.3.4:18888"}
+	discovery := false
+	i := &intent.Intent{
+		Name:    "probe-witness",
+		Network: "mainnet",
+		Nodes: []intent.NodeSpec{{
+			Type:       "witness",
+			WitnessKey: &intent.WitnessKey{PrivateKeyEnv: envName},
+			NetworkOverrides: intent.NetworkOverrides{
+				Seeds:     &seeds,
+				Discovery: &discovery,
+			},
+			ConfigOverrides: map[string]any{"vm.supportConstant": true},
+		}},
+	}
+	return i, &i.Nodes[0]
+}
+
+// TestRendered_DeployCarriesKey_DisplayDoesNot is the core of F3: the
+// bytes java-tron gets still hold the real key, while the string every
+// print / JSON / MCP / diff surface handles does not.
+func TestRendered_DeployCarriesKey_DisplayDoesNot(t *testing.T) {
+	t.Setenv("PROBE_SR_KEY", probeWitnessKey)
+	i, node := witnessIntent(t, "PROBE_SR_KEY")
+
+	r, err := RenderHOCONWithSecrets("", i, node)
+	if err != nil {
+		t.Fatalf("RenderHOCONWithSecrets: %v", err)
+	}
+
+	wantLine := fmt.Sprintf(`localwitness = [%q]`, probeWitnessKey)
+	if !strings.Contains(r.Deployable(), wantLine) {
+		t.Fatalf("deploy form must inline the real key; missing %q", wantLine)
+	}
+	if strings.Contains(r.Config, probeWitnessKey) {
+		t.Fatal("display form leaked the raw witness key")
+	}
+	if !strings.Contains(r.Config, `localwitness = ["<REDACTED:PROBE_SR_KEY>"]`) {
+		t.Fatalf("display form missing the redaction placeholder:\n%s", tailOf(r.Config))
+	}
+	if !r.Redacted {
+		t.Error("Redacted must be true when a key was removed from the display form")
+	}
+	if r.WitnessKey.Value() != probeWitnessKey {
+		t.Error("WitnessKey should carry the resolved key for callers that genuinely need it")
+	}
+	if strings.Contains(r.WitnessKey.String(), probeWitnessKey) {
+		t.Error("security.PrivateKey.String() leaked the key")
+	}
+}
+
+// TestRenderHOCON_ReturnsDisplayForm pins that the long-standing
+// exported entry point — the one every preview caller uses — is the
+// redacted one.
+func TestRenderHOCON_ReturnsDisplayForm(t *testing.T) {
+	t.Setenv("PROBE_SR_KEY", probeWitnessKey)
+	i, node := witnessIntent(t, "PROBE_SR_KEY")
+
+	out, err := RenderHOCON("", i, node)
+	if err != nil {
+		t.Fatalf("RenderHOCON: %v", err)
+	}
+	if strings.Contains(out, probeWitnessKey) {
+		t.Fatal("RenderHOCON leaked the raw witness key")
+	}
+}
+
+// TestRendered_DeployAndDisplayDifferOnlyInWitnessLine is the
+// byte-identity guard: the deploy form must stay exactly what it was
+// before the redaction split, so runtime.Deploy writes the same file
+// and config_hash never moves. Reconstructing the deploy text from the
+// display text by swapping back a single line proves nothing else in
+// the render changed.
+func TestRendered_DeployAndDisplayDifferOnlyInWitnessLine(t *testing.T) {
+	t.Setenv("PROBE_SR_KEY", probeWitnessKey)
+	i, node := witnessIntent(t, "PROBE_SR_KEY")
+
+	r, err := RenderHOCONWithSecrets("", i, node)
+	if err != nil {
+		t.Fatalf("RenderHOCONWithSecrets: %v", err)
+	}
+
+	display := strings.Split(r.Config, "\n")
+	deploy := strings.Split(r.Deployable(), "\n")
+	if len(display) != len(deploy) {
+		t.Fatalf("line count drifted: display %d, deploy %d", len(display), len(deploy))
+	}
+	changed := 0
+	for n := range display {
+		if display[n] == deploy[n] {
+			continue
+		}
+		changed++
+		if display[n] != `localwitness = ["<REDACTED:PROBE_SR_KEY>"]` {
+			t.Errorf("line %d differs but is not the witness placeholder: %q", n, display[n])
+		}
+		if deploy[n] != fmt.Sprintf(`localwitness = [%q]`, probeWitnessKey) {
+			t.Errorf("line %d deploy side is not the inlined key: %q", n, deploy[n])
+		}
+	}
+	if changed != 1 {
+		t.Fatalf("expected exactly 1 differing line, got %d", changed)
+	}
+}
+
+// TestRendered_NoSecret_FormsAreIdentical covers every non-witness
+// path: nothing about those renders may change, in either form.
+func TestRendered_NoSecret_FormsAreIdentical(t *testing.T) {
+	discovery := false
+	cases := map[string]intent.NodeSpec{
+		"fullnode-bare": {Type: "fullnode"},
+		"fullnode-overrides": {
+			Type:             "fullnode",
+			NetworkOverrides: intent.NetworkOverrides{Discovery: &discovery},
+			ConfigOverrides:  map[string]any{"vm.supportConstant": true},
+		},
+		"witness-keystore": {
+			Type: "witness",
+			WitnessKey: &intent.WitnessKey{
+				KeystorePath:   "/opt/tron/keystore.json",
+				AccountAddress: "TPL66VK2gCXNCD7EJg9pgJRfqcRazjhUZY",
+			},
+		},
+		"witness-no-key": {Type: "witness"},
+	}
+	for name, spec := range cases {
+		t.Run(name, func(t *testing.T) {
+			i := &intent.Intent{Name: "probe", Network: "mainnet", Nodes: []intent.NodeSpec{spec}}
+			r, err := RenderHOCONWithSecrets("", i, &i.Nodes[0])
+			if err != nil {
+				t.Fatalf("RenderHOCONWithSecrets: %v", err)
+			}
+			if r.Config != r.Deployable() {
+				t.Error("no secret was resolved, so both forms must be byte-identical")
+			}
+			if r.Redacted {
+				t.Error("Redacted must stay false when nothing was removed")
+			}
+		})
+	}
+}
+
+// TestRendered_UnsetEnvIsNotRedacted keeps the pre-existing loud
+// failure mode intact: `<UNSET:NAME>` is not a secret, so it must
+// still appear verbatim in both forms and must not raise the
+// "this is a preview" flag.
+func TestRendered_UnsetEnvIsNotRedacted(t *testing.T) {
+	t.Setenv("PROBE_SR_KEY", "")
+	i, node := witnessIntent(t, "PROBE_SR_KEY")
+
+	r, err := RenderHOCONWithSecrets("", i, node)
+	if err != nil {
+		t.Fatalf("RenderHOCONWithSecrets: %v", err)
+	}
+	if r.Config != r.Deployable() {
+		t.Error("unset env: both forms must be identical")
+	}
+	if r.Redacted {
+		t.Error("unset env: nothing secret was removed, so Redacted must be false")
+	}
+	if !strings.Contains(r.Config, `localwitness = ["<UNSET:PROBE_SR_KEY>"]`) {
+		t.Errorf("unset env placeholder changed shape:\n%s", tailOf(r.Config))
+	}
+}
+
+// TestRendered_FormattingCannotSpillTheKey covers the accidental-print
+// paths: fmt reflects over unexported fields for %+v / %#v, so
+// Rendered has to implement Stringer / GoStringer.
+func TestRendered_FormattingCannotSpillTheKey(t *testing.T) {
+	t.Setenv("PROBE_SR_KEY", probeWitnessKey)
+	i, node := witnessIntent(t, "PROBE_SR_KEY")
+
+	r, err := RenderHOCONWithSecrets("", i, node)
+	if err != nil {
+		t.Fatalf("RenderHOCONWithSecrets: %v", err)
+	}
+	for _, verb := range []string{"%v", "%+v", "%#v", "%s", "%q"} {
+		if out := fmt.Sprintf(verb, r); strings.Contains(out, probeWitnessKey) {
+			t.Errorf("fmt %s spilled the witness key", verb)
+		}
+	}
+	blob, err := json.Marshal(r)
+	if err != nil {
+		t.Fatalf("json.Marshal: %v", err)
+	}
+	if strings.Contains(string(blob), probeWitnessKey) {
+		t.Error("json.Marshal spilled the witness key")
+	}
+}
+
+// TestIsWitnessKeyLine_ExactKeyMatch pins the stateless single-line
+// predicate: it must catch every shape trond or an operator writes for
+// the key itself, and must not swallow the sibling keys that carry no
+// secret.
+func TestIsWitnessKeyLine_ExactKeyMatch(t *testing.T) {
+	match := []string{
+		`localwitness = ["deadbeef"]`,
+		`localwitness=["deadbeef"]`,
+		`  localwitness  =  [ deadbeef ]`,
+		"\tlocalwitness\t=\t[\"deadbeef\"]",
+		`localwitness = [`,
+		`localwitness = ["deadbeef"] # trailing comment`,
+	}
+	for _, line := range match {
+		if !IsWitnessKeyLine(line) {
+			t.Errorf("expected witness-key line: %q", line)
+		}
+	}
+	noMatch := []string{
+		`localwitnesskeystore = ["/opt/tron/keystore.json"]`,
+		`#localwitnesskeystore = [`,
+		`localWitnessAccountAddress = "TPL66VK2gCXNCD7EJg9pgJRfqcRazjhUZY"`,
+		`# and the localwitness is configured with the private key`,
+		`// When it is empty,the localwitness is configured with the private key`,
+		`# localWitnessAccountAddress =`,
+		`node.discovery.enable = true`,
+		``,
+		`]`,
+	}
+	for _, line := range noMatch {
+		if IsWitnessKeyLine(line) {
+			t.Errorf("must not match: %q", line)
+		}
+	}
+}
+
+// TestRedactWitnessLine covers the substitution every diff surface
+// applies at emission time.
+func TestRedactWitnessLine(t *testing.T) {
+	got := RedactWitnessLine(fmt.Sprintf(`localwitness = [%q]`, probeWitnessKey))
+	if strings.Contains(got, probeWitnessKey) {
+		t.Fatalf("RedactWitnessLine left the key in place: %q", got)
+	}
+	if got != `localwitness = ["<REDACTED>"]` {
+		t.Errorf("unexpected marker: %q", got)
+	}
+	// Indent is preserved so redacted diff lines stay aligned.
+	if got := RedactWitnessLine(`    localwitness = ["x"]`); got != `    localwitness = ["<REDACTED>"]` {
+		t.Errorf("indent not preserved: %q", got)
+	}
+	// Unrelated lines pass through untouched.
+	for _, line := range []string{"", "node.discovery.enable = true", `  localwitnesskeystore = ["/k.json"]`} {
+		if got := RedactWitnessLine(line); got != line {
+			t.Errorf("RedactWitnessLine(%q) = %q, want unchanged", line, got)
+		}
+	}
+}
+
+func tailOf(s string) string {
+	lines := strings.Split(strings.TrimRight(s, "\n"), "\n")
+	if len(lines) > 12 {
+		lines = lines[len(lines)-12:]
+	}
+	return strings.Join(lines, "\n")
+}

--- a/internal/render/witness_redaction_test.go
+++ b/internal/render/witness_redaction_test.go
@@ -13,7 +13,10 @@ import (
 // search over any output surface is conclusive.
 const probeWitnessKey = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 
-func witnessIntent(t *testing.T, envName string) (*intent.Intent, *intent.NodeSpec) {
+// The env var name every case in this file renders through.
+const probeWitnessKeyEnv = "PROBE_SR_KEY"
+
+func witnessIntent(t *testing.T) (*intent.Intent, *intent.NodeSpec) {
 	t.Helper()
 	seeds := []string{"1.2.3.4:18888"}
 	discovery := false
@@ -22,7 +25,7 @@ func witnessIntent(t *testing.T, envName string) (*intent.Intent, *intent.NodeSp
 		Network: "mainnet",
 		Nodes: []intent.NodeSpec{{
 			Type:       "witness",
-			WitnessKey: &intent.WitnessKey{PrivateKeyEnv: envName},
+			WitnessKey: &intent.WitnessKey{PrivateKeyEnv: probeWitnessKeyEnv},
 			NetworkOverrides: intent.NetworkOverrides{
 				Seeds:     &seeds,
 				Discovery: &discovery,
@@ -38,7 +41,7 @@ func witnessIntent(t *testing.T, envName string) (*intent.Intent, *intent.NodeSp
 // print / JSON / MCP / diff surface handles does not.
 func TestRendered_DeployCarriesKey_DisplayDoesNot(t *testing.T) {
 	t.Setenv("PROBE_SR_KEY", probeWitnessKey)
-	i, node := witnessIntent(t, "PROBE_SR_KEY")
+	i, node := witnessIntent(t)
 
 	r, err := RenderHOCONWithSecrets("", i, node)
 	if err != nil {
@@ -71,7 +74,7 @@ func TestRendered_DeployCarriesKey_DisplayDoesNot(t *testing.T) {
 // redacted one.
 func TestRenderHOCON_ReturnsDisplayForm(t *testing.T) {
 	t.Setenv("PROBE_SR_KEY", probeWitnessKey)
-	i, node := witnessIntent(t, "PROBE_SR_KEY")
+	i, node := witnessIntent(t)
 
 	out, err := RenderHOCON("", i, node)
 	if err != nil {
@@ -90,7 +93,7 @@ func TestRenderHOCON_ReturnsDisplayForm(t *testing.T) {
 // the render changed.
 func TestRendered_DeployAndDisplayDifferOnlyInWitnessLine(t *testing.T) {
 	t.Setenv("PROBE_SR_KEY", probeWitnessKey)
-	i, node := witnessIntent(t, "PROBE_SR_KEY")
+	i, node := witnessIntent(t)
 
 	r, err := RenderHOCONWithSecrets("", i, node)
 	if err != nil {
@@ -163,7 +166,7 @@ func TestRendered_NoSecret_FormsAreIdentical(t *testing.T) {
 // "this is a preview" flag.
 func TestRendered_UnsetEnvIsNotRedacted(t *testing.T) {
 	t.Setenv("PROBE_SR_KEY", "")
-	i, node := witnessIntent(t, "PROBE_SR_KEY")
+	i, node := witnessIntent(t)
 
 	r, err := RenderHOCONWithSecrets("", i, node)
 	if err != nil {
@@ -185,7 +188,7 @@ func TestRendered_UnsetEnvIsNotRedacted(t *testing.T) {
 // Rendered has to implement Stringer / GoStringer.
 func TestRendered_FormattingCannotSpillTheKey(t *testing.T) {
 	t.Setenv("PROBE_SR_KEY", probeWitnessKey)
-	i, node := witnessIntent(t, "PROBE_SR_KEY")
+	i, node := witnessIntent(t)
 
 	r, err := RenderHOCONWithSecrets("", i, node)
 	if err != nil {

--- a/internal/runtime/docker.go
+++ b/internal/runtime/docker.go
@@ -28,14 +28,29 @@ func NewDockerRuntime(t target.Target, workDir string) *DockerRuntime {
 func (r *DockerRuntime) Deploy(ctx context.Context, opts DeployOpts) error {
 	dir := filepath.Join(r.workDir, opts.Name)
 
-	// Create deployment directory
-	if _, err := r.target.Exec(ctx, "mkdir", "-p", dir); err != nil {
+	// Create deployment directory, owner-only.
+	//
+	// The mode is set by `mkdir -m` at creation instead of a follow-up
+	// `chmod 0700 <dir>`: a separate chmod would leave a window in which
+	// the directory (and the secret-bearing config written into it) is
+	// world-readable, and it would apply the mode to a path that could
+	// have been substituted in the meantime. A bare `mkdir -p` takes the
+	// target's umask, which is 0755 on a typical host — on an SSH target
+	// or a shared --state-dir that makes the config below reachable by
+	// every local account. `-p` still succeeds on an existing directory
+	// (whose mode it leaves alone), so redeploys are unaffected.
+	if _, err := r.target.Exec(ctx, "mkdir", "-p", "-m", "0700", dir); err != nil {
 		return fmt.Errorf("create deploy dir: %w", err)
 	}
 
-	// Write config file
+	// Write config file, owner-only: for witness nodes the rendered HOCON
+	// inlines the block-signing private key (localwitness = ["<hex>"]),
+	// plus whatever secrets config_overrides carries. Nothing needs it
+	// world-readable — compose mounts it into the container read-only and
+	// the java-tron image declares no USER, so the process that reads it
+	// is root inside the container.
 	configPath := filepath.Join(dir, opts.Name+".conf")
-	if err := r.target.WriteFile(ctx, configPath, opts.ConfigData, 0644); err != nil {
+	if err := r.target.WriteFile(ctx, configPath, opts.ConfigData, 0600); err != nil {
 		return fmt.Errorf("write config: %w", err)
 	}
 

--- a/internal/runtime/docker_test.go
+++ b/internal/runtime/docker_test.go
@@ -1,0 +1,214 @@
+package runtime
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/tronprotocol/tron-deployment/internal/target"
+)
+
+// witnessConfig stands in for the rendered HOCON of a witness node: the
+// block-signing key is inlined into the file trond writes (java-tron's
+// typesafe-config does no ${ENV} substitution), so the deployment
+// directory and the .conf inside it must not be readable by other local
+// accounts.
+const witnessConfig = `localwitness = [
+  "0000000000000000000000000000000000000000000000000000000000000001"
+]
+`
+
+func TestDockerRuntime_Deploy_ConfigWrittenOwnerOnly(t *testing.T) {
+	ft := newFakeTarget()
+	rt := NewDockerRuntime(ft, "/tmp/trond-deployments")
+
+	opts := DeployOpts{
+		Name:        "my-witness",
+		ConfigData:  []byte(witnessConfig),
+		ComposeData: []byte("services:\n  my-witness:\n"),
+	}
+	if err := rt.Deploy(context.Background(), opts); err != nil {
+		t.Fatalf("Deploy failed: %v", err)
+	}
+
+	confPath := "/tmp/trond-deployments/my-witness/my-witness.conf"
+	if got := string(ft.files[confPath]); got != witnessConfig {
+		t.Fatalf("config not written to %s (got %q)", confPath, got)
+	}
+	perm, ok := ft.perms[confPath]
+	if !ok {
+		t.Fatalf("no mode recorded for %s", confPath)
+	}
+	if perm != 0600 {
+		t.Errorf("config mode = %#o, want 0600 (secret-bearing config must be owner-only)", perm)
+	}
+	if perm&0077 != 0 {
+		t.Errorf("config mode %#o grants group/other access to the witness key", perm)
+	}
+}
+
+// The deployment directory must be created restrictive, and restrictive at
+// creation time — not widened by the umask and narrowed afterwards by a
+// separate chmod, which would both leave a window and re-target a path that
+// could have been swapped in between.
+func TestDockerRuntime_Deploy_DeployDirCreatedOwnerOnly(t *testing.T) {
+	ft := newFakeTarget()
+	rt := NewDockerRuntime(ft, "/tmp/trond-deployments")
+
+	opts := DeployOpts{
+		Name:        "my-witness",
+		ConfigData:  []byte(witnessConfig),
+		ComposeData: []byte("services:\n  my-witness:\n"),
+	}
+	if err := rt.Deploy(context.Background(), opts); err != nil {
+		t.Fatalf("Deploy failed: %v", err)
+	}
+
+	if len(ft.cmds) == 0 {
+		t.Fatal("no commands executed")
+	}
+	want := []string{"mkdir", "-p", "-m", "0700", "/tmp/trond-deployments/my-witness"}
+	if !reflect.DeepEqual(ft.cmds[0], want) {
+		t.Fatalf("first command = %v, want %v", ft.cmds[0], want)
+	}
+	for _, cmd := range ft.cmds {
+		if len(cmd) > 0 && cmd[0] == "chmod" {
+			t.Errorf("unexpected post-hoc chmod on a target path: %v", cmd)
+		}
+	}
+}
+
+// dockerStubTarget runs every command on the real local filesystem except
+// `docker`, which is recorded and stubbed so the test never talks to a
+// container runtime. It lets Deploy exercise the actual mkdir + file write
+// and assert the modes that land on disk.
+type dockerStubTarget struct {
+	*target.LocalTarget
+	dockerCalls [][]string
+}
+
+func (d *dockerStubTarget) Exec(ctx context.Context, cmd string, args ...string) ([]byte, error) {
+	if cmd == "docker" {
+		d.dockerCalls = append(d.dockerCalls, append([]string{cmd}, args...))
+		return nil, nil
+	}
+	return d.LocalTarget.Exec(ctx, cmd, args...)
+}
+
+func newDockerStubTarget() *dockerStubTarget {
+	return &dockerStubTarget{LocalTarget: target.NewLocalTarget()}
+}
+
+func TestDockerRuntime_Deploy_ModesOnDisk(t *testing.T) {
+	ctx := context.Background()
+	tgt := newDockerStubTarget()
+	if !tgt.CommandExists(ctx, "mkdir") {
+		t.Skip("mkdir not available on PATH")
+	}
+
+	workDir := t.TempDir()
+	rt := NewDockerRuntime(tgt, workDir)
+
+	opts := DeployOpts{
+		Name:        "my-witness",
+		ConfigData:  []byte(witnessConfig),
+		ComposeData: []byte("services:\n  my-witness:\n"),
+	}
+	if err := rt.Deploy(ctx, opts); err != nil {
+		t.Fatalf("Deploy failed: %v", err)
+	}
+
+	dir := filepath.Join(workDir, "my-witness")
+	di, err := os.Stat(dir)
+	if err != nil {
+		t.Fatalf("stat deploy dir: %v", err)
+	}
+	if di.Mode().Perm() != 0700 {
+		t.Errorf("deploy dir mode = %#o, want 0700", di.Mode().Perm())
+	}
+	if di.Mode().Perm()&0077 != 0 {
+		t.Errorf("deploy dir mode %#o is reachable by group/other", di.Mode().Perm())
+	}
+
+	confPath := filepath.Join(dir, "my-witness.conf")
+	ci, err := os.Stat(confPath)
+	if err != nil {
+		t.Fatalf("stat config: %v", err)
+	}
+	if ci.Mode().Perm() != 0600 {
+		t.Errorf("config mode = %#o, want 0600", ci.Mode().Perm())
+	}
+
+	data, err := os.ReadFile(confPath)
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	if string(data) != witnessConfig {
+		t.Errorf("config content = %q, want %q", string(data), witnessConfig)
+	}
+
+	if len(tgt.dockerCalls) != 1 || !strings.Contains(strings.Join(tgt.dockerCalls[0], " "), "up") {
+		t.Errorf("expected one `docker compose ... up` call, got %v", tgt.dockerCalls)
+	}
+}
+
+// Redeploying over an existing deployment directory must still work:
+// `mkdir -p -m 0700` is not an error on an existing directory, and the
+// rewritten config keeps its restrictive mode.
+func TestDockerRuntime_Deploy_RedeployExistingDeployment(t *testing.T) {
+	ctx := context.Background()
+	tgt := newDockerStubTarget()
+	if !tgt.CommandExists(ctx, "mkdir") {
+		t.Skip("mkdir not available on PATH")
+	}
+
+	workDir := t.TempDir()
+	rt := NewDockerRuntime(tgt, workDir)
+
+	opts := DeployOpts{
+		Name:        "my-witness",
+		ConfigData:  []byte(witnessConfig),
+		ComposeData: []byte("services:\n  my-witness:\n"),
+	}
+	if err := rt.Deploy(ctx, opts); err != nil {
+		t.Fatalf("first Deploy failed: %v", err)
+	}
+
+	updated := witnessConfig + "node.p2p.version = 11111\n"
+	opts.ConfigData = []byte(updated)
+	if err := rt.Deploy(ctx, opts); err != nil {
+		t.Fatalf("redeploy failed: %v", err)
+	}
+
+	dir := filepath.Join(workDir, "my-witness")
+	confPath := filepath.Join(dir, "my-witness.conf")
+	data, err := os.ReadFile(confPath)
+	if err != nil {
+		t.Fatalf("read config after redeploy: %v", err)
+	}
+	if string(data) != updated {
+		t.Errorf("config not updated on redeploy: got %q", string(data))
+	}
+
+	di, err := os.Stat(dir)
+	if err != nil {
+		t.Fatalf("stat deploy dir: %v", err)
+	}
+	if di.Mode().Perm()&0077 != 0 {
+		t.Errorf("deploy dir mode %#o is reachable by group/other after redeploy", di.Mode().Perm())
+	}
+	ci, err := os.Stat(confPath)
+	if err != nil {
+		t.Fatalf("stat config: %v", err)
+	}
+	if ci.Mode().Perm()&0077 != 0 {
+		t.Errorf("config mode %#o is readable by group/other after redeploy", ci.Mode().Perm())
+	}
+
+	if len(tgt.dockerCalls) != 2 {
+		t.Errorf("expected 2 docker calls across two deploys, got %v", tgt.dockerCalls)
+	}
+}

--- a/internal/runtime/monitoring_test.go
+++ b/internal/runtime/monitoring_test.go
@@ -9,11 +9,12 @@ import (
 // fakeTarget is a minimal in-memory target for unit testing.
 type fakeTarget struct {
 	files map[string][]byte
+	perms map[string]os.FileMode
 	cmds  [][]string
 }
 
 func newFakeTarget() *fakeTarget {
-	return &fakeTarget{files: make(map[string][]byte)}
+	return &fakeTarget{files: make(map[string][]byte), perms: make(map[string]os.FileMode)}
 }
 
 func (f *fakeTarget) Exec(ctx context.Context, cmd string, args ...string) ([]byte, error) {
@@ -28,6 +29,7 @@ func (f *fakeTarget) ReadFile(ctx context.Context, path string) ([]byte, error) 
 }
 func (f *fakeTarget) WriteFile(ctx context.Context, path string, data []byte, perm os.FileMode) error {
 	f.files[path] = data
+	f.perms[path] = perm
 	return nil
 }
 func (f *fakeTarget) DiskFree(ctx context.Context, path string) (uint64, error)       { return 0, nil }

--- a/internal/schema/embed.go
+++ b/internal/schema/embed.go
@@ -98,7 +98,13 @@ import (
 //	        `metrics_port` so `network add` rebuilds scrape targets with
 //	        the node's real metrics port (instead of hardcoded 9527).
 //	        Additive optional fields throughout — PATCH.
-const SchemaVersion = "1.12.2"
+//	1.12.3 — config-render output gains `redacted` (top level and per
+//	        node). A witness node's private key is no longer inlined
+//	        into the rendered `hocon` a preview surface returns; it is
+//	        replaced by a `<REDACTED:ENV_NAME>` placeholder and the flag
+//	        tells the caller the artifact is a preview java-tron would
+//	        reject. Additive optional fields — PATCH.
+const SchemaVersion = "1.12.3"
 
 // JSONSchemaURLBase is the canonical URL prefix for individual output
 // schema files. Embedded $id values inside each schema mirror this so

--- a/internal/schema/files/config-render.schema.json
+++ b/internal/schema/files/config-render.schema.json
@@ -8,6 +8,10 @@
   "properties": {
     "name":    { "type": "string" },
     "network": { "type": "string" },
+    "redacted": {
+      "type": "boolean",
+      "description": "Present and true when at least one node's witness private key was replaced by a `<REDACTED:ENV_NAME>` placeholder. The rendered HOCON is then a PREVIEW: java-tron rejects the placeholder, so files written by --output-dir must not be deployed as-is. Deploy with `trond apply`, which inlines the real key without printing it."
+    },
     "nodes": {
       "type": "array",
       "items": {
@@ -17,7 +21,8 @@
           "index":    { "type": "integer", "minimum": 0 },
           "name":     { "type": "string" },
           "type":     { "type": "string", "enum": ["fullnode", "witness", "solidity", "lite"] },
-          "hocon":    { "type": "string", "description": "Full rendered java-tron .conf contents." },
+          "hocon":    { "type": "string", "description": "Full rendered java-tron .conf contents. A witness node's private key is never included: it is replaced by a `<REDACTED:ENV_NAME>` placeholder and the node's `redacted` flag is set." },
+          "redacted": { "type": "boolean", "description": "Present and true when this node's witness private key was redacted from `hocon`." },
           "compose":  { "type": "string", "description": "Rendered docker-compose.yaml; empty for jar runtime." },
           "systemd":  { "type": "string", "description": "Rendered systemd unit file; empty for docker runtime." },
           "jvm_args": { "type": "string", "description": "Space-separated JVM args fed to FullNode -jvm." }

--- a/internal/schema/version_baseline.json
+++ b/internal/schema/version_baseline.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": "1.12.2",
+  "schema_version": "1.12.3",
   "entries": [
     {
       "name": "apply",
@@ -31,7 +31,7 @@
     },
     {
       "name": "config-render",
-      "hash": "9a845732c24c2be1b0fa4f7945a530f8abf16dce8202d18f8940ee1e33f73e45"
+      "hash": "6d267c80d8feb29a29a98409f720b24d0833fb754973a74a40ef4777ed49b538"
     },
     {
       "name": "config-validate",

--- a/knowledge/shadow-fork-poc.md
+++ b/knowledge/shadow-fork-poc.md
@@ -100,8 +100,10 @@ The `observe` step below is the actual readiness check.
 **Security note — rendered HOCON contains the private key.**
 trond inlines the witness's hex private key into the per-node
 HOCON config at `~/.trond/deployments/shadow-fork-poc/shadow-fork-poc.conf`
-(java-tron requires the key in-config for production). Mode
-defaults to 0644. Treat that file like the keypair stash —
+(java-tron requires the key in-config for production). It is
+written 0600 inside a 0700 deployment directory (the container
+reads it through a read-only bind mount as root, so nothing else
+needs access). Treat that file like the keypair stash —
 remove with the `teardown` recipe at the bottom of this doc
 once finished.
 

--- a/schemas/output/config-render.schema.json
+++ b/schemas/output/config-render.schema.json
@@ -8,6 +8,10 @@
   "properties": {
     "name":    { "type": "string" },
     "network": { "type": "string" },
+    "redacted": {
+      "type": "boolean",
+      "description": "Present and true when at least one node's witness private key was replaced by a `<REDACTED:ENV_NAME>` placeholder. The rendered HOCON is then a PREVIEW: java-tron rejects the placeholder, so files written by --output-dir must not be deployed as-is. Deploy with `trond apply`, which inlines the real key without printing it."
+    },
     "nodes": {
       "type": "array",
       "items": {
@@ -17,7 +21,8 @@
           "index":    { "type": "integer", "minimum": 0 },
           "name":     { "type": "string" },
           "type":     { "type": "string", "enum": ["fullnode", "witness", "solidity", "lite"] },
-          "hocon":    { "type": "string", "description": "Full rendered java-tron .conf contents." },
+          "hocon":    { "type": "string", "description": "Full rendered java-tron .conf contents. A witness node's private key is never included: it is replaced by a `<REDACTED:ENV_NAME>` placeholder and the node's `redacted` flag is set." },
+          "redacted": { "type": "boolean", "description": "Present and true when this node's witness private key was redacted from `hocon`." },
           "compose":  { "type": "string", "description": "Rendered docker-compose.yaml; empty for jar runtime." },
           "systemd":  { "type": "string", "description": "Rendered systemd unit file; empty for docker runtime." },
           "jvm_args": { "type": "string", "description": "Space-separated JVM args fed to FullNode -jvm." }

--- a/scripts/poc-shadow-fork.sh
+++ b/scripts/poc-shadow-fork.sh
@@ -60,6 +60,21 @@ ensure_trond() {
   fi
 }
 
+# Create the key stash empty and private BEFORE any secret byte is
+# written to it. A `chmod 600` applied after the write leaves the
+# private key on disk at the umask default (0644 under the usual 022)
+# for the whole length of the write, and truncating an existing
+# loose-moded stash keeps that loose mode regardless of umask. The
+# unlink also means we never write a private key through a symlink (or
+# into a FIFO / pre-planted hardlink) sitting at that path.
+init_key_stash() {
+  if [[ -L "$KEY_STASH" ]]; then
+    log "replacing symlink at $KEY_STASH with a private regular file"
+  fi
+  rm -f "$KEY_STASH" || err "cannot replace $KEY_STASH"
+  (umask 077; : > "$KEY_STASH") || err "cannot create $KEY_STASH"
+}
+
 generate_witness_key() {
   # Generate a fresh secp256k1 keypair + derive the TRON Base58Check
   # address. We don't have a Go subcommand for this (out of trond's
@@ -68,10 +83,12 @@ generate_witness_key() {
   # caller-supplied key from env vars if they have their own.
   if [[ -n "${SHADOW_FORK_WITNESS_KEY:-}" && -n "${SHADOW_FORK_WITNESS_ADDRESS:-}" ]]; then
     log "using caller-supplied SHADOW_FORK_WITNESS_KEY + SHADOW_FORK_WITNESS_ADDRESS"
+    init_key_stash
     cat > "$KEY_STASH" <<EOF
 export SHADOW_FORK_WITNESS_KEY="$SHADOW_FORK_WITNESS_KEY"
 export SHADOW_FORK_WITNESS_ADDRESS="$SHADOW_FORK_WITNESS_ADDRESS"
 EOF
+    log "stashed at $KEY_STASH (mode 0600)"
     return
   fi
   if [[ -f "$KEY_STASH" ]]; then
@@ -85,6 +102,7 @@ EOF
     err "tronpy not installed — run 'pip install tronpy' or set SHADOW_FORK_WITNESS_KEY+ADDRESS"
   fi
   log "generating fresh witness keypair via tronpy"
+  init_key_stash
   python3 - <<'PY' > "$KEY_STASH"
 from tronpy.keys import PrivateKey
 k = PrivateKey.random()
@@ -92,12 +110,11 @@ addr = k.public_key.to_base58check_address()
 print(f'export SHADOW_FORK_WITNESS_KEY="{k.hex()}"')
 print(f'export SHADOW_FORK_WITNESS_ADDRESS="{addr}"')
 PY
-  # chmod 600 immediately — the file contains a fresh secp256k1
-  # private key. Default umask 022 leaves world-readable bits set,
-  # which is the wrong default for a secret. .gitignore catches the
-  # commit path; this protects against shared-filesystem leaks +
+  # The file holds a fresh secp256k1 private key; init_key_stash above
+  # created it 0600 so the key is never on disk world-readable, not
+  # even for the length of the write. .gitignore catches the commit
+  # path; the mode protects against shared-filesystem leaks +
   # accidental `tar`/`zip` exposure.
-  chmod 600 "$KEY_STASH"
   log "stashed at $KEY_STASH (mode 0600)"
 }
 

--- a/tools/txgen/README.md
+++ b/tools/txgen/README.md
@@ -309,7 +309,7 @@ All files land under `generate.outputDir` (default `txgen-output/`), except the 
 
 | File | Contents |
 |---|---|
-| `receivers.csv` | Inline-generated receiver addresses + private keys. Useful for `db fork` pre-funding. |
+| `receivers.csv` | Inline-generated receiver addresses + private keys. Useful for `db fork` pre-funding. **Secret:** written `0600` inside a `0700` `outputDir`, and an existing file is re-tightened to `0600` on every run — never commit it or ship it in a CI artifact (`txgen-output/` is gitignored). On a filesystem with no POSIX modes (vfat/exFAT, some SMB mounts) the `chmod` fails and the run aborts rather than dumping keys world-readable; point `outputDir` at a real filesystem. |
 | `generate-tx-NNNN.csv` | Signed transactions, `txID,signed_tx_json` per row. |
 | `broadcast-txid.csv` | TxIDs the node accepted into its pool (one per line). |
 | `broadcast-report.txt` | Final report (TPS, on-chain rate, block size stats). |

--- a/tools/txgen/csv.go
+++ b/tools/txgen/csv.go
@@ -18,17 +18,27 @@ type AddressRow struct {
 }
 
 // WriteAddressList writes rows to path in CSV form with a header.
+//
+// Every row carries a receiver's cleartext secp256k1 private key, so the
+// file is created 0600 inside a 0700 directory — never the 0666&umask
+// that os.Create would give it. The explicit Chmod covers the case where
+// path already exists (O_CREATE leaves a pre-existing file's mode alone)
+// and runs before the first row is written, so the keys are never
+// readable by another local uid, not even for an instant.
 func WriteAddressList(path string, rows []AddressRow) error {
 	if dir := filepath.Dir(path); dir != "" {
-		if err := os.MkdirAll(dir, 0o755); err != nil {
+		if err := os.MkdirAll(dir, 0o700); err != nil {
 			return err
 		}
 	}
-	f, err := os.Create(path)
+	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o600)
 	if err != nil {
 		return err
 	}
 	defer f.Close()
+	if err := f.Chmod(0o600); err != nil {
+		return fmt.Errorf("restrict %s to 0600: %w", path, err)
+	}
 	w := csv.NewWriter(f)
 	if err := w.Write([]string{"base58", "hex_address", "private_key"}); err != nil {
 		return err

--- a/tools/txgen/csv_perms_test.go
+++ b/tools/txgen/csv_perms_test.go
@@ -1,0 +1,171 @@
+package main
+
+import (
+	"encoding/csv"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// receivers.csv holds one cleartext secp256k1 private key per row, so
+// these tests pin the on-disk permissions of WriteAddressList: 0600 for
+// the file, 0700 for any directory it creates, on a fresh path and on a
+// pre-existing one.
+
+func sampleRows() []AddressRow {
+	return []AddressRow{
+		{Base58: "TAAA", HexAddress: "41aa", PrivateKey: "aa" + testPrivKeyHex[2:]},
+		{Base58: "TBBB", HexAddress: "41bb", PrivateKey: "bb" + testPrivKeyHex[2:]},
+	}
+}
+
+func modeOf(t *testing.T, path string) os.FileMode {
+	t.Helper()
+	st, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat %s: %v", path, err)
+	}
+	return st.Mode().Perm()
+}
+
+func TestWriteAddressListCreatesFile0600(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "receivers.csv")
+	if err := WriteAddressList(path, sampleRows()); err != nil {
+		t.Fatalf("WriteAddressList: %v", err)
+	}
+	if got := modeOf(t, path); got != 0o600 {
+		t.Errorf("receivers.csv mode = %#o, want 0600 (file holds private keys)", got)
+	}
+}
+
+func TestWriteAddressListCreatesDir0700(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "txgen-output")
+	path := filepath.Join(dir, "receivers.csv")
+	if err := WriteAddressList(path, sampleRows()); err != nil {
+		t.Fatalf("WriteAddressList: %v", err)
+	}
+	if got := modeOf(t, dir); got != 0o700 {
+		t.Errorf("output dir mode = %#o, want 0700", got)
+	}
+}
+
+func TestWriteAddressListTightensExistingFile0644(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "receivers.csv")
+	if err := os.WriteFile(path, []byte("stale\n"), 0o644); err != nil {
+		t.Fatalf("seed file: %v", err)
+	}
+	if err := WriteAddressList(path, sampleRows()); err != nil {
+		t.Fatalf("WriteAddressList: %v", err)
+	}
+	// O_CREATE leaves a pre-existing file's mode alone, so the explicit
+	// Chmod is what closes this case.
+	if got := modeOf(t, path); got != 0o600 {
+		t.Errorf("pre-existing 0644 file left at %#o, want 0600", got)
+	}
+}
+
+func TestWriteAddressListTightensExistingFile0666(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "receivers.csv")
+	if err := os.WriteFile(path, []byte("stale\n"), 0o666); err != nil {
+		t.Fatalf("seed file: %v", err)
+	}
+	if err := os.Chmod(path, 0o666); err != nil {
+		t.Fatalf("chmod seed file: %v", err)
+	}
+	if err := WriteAddressList(path, sampleRows()); err != nil {
+		t.Fatalf("WriteAddressList: %v", err)
+	}
+	if got := modeOf(t, path); got != 0o600 {
+		t.Errorf("pre-existing world-writable file left at %#o, want 0600", got)
+	}
+}
+
+func TestWriteAddressListKeepsExistingDirMode(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "preexisting")
+	if err := os.Mkdir(dir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.Chmod(dir, 0o755); err != nil {
+		t.Fatalf("chmod dir: %v", err)
+	}
+	if err := WriteAddressList(filepath.Join(dir, "receivers.csv"), sampleRows()); err != nil {
+		t.Fatalf("WriteAddressList: %v", err)
+	}
+	// MkdirAll is a no-op on an existing directory: the caller's chosen
+	// mode is left as-is rather than silently re-chmod'ed.
+	if got := modeOf(t, dir); got != 0o755 {
+		t.Errorf("pre-existing dir mode = %#o, want 0755 (unchanged)", got)
+	}
+}
+
+func TestWriteAddressListContentAtRestrictedMode(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "receivers.csv")
+	rows := sampleRows()
+	if err := WriteAddressList(path, rows); err != nil {
+		t.Fatalf("WriteAddressList: %v", err)
+	}
+	if got := modeOf(t, path); got != 0o600 {
+		t.Fatalf("mode = %#o, want 0600", got)
+	}
+
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer f.Close()
+	recs, err := csv.NewReader(f).ReadAll()
+	if err != nil {
+		t.Fatalf("read csv: %v", err)
+	}
+	if len(recs) != len(rows)+1 {
+		t.Fatalf("got %d records, want %d (header + rows)", len(recs), len(rows)+1)
+	}
+	if recs[0][0] != "base58" || recs[0][1] != "hex_address" || recs[0][2] != "private_key" {
+		t.Errorf("header = %v, want [base58 hex_address private_key]", recs[0])
+	}
+	for i, r := range rows {
+		got := recs[i+1]
+		if got[0] != r.Base58 || got[1] != r.HexAddress || got[2] != r.PrivateKey {
+			t.Errorf("row %d = %v, want %v", i, got, r)
+		}
+	}
+}
+
+func TestWriteAddressListReceiverSidecarEndToEnd(t *testing.T) {
+	// The runGenerate path, minus the node round-trips: mint real
+	// receivers and dump them exactly as the sidecar write does.
+	const n = 3
+	addrs, err := buildReceivers(n)
+	if err != nil {
+		t.Fatalf("buildReceivers: %v", err)
+	}
+	dir := filepath.Join(t.TempDir(), "txgen-output")
+	path := filepath.Join(dir, "receivers.csv")
+	if err := WriteAddressList(path, addrs); err != nil {
+		t.Fatalf("WriteAddressList: %v", err)
+	}
+	if got := modeOf(t, dir); got != 0o700 {
+		t.Errorf("output dir mode = %#o, want 0700", got)
+	}
+	if got := modeOf(t, path); got != 0o600 {
+		t.Errorf("sidecar mode = %#o, want 0600", got)
+	}
+
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer f.Close()
+	recs, err := csv.NewReader(f).ReadAll()
+	if err != nil {
+		t.Fatalf("read csv: %v", err)
+	}
+	if len(recs) != n+1 {
+		t.Fatalf("got %d records, want %d", len(recs), n+1)
+	}
+	for i := 1; i < len(recs); i++ {
+		if len(recs[i][2]) != 64 {
+			t.Errorf("row %d private key length = %d, want 64 hex chars", i, len(recs[i][2]))
+		}
+	}
+}

--- a/tools/txgen/generate.go
+++ b/tools/txgen/generate.go
@@ -36,7 +36,13 @@ import (
 // 60s by default for HTTP-built transactions. txgen rewrites raw_data
 // before signing so generated transactions use cfg.Generate.ExpirationMillis.
 func runGenerate(ctx context.Context, cfg *Config) error {
-	if err := os.MkdirAll(cfg.Generate.OutputDir, 0o755); err != nil {
+	// 0700: receivers.csv lands here with one cleartext secp256k1
+	// private key per receiver, so the directory must not be traversable
+	// by other local uids. The generate-tx-NNNN.csv files keep the
+	// default mode — they hold only txIDs and signed transactions, which
+	// are public once broadcast — but they inherit this directory's
+	// protection anyway.
+	if err := os.MkdirAll(cfg.Generate.OutputDir, 0o700); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Five fixes for witness/SR private key exposure, found by an audit of `develop` at `0c654cd`. Each commit stands alone; they are grouped because they all concern key material reaching somewhere it should not.

## What is fixed

**`stop resolving the witness key into rendered config text`** — the root cause. `renderHOCONAppendix` read the key from the environment and inlined it into the one string every caller treats as ordinary text, so it reached stdout, the `-o json` payload, `--output-dir` files, `plan --diff`, `config diff`, `verify-config` and both MCP tool results. The render is now split into a display form carrying `<REDACTED:ENV_NAME>` and an unexported deploy form reachable only through `Deployable()`.

The four differs are positional and LCS-free, so any line-count change above `localwitness` misaligns them and emits the key — they still compare the real bytes, so drift detection is unchanged, but every emitted line including `--context` neighbours now passes through a stateless single-line redactor. Deployed bytes and `config_hash` are byte-identical to before, verified by sha256 across mainnet/nile/private with and without seeds, discovery, `config_overrides` and `account_address`.

**`write rendered config files 0600`** — `config render --output-dir` wrote the `.conf` at 0644 in a 0755 directory. Now opened `O_WRONLY|O_CREATE|O_TRUNC` at 0600 with an `fchmod` on the open descriptor before the body, so a file an earlier run left at 0644 is tightened too.

**`write docker node config 0600 in a 0700 deployment dir`** — same exposure on the docker runtime. No ownership transfer is added: the bind mount is read by the container as root, confirmed against the published image config, which declares no `USER`.

**`create the shadow-fork key stash 0600 before writing to it`** — the caller-supplied branch never set the mode, and the self-generated branch chmod'ed only after `python3` had finished writing, leaving the key readable mid-write. Also stops the script writing the key through a symlink planted at that path.

**`write the txgen receivers CSV 0600`** — one private key per receiver, 1000 by default, was written world-readable. `txgen-output/` added to `.gitignore`.

## Behaviour changes worth reviewing

- `config render` and the MCP `config_render` tool no longer return the real key. `--output-dir` therefore produces a preview java-tron will reject; this is signalled by a stderr warning and a `redacted` field rather than failing silently.
- The four diff surfaces print `localwitness = ["<REDACTED>"]` in place of any `localwitness` line. Counts and `in_sync` are unchanged.
- A witness config that another local account previously read is now unreadable to it. That is the point, but it is a real access change, including for non-witness jar and docker nodes.
- Adds one additive optional field to `config-render.schema.json`, so `SchemaVersion` goes 1.12.2 → 1.12.3 with a regenerated baseline.

## Testing

`go test ./... -race -count=1`, `go vet ./...` and `gofmt` are clean on the branch. Each fix ships regression tests that fail against the unpatched tree.

## Note on ordering

Two sibling PRs also bump `SchemaVersion` to 1.12.3 independently. Whichever merges second will need a rebase and a bump to 1.12.4 with `make snapshot-schema-baseline`.
