### PR TITLE
fix(security): snapshot tar-entry containment, sidecar parse panic, and cleartext transport disclosure

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -252,9 +252,11 @@ trond snapshot sources -o json
 # 2. Dry-run to confirm disk space + URL + would-overwrite check.
 trond snapshot download --network mainnet --to /srv/tron/<node> --dry-run -o json
 # Output: {"preflight":{"expected_size_bytes":...,"free_bytes":...,
-#          "needed_bytes":...,"would_overwrite":false,"has_md5_sidecar":true}, ...}
+#          "needed_bytes":...,"would_overwrite":false,"has_md5_sidecar":true,
+#          "plaintext_transport":true}, ...}
 # If needed_bytes > free_bytes → tell user, abort.
 # If would_overwrite → ask user before passing --force.
+# If plaintext_transport is true → say so before proceeding (see below).
 
 # 3. Start the actual download in background.
 trond snapshot download --network mainnet --to /srv/tron/<node> --detach -o json
@@ -275,6 +277,39 @@ done
 #    Now apply with an intent whose storage.data points there.
 trond apply --intent intent-with-snapshot.yaml --auto-approve --wait -o json
 ```
+
+### `plaintext_transport` — do not skip this
+
+The six mainnet mirrors are bare IPs that publish **no HTTPS endpoint**
+(probed 2026-07-31: `:443` closed, `:80` answers). Only the nile mirror
+serves TLS. Both the `--dry-run` `preflight` object and the completion
+payload carry `"plaintext_transport": true` for those transfers, and trond
+prints a warning to stderr (which, under `--detach`, lands in the job log).
+
+What that means when you report to a user: **`"md5_verified": true` is not
+a security statement on those mirrors.** The `.md5sum` sidecar arrives over
+the same unauthenticated connection as the tarball, so anyone able to
+substitute the archive can substitute the sidecar too. Do not tell a user
+the snapshot is "verified" on the strength of that field alone.
+
+The completion payload also carries `"sha256"` (always computed) and
+`"sha256_verified"` (true only when the operator supplied a pin **and** it
+matched):
+
+```bash
+# Record the digest on a fetch you have reason to trust...
+trond snapshot download --network mainnet --to /srv/a -o json | jq -r .sha256
+
+# ...then pin it on later fetches of that same backup.
+trond snapshot download --network mainnet --backup backup20250115 \
+  --to /srv/b --sha256 <hex> -o json
+# A mismatch fails the download with "sha256 mismatch: ...".
+```
+
+A pin is only worth the channel you got it over — a digest read off the
+same cleartext mirror buys nothing. Surface `plaintext_transport` to the
+user rather than deciding for them; if they have an out-of-band digest,
+pass it through `--sha256` (or the MCP `snapshot_download` `sha256` arg).
 
 When the download finishes, its manifest + log stay under
 `~/.trond/snapshots/<id>.{json,log}` so you can audit later. Stale
@@ -810,7 +845,10 @@ The server registers 23 tools (read-only unless marked):
   human suggestion. Pass `dry_run=true` to propose without acting)
 - **lifecycle** (2): `plan`, `apply` (destructive)
 - **snapshot** (4): `snapshot_sources`, `snapshot_list`, `snapshot_jobs`,
-  `snapshot_download` (destructive, emits MCP progress notifications).
+  `snapshot_download` (destructive, emits MCP progress notifications;
+  takes an optional out-of-band `sha256` pin and returns
+  `plaintext_transport` — an MCP caller has no stderr to read the
+  cleartext-transport warning from, so check that field).
   Job control (`snapshot stop`, `snapshot logs`) is CLI-only.
 - **knowledge** (2): `knowledge_list`, `knowledge_get`
 - **build** (3): `build_list`, `build_inspect`, `build_prune`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -223,6 +223,29 @@ The agent-ergonomics arc lands across four sequenced PRs:
 - `network add` now honors target.type instead of hard-coding
   LocalTarget (an SSH intent would otherwise deploy on the operator's
   local host)
+- **Snapshot downloads: the cleartext transport is now visible, and a
+  strong digest can be pinned.** The six mainnet mirrors are bare IPs
+  that publish no HTTPS endpoint (probed 2026-07-31: `:443` closed,
+  `:80` answers), so their tarballs — and the `.md5sum` sidecar, which
+  rides the same connection — are unauthenticated in transit; a matching
+  MD5 has therefore never attested provenance, only that the transfer
+  was not corrupted. trond no longer lets that pass silently:
+  `snapshot download` warns on stderr before any bytes move (under
+  `--detach` the warning lands in the job log), reports
+  `plaintext_transport` in `-o json` on both the `--dry-run` preflight
+  and the completion payload and via the MCP `snapshot_download` tool,
+  and shows a `transport:` row in the dry-run table. A new `--sha256
+  <hex>` flag (and matching MCP `sha256` arg) checks an out-of-band
+  digest — the only verification in this flow that can detect a
+  substituted archive; a mismatch fails the download and a malformed pin
+  is rejected before the transfer starts. The SHA-256 of every download
+  is computed and reported regardless, so an operator can pin it on
+  later fetches of the same backup. The mainnet `BaseURL`s are
+  deliberately *not* rewritten to `https://` — those mirrors have no TLS
+  to upgrade to, and pretending otherwise would break every mainnet
+  download. Existing MD5 behaviour, verification ordering, and disk
+  headroom are unchanged. Schema `1.12.2` → `1.12.3` (additive optional
+  fields on one schema).
 
 ## [0.1.0-alpha] — 2026-XX-XX
 

--- a/cmd/snapshot/download.go
+++ b/cmd/snapshot/download.go
@@ -26,6 +26,7 @@ var (
 	dlNode     string
 	dlForce    bool
 	dlNoVerify bool
+	dlSHA256   string
 	dlDryRun   bool
 	dlDetach   bool
 )
@@ -41,7 +42,17 @@ refuses to overwrite an existing database without --force.
 The default destination is ./output-directory under the current working
 directory — same convention as the official tron-docker tooling. Pass
 --node <name> to write into a managed node's volume / install path
-instead.`,
+instead.
+
+Transport: the six mainnet mirrors are bare IPs that publish no HTTPS
+endpoint, so those transfers are cleartext and trond says so — on stderr
+before the transfer, and as "plaintext_transport": true in -o json. On a
+cleartext mirror the upstream .md5sum sidecar arrives over the same
+connection as the tarball, so it proves the transfer was not corrupted,
+not that the archive came from TRON. Pass --sha256 <hex> with a digest
+you obtained out of band to get a check that can actually detect
+substitution; the sha256 of every download is printed and reported so you
+can pin it on later fetches of the same backup. The nile mirror is HTTPS.`,
 	Example: `  # Latest mainnet lite snapshot, default mirror
   trond snapshot download --network mainnet
 
@@ -67,6 +78,11 @@ func init() {
 	downloadCmd.Flags().StringVar(&dlNode, "node", "", "Managed node name; resolves --to from state")
 	downloadCmd.Flags().BoolVar(&dlForce, "force", false, "Overwrite existing database in destination")
 	downloadCmd.Flags().BoolVar(&dlNoVerify, "no-verify", false, "Skip MD5 verification (not recommended)")
+	downloadCmd.Flags().StringVar(&dlSHA256, "sha256", "",
+		"Expected SHA-256 of the tarball, obtained out of band (64 hex chars). "+
+			"Unlike the upstream .md5sum — which travels the same channel as the "+
+			"tarball — a pin supplied here can detect a substituted archive. "+
+			"A mismatch fails the download.")
 	downloadCmd.Flags().BoolVar(&dlDryRun, "dry-run", false, "Print what would be downloaded and exit")
 	downloadCmd.Flags().BoolVar(&dlDetach, "detach", false, "Run in background; survives terminal close (logs to ~/.trond/snapshots/<id>.log)")
 }
@@ -101,12 +117,17 @@ func runDownload(cmd *cobra.Command, _ []string) error {
 	}
 
 	opts := snapshot.DownloadOptions{
-		Source:   *src,
-		Backup:   backup,
-		Kind:     snapshot.DBKind(dlKind),
-		DestDir:  dest,
-		Force:    dlForce,
-		NoVerify: dlNoVerify,
+		Source:         *src,
+		Backup:         backup,
+		Kind:           snapshot.DBKind(dlKind),
+		DestDir:        dest,
+		Force:          dlForce,
+		NoVerify:       dlNoVerify,
+		ExpectedSHA256: dlSHA256,
+		// Warnings go to stderr in every mode — JSON callers keep a clean
+		// stdout, and under --detach the re-execed child's stderr is the
+		// job log, so the notice is preserved there too.
+		WarnFn: func(msg string) { fmt.Fprint(cmd.ErrOrStderr(), msg) },
 	}
 
 	pre, err := snapshot.Preflight(cmd.Context(), opts)
@@ -138,6 +159,13 @@ func runDownload(cmd *cobra.Command, _ []string) error {
 	// disown via Setsid so SIGHUP doesn't reach it). Returns immediately
 	// with the job manifest.
 	if dlDetach {
+		// The child re-execs and warns into the job log, but the operator
+		// is looking at *this* terminal right now — warn here too rather
+		// than making them go read a file to learn the transfer is
+		// cleartext.
+		if pre.PlaintextTransport {
+			fmt.Fprint(cmd.ErrOrStderr(), snapshot.PlaintextWarning(pre.URL, dlSHA256 != ""))
+		}
 		return spawnDetached(outputFmt, src, backup, dest)
 	}
 
@@ -157,17 +185,7 @@ func runDownload(cmd *cobra.Command, _ []string) error {
 	}
 
 	if outputFmt == "json" {
-		return output.WriteJSON(os.Stdout, map[string]any{
-			"source":           src,
-			"backup":           backup,
-			"dest":             dest,
-			"bytes_downloaded": res.BytesDownloaded,
-			"duration_ms":      res.DurationMs,
-			"md5_verified":     res.MD5Verified,
-			"actual_md5":       res.ActualMD5,
-			"files_extracted":  res.FilesExtracted,
-			"userdata_present": pre.UserdataPresent,
-		})
+		return output.WriteJSON(os.Stdout, downloadPayload(src, backup, dest, res, pre))
 	}
 
 	fmt.Fprintf(cmd.OutOrStdout(),
@@ -178,21 +196,65 @@ func runDownload(cmd *cobra.Command, _ []string) error {
 	} else if !dlNoVerify {
 		fmt.Fprint(cmd.OutOrStdout(), " (md5 sidecar absent — not verified)")
 	}
+	if res.SHA256Verified {
+		fmt.Fprint(cmd.OutOrStdout(), " (sha256 pin ✓)")
+	}
 	fmt.Fprintln(cmd.OutOrStdout())
+	fmt.Fprintf(cmd.OutOrStdout(), "sha256: %s\n", res.SHA256)
+	if res.PlaintextTransport && !res.SHA256Verified {
+		fmt.Fprintln(cmd.OutOrStdout(),
+			"Note: fetched over cleartext HTTP with no --sha256 pin — the md5 above proves\n"+
+				"transfer integrity, not that these bytes came from TRON. Record the sha256\n"+
+				"and pass it as --sha256 on future fetches of this same backup.")
+	}
 	if pre.UserdataPresent {
 		fmt.Fprintln(cmd.OutOrStdout(), "Note: pre-existing userdata/ was preserved.")
 	}
 	return nil
 }
 
+// downloadPayload builds the `-o json` body for a completed foreground
+// download. Extracted from runDownload so a unit test can validate the
+// exact shipped shape against schemas/output/snapshot-download.schema.json
+// without needing a live multi-GB transfer.
+func downloadPayload(src *snapshot.Source, backup, dest string, res *snapshot.DownloadResult, pre *snapshot.PreflightResult) map[string]any {
+	payload := map[string]any{
+		"source":           src,
+		"backup":           backup,
+		"dest":             dest,
+		"bytes_downloaded": res.BytesDownloaded,
+		"duration_ms":      res.DurationMs,
+		"md5_verified":     res.MD5Verified,
+		"actual_md5":       res.ActualMD5,
+		"files_extracted":  res.FilesExtracted,
+		"userdata_present": pre.UserdataPresent,
+		"sha256":           res.SHA256,
+		"sha256_verified":  res.SHA256Verified,
+		// The cleartext-transport fact has to reach agents that read
+		// stdout only and never see the stderr warning.
+		"plaintext_transport": res.PlaintextTransport,
+	}
+	if res.ExpectedSHA256 != "" {
+		payload["expected_sha256"] = res.ExpectedSHA256
+	}
+	return payload
+}
+
+// planPayload builds the `--dry-run -o json` body. Extracted alongside
+// downloadPayload so both shipped shapes are unit-testable against the
+// published schema.
+func planPayload(src *snapshot.Source, backup, dest string, pre *snapshot.PreflightResult) map[string]any {
+	return map[string]any{
+		"source":    src,
+		"backup":    backup,
+		"dest":      dest,
+		"preflight": pre,
+	}
+}
+
 func emitPlan(outputFmt string, src *snapshot.Source, backup, dest string, pre *snapshot.PreflightResult) error {
 	if outputFmt == "json" {
-		return output.WriteJSON(os.Stdout, map[string]any{
-			"source":    src,
-			"backup":    backup,
-			"dest":      dest,
-			"preflight": pre,
-		})
+		return output.WriteJSON(os.Stdout, planPayload(src, backup, dest, pre))
 	}
 	fmt.Println("Snapshot download plan:")
 	fmt.Printf("  source:           %s (%s, %s, %s)\n", src.Domain, src.Network, src.DBKind, src.Region)
@@ -205,6 +267,10 @@ func emitPlan(outputFmt string, src *snapshot.Source, backup, dest string, pre *
 	fmt.Printf("  database present: %t\n", pre.DatabasePresent)
 	fmt.Printf("  userdata present: %t (preserved across extraction)\n", pre.UserdataPresent)
 	fmt.Printf("  md5 sidecar:      %t\n", pre.HasMD5Sidecar)
+	fmt.Printf("  transport:        %s\n", transportLabel(pre.PlaintextTransport))
+	if pre.PlaintextTransport {
+		fmt.Print(snapshot.PlaintextWarning(pre.URL, dlSHA256 != ""))
+	}
 	if pre.WouldOverwrite {
 		fmt.Println("  WARNING: existing database would be overwritten (use --force).")
 	}
@@ -212,6 +278,16 @@ func emitPlan(outputFmt string, src *snapshot.Source, backup, dest string, pre *
 		fmt.Println("  WARNING: insufficient disk space for safe extraction.")
 	}
 	return nil
+}
+
+// transportLabel renders the plaintext-transport fact for the human dry-run
+// table. Kept blunt on purpose: "https (authenticated)" would overclaim, so
+// we name the transport and let the warning below carry the consequence.
+func transportLabel(plaintext bool) string {
+	if plaintext {
+		return "cleartext http — NOT authenticated"
+	}
+	return "https"
 }
 
 // destFromNode looks up a managed node and returns a path that maps to

--- a/cmd/snapshot/download_transport_test.go
+++ b/cmd/snapshot/download_transport_test.go
@@ -1,0 +1,189 @@
+package snapshot
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/santhosh-tekuri/jsonschema/v6"
+
+	"github.com/tronprotocol/tron-deployment/internal/snapshot"
+)
+
+// The mainnet mirrors serve cleartext HTTP with no HTTPS endpoint, so the
+// only defence trond can offer is to make that visible. A human reads the
+// stderr warning; an agent reads stdout. These tests pin the stdout half —
+// that `plaintext_transport` is actually emitted, and that the payload
+// carrying it still validates against the published contract.
+
+const schemaRelPath = "../../schemas/output/snapshot-download.schema.json"
+
+func TestDownloadPayload_CarriesTransportFactsAndValidates(t *testing.T) {
+	src := snapshot.LookupDomain("34.143.247.77") // a cleartext mainnet mirror
+	if src == nil {
+		t.Fatal("expected the SG mainnet mirror in SourceTable")
+	}
+	res := &snapshot.DownloadResult{
+		BytesDownloaded:    4096,
+		Duration:           3 * time.Second,
+		DurationMs:         3000,
+		ActualMD5:          strings.Repeat("a", 32),
+		FilesExtracted:     12,
+		SHA256:             strings.Repeat("b", 64),
+		PlaintextTransport: true,
+	}
+	pre := &snapshot.PreflightResult{PlaintextTransport: true}
+
+	payload := downloadPayload(src, "backup20250115", "/tmp/dest", res, pre)
+
+	got, ok := payload["plaintext_transport"].(bool)
+	if !ok || !got {
+		t.Errorf("plaintext_transport should be true for an http:// mirror, got %v", payload["plaintext_transport"])
+	}
+	if payload["sha256"] != res.SHA256 {
+		t.Errorf("sha256 missing from payload: %v", payload["sha256"])
+	}
+	if v, ok := payload["sha256_verified"].(bool); !ok || v {
+		t.Errorf("sha256_verified should be false with no pin, got %v", payload["sha256_verified"])
+	}
+	if _, present := payload["expected_sha256"]; present {
+		t.Error("expected_sha256 must be omitted when no pin was supplied")
+	}
+	mustValidate(t, payload)
+}
+
+func TestDownloadPayload_HTTPSMirrorReportsFalse(t *testing.T) {
+	src := snapshot.LookupDomain("snapshots.nileex.io") // the one HTTPS mirror
+	if src == nil {
+		t.Fatal("expected the nile mirror in SourceTable")
+	}
+	res := &snapshot.DownloadResult{
+		BytesDownloaded:    4096,
+		DurationMs:         3000,
+		ActualMD5:          strings.Repeat("a", 32),
+		FilesExtracted:     12,
+		SHA256:             strings.Repeat("b", 64),
+		PlaintextTransport: false,
+	}
+	payload := downloadPayload(src, "backup20260524", "/tmp/dest", res, &snapshot.PreflightResult{})
+
+	if v, ok := payload["plaintext_transport"].(bool); !ok || v {
+		t.Errorf("plaintext_transport should be false for the https:// nile mirror, got %v", payload["plaintext_transport"])
+	}
+	mustValidate(t, payload)
+}
+
+func TestDownloadPayload_WithPinValidates(t *testing.T) {
+	src := snapshot.LookupDomain("34.143.247.77")
+	pin := strings.Repeat("c", 64)
+	res := &snapshot.DownloadResult{
+		BytesDownloaded:    4096,
+		DurationMs:         3000,
+		ActualMD5:          strings.Repeat("a", 32),
+		ExpectedMD5:        strings.Repeat("a", 32),
+		MD5Verified:        true,
+		FilesExtracted:     12,
+		SHA256:             pin,
+		ExpectedSHA256:     pin,
+		SHA256Verified:     true,
+		PlaintextTransport: true,
+	}
+	payload := downloadPayload(src, "backup20250115", "/tmp/dest", res, &snapshot.PreflightResult{})
+
+	if payload["expected_sha256"] != pin {
+		t.Errorf("expected_sha256 should echo the pin, got %v", payload["expected_sha256"])
+	}
+	if v, ok := payload["sha256_verified"].(bool); !ok || !v {
+		t.Error("sha256_verified should be true when the pin matched")
+	}
+	mustValidate(t, payload)
+}
+
+// TestPlanPayload_PreflightCarriesTransportFact covers the --dry-run shape,
+// where the operator decides whether to spend hours on the transfer at all.
+func TestPlanPayload_PreflightCarriesTransportFact(t *testing.T) {
+	src := snapshot.LookupDomain("34.143.247.77")
+	pre := &snapshot.PreflightResult{
+		URL:                snapshot.TarballURL(*src, "backup20250115", snapshot.DBKindLite),
+		ExpectedSize:       1024,
+		FreeBytes:          8192,
+		NeededBytes:        2048,
+		PlaintextTransport: true,
+	}
+	payload := planPayload(src, "backup20250115", "/tmp/dest", pre)
+
+	round := roundTrip(t, payload)
+	flight, ok := round["preflight"].(map[string]any)
+	if !ok {
+		t.Fatalf("preflight missing from plan payload: %#v", round)
+	}
+	if v, ok := flight["plaintext_transport"].(bool); !ok || !v {
+		t.Errorf("preflight.plaintext_transport should be true for an http:// mirror, got %v",
+			flight["plaintext_transport"])
+	}
+	mustValidate(t, payload)
+}
+
+// TestTransportLabel_DoesNotOverclaim — the dry-run table must not describe
+// a cleartext mirror in words an operator could read as "verified".
+func TestTransportLabel_DoesNotOverclaim(t *testing.T) {
+	plain := transportLabel(true)
+	if !strings.Contains(plain, "NOT authenticated") {
+		t.Errorf("cleartext label should say it is not authenticated, got %q", plain)
+	}
+	if secure := transportLabel(false); secure != "https" {
+		t.Errorf("https label = %q, want %q", secure, "https")
+	}
+}
+
+// Helpers ----------------------------------------------------------------
+
+// roundTrip marshals the payload and decodes it back, so assertions run
+// against the bytes a consumer actually sees rather than the Go map.
+func roundTrip(t *testing.T, payload map[string]any) map[string]any {
+	t.Helper()
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(payload); err != nil {
+		t.Fatalf("marshal payload: %v", err)
+	}
+	var out map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &out); err != nil {
+		t.Fatalf("unmarshal payload: %v", err)
+	}
+	return out
+}
+
+// mustValidate asserts the payload satisfies the published output schema.
+// The schema's top-level oneOf means this also proves the payload matches
+// exactly one of the three documented variants.
+func mustValidate(t *testing.T, payload map[string]any) {
+	t.Helper()
+	schemaPath, err := filepath.Abs(schemaRelPath)
+	if err != nil {
+		t.Fatalf("abs schema path: %v", err)
+	}
+	f, err := os.Open(schemaPath)
+	if err != nil {
+		t.Fatalf("open schema: %v", err)
+	}
+	defer f.Close()
+	doc, err := jsonschema.UnmarshalJSON(f)
+	if err != nil {
+		t.Fatalf("parse schema: %v", err)
+	}
+	c := jsonschema.NewCompiler()
+	if err := c.AddResource(schemaPath, doc); err != nil {
+		t.Fatalf("add schema resource: %v", err)
+	}
+	sch, err := c.Compile(schemaPath)
+	if err != nil {
+		t.Fatalf("compile schema: %v", err)
+	}
+	if err := sch.Validate(roundTrip(t, payload)); err != nil {
+		t.Fatalf("payload does not validate against %s: %v", schemaRelPath, err)
+	}
+}

--- a/internal/knowledge/files/snapshots.md
+++ b/internal/knowledge/files/snapshots.md
@@ -92,7 +92,31 @@ Two adjacent directories under the destination get special treatment:
 Pre-existing symlinks at any target path are refused, never followed.
 Any tar entry containing `..` is rejected before `open()`.
 
-## MD5 verification
+## Transport: the mainnet mirrors are cleartext
+
+Probed 2026-07-31, and worth knowing before you trust a snapshot:
+
+| Mirror | Transport |
+|---|---|
+| `snapshots.nileex.io` (both nile rows) | **HTTPS.** Port 443 serves HTTP/2; `:80` 301-redirects to it. |
+| The six mainnet mirrors (`34.143.247.77`, `35.247.128.170`, `34.86.86.229`, `34.48.6.163`, `35.197.17.205`) | **Cleartext HTTP only.** Port 443 is closed on every one; `:80` answers. They are bare IPs, so they could not present a CA-issued certificate anyway. |
+
+trond does not pretend otherwise. It will not rewrite those URLs to
+`https://` (every mainnet download would break) and it does not try HTTPS
+opportunistically (that buys a connect timeout per transfer and nothing
+else). Instead it makes the cleartext hop visible:
+
+- A warning on **stderr** before any bytes move — including under
+  `--detach`, where the child's stderr is the job log.
+- `"plaintext_transport": true` in `-o json`, on both the completion
+  payload and the `--dry-run` `preflight` object, so an agent can branch
+  on it.
+- A `transport:` row in the human `--dry-run` table.
+
+If a mirror ever gains HTTPS, switch its `BaseURL` in
+`internal/snapshot/sources.go` and the warning stops on its own.
+
+## What the MD5 sidecar does and does not buy
 
 Mainnet mirrors publish `<tarball>.tgz.md5sum` sidecars. trond:
 
@@ -102,10 +126,51 @@ Mainnet mirrors publish `<tarball>.tgz.md5sum` sidecars. trond:
 4. Compares — mismatch fails the operation with the database in whatever
    partial state extraction reached.
 
+**Read this before treating `md5 ✓` as a security control.** The sidecar
+comes down the same cleartext connection as the tarball. Anyone in a
+position to substitute the archive — hostile Wi-Fi, an upstream ISP or
+transparent proxy, a BGP hijack of the mirror's IP — is equally able to
+substitute the sidecar, and the two will agree. MD5 is also collision-prone
+on its own merits. So the sidecar check proves the transfer was not
+*corrupted*; it proves nothing about where the bytes came from.
+
 Nile and the occasional outage may leave the sidecar absent. trond will
 still extract; the result message reads `(md5 sidecar absent — not
 verified)`. Pass `--no-verify` to suppress that note when you've made
 the choice deliberately.
+
+## `--sha256`: the check that can detect substitution
+
+A digest is only worth as much as the channel you got it from. trond
+computes the SHA-256 of every download and reports it (`sha256:` in the
+text output, `"sha256"` in JSON) whether or not you asked for one.
+
+```bash
+# First fetch: record the digest trond reports.
+trond snapshot download --network mainnet --to /srv/chain -o json | jq -r .sha256
+
+# Every later fetch of that same backup: pin it.
+trond snapshot download --network mainnet --backup backup20250115 \
+  --to /srv/chain2 --sha256 <hex>
+```
+
+A mismatching pin fails the download (`sha256 mismatch: expected ..., got
+...`); a malformed pin is rejected up front rather than after a multi-hour
+transfer. `"sha256_verified": true` appears in the JSON only when a pin was
+supplied **and** matched — computing a digest is not verifying it.
+
+The pin is worth exactly as much as the path you obtained it over. A digest
+you read off the same cleartext mirror is worth nothing; one you got from a
+trusted operator, a previous verified fetch, or a peer who independently
+downloaded the same backup is worth a great deal. The MCP
+`snapshot_download` tool takes the same value as its `sha256` argument.
+
+`--no-verify` skips only the MD5 sidecar. It does **not** disable a
+`--sha256` pin: if you asked for that check explicitly, you get it.
+
+Neither `--sha256` nor the MD5 sidecar changes *when* verification happens:
+the stream is extracted as it arrives, so a failed check leaves partially
+extracted data behind. Re-run with `--force` to replace it.
 
 ## Long downloads: `--detach`
 
@@ -222,6 +287,19 @@ version change.
   - The tarball got corrupted in flight or the mirror is serving a
     different file than its sidecar advertises. Retry; if the mismatch
     persists, switch `--region` or `--domain`.
+
+`sha256 mismatch: expected ..., got ...`
+  - The archive is not the one your pinned digest describes. Unlike an md5
+    mismatch this is not routine corruption — on a cleartext mirror it is
+    exactly what a substituted archive looks like. Do not `--no-verify`
+    around it. Re-check that the pin belongs to this `--backup` (digests
+    are per-backup), then retry from a different `--domain`; if a second
+    mirror produces the same unexpected digest, the pin is probably stale
+    rather than the download hostile.
+
+`invalid --sha256 "...": expected 64 hex characters`
+  - Malformed pin, rejected before the transfer starts. SHA-256 digests are
+    64 hex characters; you may have pasted an MD5 (32).
 
 ## Local database backup with `db_cp`
 

--- a/internal/mcp/tools_snapshot.go
+++ b/internal/mcp/tools_snapshot.go
@@ -31,6 +31,7 @@ type snapshotDownloadArgs struct {
 	Dest    string `json:"dest" jsonschema:"absolute destination directory; the snapshot expands to <dest>/output-directory/..."`
 	Force   bool   `json:"force,omitempty" jsonschema:"overwrite an existing chain DB (DESTRUCTIVE)"`
 	DryRun  bool   `json:"dry_run,omitempty" jsonschema:"print the plan and exit without downloading"`
+	SHA256  string `json:"sha256,omitempty" jsonschema:"expected SHA-256 of the tarball (64 hex chars) obtained out of band; a mismatch fails the download. The mainnet mirrors are cleartext HTTP and their .md5sum sidecar rides the same channel, so this pin is the only check that can detect a substituted archive"`
 }
 
 func registerSnapshotTools(s *mcp.Server) {
@@ -140,11 +141,12 @@ func snapshotDownloadTool(ctx context.Context, req *mcp.CallToolRequest, args sn
 	}
 
 	opts := snapshot.DownloadOptions{
-		Source:  *src,
-		Backup:  backup,
-		Kind:    kind,
-		DestDir: args.Dest,
-		Force:   args.Force,
+		Source:         *src,
+		Backup:         backup,
+		Kind:           kind,
+		DestDir:        args.Dest,
+		Force:          args.Force,
+		ExpectedSHA256: args.SHA256,
 	}
 
 	pre, err := snapshot.Preflight(ctx, opts)
@@ -179,7 +181,7 @@ func snapshotDownloadTool(ctx context.Context, req *mcp.CallToolRequest, args sn
 	if err != nil {
 		return errResult(err)
 	}
-	return jsonResult(map[string]any{
+	payload := map[string]any{
 		"source":           src,
 		"backup":           backup,
 		"dest":             args.Dest,
@@ -189,7 +191,16 @@ func snapshotDownloadTool(ctx context.Context, req *mcp.CallToolRequest, args sn
 		"actual_md5":       res.ActualMD5,
 		"files_extracted":  res.FilesExtracted,
 		"userdata_present": pre.UserdataPresent,
-	})
+		"sha256":           res.SHA256,
+		"sha256_verified":  res.SHA256Verified,
+		// An MCP caller has no stderr to read the warning from, so the
+		// cleartext-transport fact has to travel in the payload.
+		"plaintext_transport": res.PlaintextTransport,
+	}
+	if res.ExpectedSHA256 != "" {
+		payload["expected_sha256"] = res.ExpectedSHA256
+	}
+	return jsonResult(payload)
 }
 
 // pickSource resolves --domain / --network / --kind / --region into a

--- a/internal/schema/embed.go
+++ b/internal/schema/embed.go
@@ -104,7 +104,16 @@ import (
 //	        replaced by a `<REDACTED:ENV_NAME>` placeholder and the flag
 //	        tells the caller the artifact is a preview java-tron would
 //	        reject. Additive optional fields — PATCH.
-const SchemaVersion = "1.12.3"
+//	1.12.4 — snapshot-download output gains `plaintext_transport` (both on
+//	        the dry-run `preflight` object and the foreground completion),
+//	        plus `sha256`, `expected_sha256` and `sha256_verified`. The six
+//	        mainnet mirrors publish no HTTPS endpoint, so their transfers —
+//	        and the .md5sum sidecar that rides the same connection — are
+//	        unauthenticated; an agent can now see that fact instead of
+//	        inferring it, and pin an out-of-band digest via `--sha256` /
+//	        the MCP `sha256` arg. One existing schema, additive optional
+//	        fields only — PATCH.
+const SchemaVersion = "1.12.4"
 
 // JSONSchemaURLBase is the canonical URL prefix for individual output
 // schema files. Embedded $id values inside each schema mirror this so

--- a/internal/schema/files/snapshot-download.schema.json
+++ b/internal/schema/files/snapshot-download.schema.json
@@ -23,11 +23,15 @@
         "duration_ms":      { "type": "integer", "minimum": 0 },
         "actual_md5":       { "type": "string", "pattern": "^[0-9a-f]{32}$" },
         "expected_md5":     { "type": "string", "pattern": "^[0-9a-f]{32}$" },
-        "md5_verified":     { "type": "boolean" },
+        "md5_verified":     { "type": "boolean", "description": "The upstream .md5sum sidecar matched. On a plaintext_transport mirror the sidecar arrives over the same unauthenticated channel as the tarball, so this attests transfer integrity only — not provenance." },
         "dest":             { "type": "string" },
         "userdata_present": { "type": "boolean" },
         "source":           { "type": "object" },
-        "backup":           { "type": "string" }
+        "backup":           { "type": "string" },
+        "sha256":           { "type": "string", "pattern": "^[0-9a-f]{64}$", "description": "SHA-256 of the downloaded tarball, always computed. Record it to pin --sha256 on later fetches of the same backup." },
+        "expected_sha256":  { "type": "string", "pattern": "^[0-9a-f]{64}$", "description": "The out-of-band digest the operator pinned via --sha256, when one was supplied." },
+        "sha256_verified":  { "type": "boolean", "description": "True only when an out-of-band --sha256 pin was supplied AND matched. This is the only verification in this output that can detect a substituted archive." },
+        "plaintext_transport": { "type": "boolean", "description": "True when the tarball was fetched over cleartext http://. The six mainnet mirrors publish no HTTPS endpoint; the nile mirror does." }
       }
     },
     {
@@ -56,7 +60,8 @@
         "userdata_present":    { "type": "boolean" },
         "database_present":    { "type": "boolean" },
         "would_overwrite":     { "type": "boolean" },
-        "has_md5_sidecar":     { "type": "boolean" }
+        "has_md5_sidecar":     { "type": "boolean" },
+        "plaintext_transport": { "type": "boolean", "description": "True when the tarball URL is cleartext http://, meaning neither the tarball nor its .md5sum sidecar is authenticated in transit." }
       }
     }
   }

--- a/internal/schema/version_baseline.json
+++ b/internal/schema/version_baseline.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": "1.12.3",
+  "schema_version": "1.12.4",
   "entries": [
     {
       "name": "apply",
@@ -103,7 +103,7 @@
     },
     {
       "name": "snapshot-download",
-      "hash": "c816d916847fa337372928fb98c0dcc03905bbfb6a5dd1b76a42d7c9703412fd"
+      "hash": "24767d4d39d7201e46c9f0d23e575283a768bc5867cab81cb9255ce0f5eb3d66"
     },
     {
       "name": "snapshot-jobs",

--- a/internal/snapshot/download.go
+++ b/internal/snapshot/download.go
@@ -5,11 +5,13 @@ import (
 	"compress/gzip"
 	"context"
 	"crypto/md5" //nolint:gosec // upstream publishes md5 .md5sum sidecars; this is integrity, not security
+	"crypto/sha256"
 	"encoding/hex"
 	"errors"
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -72,10 +74,26 @@ type DownloadOptions struct {
 	Force    bool   // overwrite a non-empty existing database
 	NoVerify bool   // skip MD5 verification (for hosts that omit the sidecar)
 
+	// ExpectedSHA256 is an operator-supplied, out-of-band SHA-256 of the
+	// tarball (64 lowercase hex chars; case-insensitive on input). It is
+	// the only digest in this flow that carries real authenticity: the
+	// upstream .md5sum sidecar arrives over the same channel as the
+	// tarball, so an on-path attacker who can rewrite one can rewrite the
+	// other. When set, a mismatch fails the download; when empty, nothing
+	// about the existing MD5 behaviour changes.
+	ExpectedSHA256 string
+
 	// ProgressFn is called periodically with bytes-downloaded out of total.
 	// Caller is responsible for rendering. Both args are bytes; total is 0
 	// when the server didn't supply a Content-Length.
 	ProgressFn func(downloaded, total int64)
+
+	// WarnFn receives operator-facing warnings that are not errors — today
+	// only the plaintext-transport notice, emitted once before any tarball
+	// bytes move. The cmd layer wires this to stderr so it lands in the
+	// terminal (and, under --detach, in the job log). Nil means "drop the
+	// warning"; the same facts stay available on the returned structs.
+	WarnFn func(msg string)
 
 	// HTTPClient lets tests stub the network. Defaults to http.DefaultClient.
 	HTTPClient *http.Client
@@ -93,6 +111,12 @@ type PreflightResult struct {
 	DatabasePresent bool   `json:"database_present"`
 	WouldOverwrite  bool   `json:"would_overwrite"`
 	HasMD5Sidecar   bool   `json:"has_md5_sidecar"`
+
+	// PlaintextTransport is true when the tarball (and therefore its
+	// .md5sum sidecar) travels over cleartext http://. Surfaced so an
+	// operator — or an agent parsing -o json — can see that this transfer
+	// has no transport authenticity before committing hours to it.
+	PlaintextTransport bool `json:"plaintext_transport"`
 }
 
 // DownloadResult is what Download returns on success.
@@ -105,6 +129,65 @@ type DownloadResult struct {
 	ActualMD5       string        `json:"actual_md5"`
 	ExtractedTo     string        `json:"extracted_to"`
 	FilesExtracted  int           `json:"files_extracted"`
+
+	// SHA256 is always computed over the wire bytes, whether or not the
+	// caller pinned one. Recording it lets an operator who trusts this
+	// first fetch pin --sha256 on every later fetch of the same backup.
+	SHA256 string `json:"sha256"`
+	// ExpectedSHA256 echoes the operator-supplied pin, when there was one.
+	ExpectedSHA256 string `json:"expected_sha256,omitempty"`
+	// SHA256Verified is true only when a pin was supplied AND matched.
+	SHA256Verified bool `json:"sha256_verified"`
+	// PlaintextTransport mirrors PreflightResult.PlaintextTransport.
+	PlaintextTransport bool `json:"plaintext_transport"`
+}
+
+// PlaintextTransport reports whether rawURL is delivered over a cleartext,
+// unauthenticated channel. Anything that is not https:// counts — including
+// a URL we cannot parse or one with no scheme at all — so the answer fails
+// safe towards "warn the operator".
+func PlaintextTransport(rawURL string) bool {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return true
+	}
+	return !strings.EqualFold(u.Scheme, "https")
+}
+
+// PlaintextWarning renders the operator-facing notice for a cleartext
+// transfer. Kept here (rather than in the cmd layer) so the CLI, the MCP
+// tool and any future caller all say the same thing.
+func PlaintextWarning(rawURL string, pinned bool) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "WARNING: %s is served over cleartext HTTP.\n", rawURL)
+	b.WriteString("  The tarball and its .md5sum sidecar arrive over the same unauthenticated\n")
+	b.WriteString("  channel, so an on-path attacker can substitute both: a matching MD5 proves\n")
+	b.WriteString("  only that the bytes you received are the bytes that were sent to you, not\n")
+	b.WriteString("  that they came from TRON. MD5 is also collision-prone in its own right.\n")
+	if pinned {
+		b.WriteString("  A --sha256 pin was supplied and will be enforced against the transfer.\n")
+	} else {
+		b.WriteString("  This mirror publishes no HTTPS endpoint. Verify the extracted chain data\n")
+		b.WriteString("  against a trusted peer before relying on it, or pin a digest you obtained\n")
+		b.WriteString("  out of band with --sha256 <hex>.\n")
+	}
+	return b.String()
+}
+
+// normalizeSHA256 validates an operator-supplied SHA-256 pin and returns it
+// lowercased. An empty input is not an error — it just means "no pin".
+func normalizeSHA256(in string) (string, error) {
+	s := strings.ToLower(strings.TrimSpace(in))
+	if s == "" {
+		return "", nil
+	}
+	if len(s) != 64 {
+		return "", fmt.Errorf("invalid --sha256 %q: expected 64 hex characters, got %d", in, len(s))
+	}
+	if _, err := hex.DecodeString(s); err != nil {
+		return "", fmt.Errorf("invalid --sha256 %q: not hexadecimal", in)
+	}
+	return s, nil
 }
 
 // Preflight inspects the destination filesystem and remote tarball
@@ -121,7 +204,7 @@ func Preflight(ctx context.Context, opts DownloadOptions) (*PreflightResult, err
 		return nil, fmt.Errorf("invalid kind %q (need lite or full)", opts.Kind)
 	}
 
-	r := &PreflightResult{URL: url}
+	r := &PreflightResult{URL: url, PlaintextTransport: PlaintextTransport(url)}
 
 	// HEAD for size. We tolerate a missing Content-Length (some mirrors
 	// don't send it) but report 0 so callers can warn.
@@ -185,7 +268,13 @@ func Preflight(ctx context.Context, opts DownloadOptions) (*PreflightResult, err
 //
 // Pipeline:
 //
-//	HTTP body → TeeReader(md5) → progress wrapper → gzip → tar → fs
+//	HTTP body → TeeReader(md5 + sha256) → progress wrapper → gzip → tar → fs
+//
+// A note on what the digests buy. The upstream .md5sum sidecar comes down
+// the same connection as the tarball, so on a cleartext mirror it proves
+// transfer integrity only — never provenance. An operator-supplied
+// ExpectedSHA256, obtained out of band, is the digest that can actually
+// detect substitution; the plaintext warning tells the operator so.
 //
 // On any error during streaming we abort cleanly: partially extracted
 // files stay where they are, the next run with --force will overwrite
@@ -198,6 +287,12 @@ func Download(ctx context.Context, opts DownloadOptions) (*DownloadResult, error
 	}
 	if opts.Backup == "" {
 		return nil, errors.New("backup is required")
+	}
+	// Validate the pin before the transfer, not after: a typo'd digest
+	// should not cost the operator a multi-hour download.
+	expectedSHA256, err := normalizeSHA256(opts.ExpectedSHA256)
+	if err != nil {
+		return nil, err
 	}
 
 	pre, err := Preflight(ctx, opts)
@@ -227,6 +322,14 @@ func Download(ctx context.Context, opts DownloadOptions) (*DownloadResult, error
 			// for hours. Caller controls timeout via ctx.
 			Timeout: 0,
 		}
+	}
+
+	// Warn before a single byte moves — including before the sidecar
+	// fetch, which rides the same channel. This is emitted once per
+	// download; the same fact is on both returned structs for callers
+	// that render JSON instead of text.
+	if pre.PlaintextTransport && opts.WarnFn != nil {
+		opts.WarnFn(PlaintextWarning(pre.URL, expectedSHA256 != ""))
 	}
 
 	// Pull the .md5sum first (tiny). If the user passed --no-verify we
@@ -260,12 +363,17 @@ func Download(ctx context.Context, opts DownloadOptions) (*DownloadResult, error
 	}
 
 	hasher := md5.New() //nolint:gosec // matches upstream .md5sum sidecar format; integrity, not crypto
+	// SHA-256 runs unconditionally alongside MD5. The cost is negligible
+	// against a network-bound transfer, and it is what makes an operator
+	// --sha256 pin — the only digest in this flow with any authenticity —
+	// possible at all.
+	sha := sha256.New()
 	progress := &progressReader{
 		r:     resp.Body,
 		total: resp.ContentLength,
 		cb:    opts.ProgressFn,
 	}
-	teed := io.TeeReader(progress, hasher)
+	teed := io.TeeReader(progress, io.MultiWriter(hasher, sha))
 
 	gz, err := gzip.NewReader(teed)
 	if err != nil {
@@ -287,6 +395,19 @@ func Download(ctx context.Context, opts DownloadOptions) (*DownloadResult, error
 	}
 
 	actualMD5 := hex.EncodeToString(hasher.Sum(nil))
+	actualSHA256 := hex.EncodeToString(sha.Sum(nil))
+
+	// The operator-supplied pin is checked first: it is the only digest
+	// here that did not arrive over the same channel as the payload, so
+	// when both are present its verdict is the one that matters.
+	sha256Verified := false
+	if expectedSHA256 != "" {
+		if !strings.EqualFold(actualSHA256, expectedSHA256) {
+			return nil, fmt.Errorf("sha256 mismatch: expected %s, got %s", expectedSHA256, actualSHA256)
+		}
+		sha256Verified = true
+	}
+
 	verified := false
 	if expectedMD5 != "" {
 		if !strings.EqualFold(actualMD5, expectedMD5) {
@@ -297,14 +418,18 @@ func Download(ctx context.Context, opts DownloadOptions) (*DownloadResult, error
 
 	dur := time.Since(start)
 	return &DownloadResult{
-		BytesDownloaded: progress.read,
-		Duration:        dur,
-		DurationMs:      dur.Milliseconds(),
-		MD5Verified:     verified,
-		ExpectedMD5:     expectedMD5,
-		ActualMD5:       actualMD5,
-		ExtractedTo:     opts.DestDir,
-		FilesExtracted:  extracted,
+		BytesDownloaded:    progress.read,
+		Duration:           dur,
+		DurationMs:         dur.Milliseconds(),
+		MD5Verified:        verified,
+		ExpectedMD5:        expectedMD5,
+		ActualMD5:          actualMD5,
+		ExtractedTo:        opts.DestDir,
+		FilesExtracted:     extracted,
+		SHA256:             actualSHA256,
+		ExpectedSHA256:     expectedSHA256,
+		SHA256Verified:     sha256Verified,
+		PlaintextTransport: pre.PlaintextTransport,
 	}, nil
 }
 

--- a/internal/snapshot/download.go
+++ b/internal/snapshot/download.go
@@ -233,12 +233,15 @@ func Download(ctx context.Context, opts DownloadOptions) (*DownloadResult, error
 	// skip this and clear ExpectedMD5.
 	expectedMD5 := ""
 	if !opts.NoVerify && pre.HasMD5Sidecar {
-		md5Body, err := fetchSmall(ctx, client, MD5URL(opts.Source, opts.Backup, opts.Kind))
+		md5URL := MD5URL(opts.Source, opts.Backup, opts.Kind)
+		md5Body, err := fetchSmall(ctx, client, md5URL)
 		if err != nil {
 			return nil, fmt.Errorf("fetch md5 sidecar: %w", err)
 		}
-		// Sidecar format is "<hex>  <filename>"; we only need the hex.
-		expectedMD5 = strings.TrimSpace(strings.Fields(string(md5Body))[0])
+		expectedMD5, err = parseMD5Sidecar(md5Body, md5URL)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	start := time.Now()
@@ -481,6 +484,47 @@ func fetchSmall(ctx context.Context, client *http.Client, url string) ([]byte, e
 	}
 	// 4 KB is a generous ceiling for an .md5sum sidecar.
 	return io.ReadAll(io.LimitReader(resp.Body, 4096))
+}
+
+// md5HexLen is the length of a hex-encoded MD5 digest.
+const md5HexLen = 32
+
+// parseMD5Sidecar pulls the hex digest out of a coreutils-style sidecar
+// body ("<digest>  <filename>", the form the live mirrors publish; a
+// bare digest is also accepted).
+//
+// The body comes off the network — mainnet mirrors are plain http:// —
+// so every shape is possible: an empty file, a whitespace-only file, an
+// HTML error page from an interception proxy, a truncated digest. Each
+// is reported as an error naming the sidecar URL rather than being
+// indexed blindly (an empty body used to panic here) and rather than
+// yielding an empty digest: Download reads an empty expectedMD5 as
+// "verification disabled", so degrading to one would silently turn a
+// corrupt sidecar into a skipped integrity check.
+func parseMD5Sidecar(body []byte, url string) (string, error) {
+	fields := strings.Fields(string(body))
+	if len(fields) == 0 {
+		return "", fmt.Errorf("malformed md5 sidecar at %s: empty body", url)
+	}
+	digest := fields[0]
+	if len(digest) != md5HexLen {
+		return "", fmt.Errorf("malformed md5 sidecar at %s: expected a %d-character hex digest, got %q (%d chars)",
+			url, md5HexLen, elide(digest), len(digest))
+	}
+	if _, err := hex.DecodeString(digest); err != nil {
+		return "", fmt.Errorf("malformed md5 sidecar at %s: digest %q is not hexadecimal", url, digest)
+	}
+	return digest, nil
+}
+
+// elide caps an untrusted value quoted into an error message; the
+// sidecar body can be up to the fetchSmall limit on a single "field".
+func elide(s string) string {
+	const max = 48
+	if len(s) > max {
+		return s[:max] + "..."
+	}
+	return s
 }
 
 func databasePath(destDir string) string {

--- a/internal/snapshot/download.go
+++ b/internal/snapshot/download.go
@@ -24,6 +24,15 @@ const (
 	tarballLiteName = "LiteFullNode_output-directory.tgz"
 )
 
+// snapshotRoot is the single top-level directory a TRON snapshot tarball
+// is packed around: both FullNode_output-directory.tgz and
+// LiteFullNode_output-directory.tgz expand to `output-directory/...`.
+// That is the layout databasePath() probes, the layout knowledge/snapshots.md
+// documents ("The upstream tarball expands as <dest>/output-directory/database/…")
+// and the layout the dbfork CI job asserts after a real Nile download.
+// extractTar refuses anything outside it — see the comment there.
+const snapshotRoot = "output-directory"
+
 // Tarball returns the .tgz filename for a given DBKind.
 func Tarball(kind DBKind) string {
 	switch kind {
@@ -301,6 +310,13 @@ func Download(ctx context.Context, opts DownloadOptions) (*DownloadResult, error
 // tron-docker's safety check (no path traversal, no writing through
 // existing symlinks) but skip the symlink-resolution dance because we
 // own the destination directory and never extract an absolute path.
+//
+// Staying inside destDir is not on its own enough: we do NOT own destDir
+// exclusively. With `--node <name>` it is a jar node's install_path,
+// which also holds FullNode.jar (what the systemd unit's ExecStart runs),
+// config.conf and userdata/. Entry names come straight off the wire from
+// a mirror that is plain HTTP for mainnet, so every entry is additionally
+// confined to snapshotRoot/.
 func extractTar(r io.Reader, destDir string, force bool) (int, error) {
 	tr := tar.NewReader(r)
 	count := 0
@@ -323,6 +339,17 @@ func extractTar(r io.Reader, destDir string, force bool) (int, error) {
 		clean := filepath.Clean(hdr.Name)
 		if filepath.IsAbs(clean) || strings.HasPrefix(clean, ".."+string(os.PathSeparator)) || clean == ".." {
 			return count, fmt.Errorf("refusing path with traversal: %q", hdr.Name)
+		}
+
+		// Confine the entry to the archive's one legitimate top-level
+		// directory. Without this, an entry named `FullNode.jar` or
+		// `config.conf` is "inside destDir" and therefore accepted, and
+		// with --force the O_EXCL guard is gone so O_TRUNC lands on the
+		// jar the node's systemd unit executes. Refuse loudly, naming the
+		// entry, and abort the extraction: a hostile archive must not be
+		// quietly sanitised into a benign-looking one.
+		if !underSnapshotRoot(clean) {
+			return count, fmt.Errorf("refusing entry outside %s/: %q", snapshotRoot, hdr.Name)
 		}
 
 		target := filepath.Join(cleanedDest, clean)
@@ -378,6 +405,25 @@ func extractTar(r io.Reader, destDir string, force bool) (int, error) {
 		}
 	}
 	return count, nil
+}
+
+// underSnapshotRoot reports whether a cleaned (relative, traversal-free)
+// tar entry name lives at or under snapshotRoot. Three shapes are legal:
+//
+//	"."                        the archive root itself, emitted as a dir
+//	                           entry by `tar -C <parent> -czf - .`; it maps
+//	                           to destDir, which already exists
+//	"output-directory"         the top-level dir entry
+//	"output-directory/<...>"   anything beneath it
+//
+// A bare separator suffix is required so a sibling like
+// "output-directory-evil/x" — which shares the string prefix but not the
+// directory — is refused.
+func underSnapshotRoot(clean string) bool {
+	if clean == "." || clean == snapshotRoot {
+		return true
+	}
+	return strings.HasPrefix(clean, snapshotRoot+string(os.PathSeparator))
 }
 
 // progressReader counts bytes flowing through it and emits a callback at

--- a/internal/snapshot/md5sidecar_test.go
+++ b/internal/snapshot/md5sidecar_test.go
@@ -1,0 +1,215 @@
+package snapshot
+
+import (
+	"context"
+	"crypto/md5" //nolint:gosec // fixture digest for the .md5sum sidecar; integrity, not crypto
+	"encoding/hex"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// The .md5sum body arrives over the network (mainnet mirrors are plain
+// http://), so every degenerate shape has to produce a named error
+// rather than a panic — and rather than an empty digest, which Download
+// reads as "verification disabled".
+func TestParseMD5Sidecar_MalformedBodiesError(t *testing.T) {
+	const url = "http://34.143.247.77/backup20250101/LiteFullNode_output-directory.tgz.md5sum"
+
+	cases := []struct {
+		name string
+		body string
+		want string // substring the error must carry
+	}{
+		{"empty body", "", "empty body"},
+		{"whitespace only", " \t\r\n  \n", "empty body"},
+		{"newline only", "\n", "empty body"},
+		{"html error page", "<html>\r\n<head><title>502 Bad Gateway</title></head>\r\n</html>\r\n", "hex digest"},
+		{"short digest", "d41d8cd98f00b204e980\n", "hex digest"},
+		{"long digest", strings.Repeat("a", 64) + "  LiteFullNode_output-directory.tgz\n", "hex digest"},
+		{"non-hex digest of the right length", strings.Repeat("z", md5HexLen) + "  LiteFullNode_output-directory.tgz\n", "not hexadecimal"},
+		{"filename first", "LiteFullNode_output-directory.tgz  d41d8cd98f00b204e9800998ecf8427e\n", "hex digest"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// A panic here fails the test, which is the point: this is
+			// the index-out-of-range sink.
+			got, err := parseMD5Sidecar([]byte(tc.body), url)
+			if err == nil {
+				t.Fatalf("expected an error for %q, got digest %q", tc.body, got)
+			}
+			if got != "" {
+				t.Fatalf("a rejected sidecar must yield no digest (an empty expectedMD5 silently disables verification), got %q", got)
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("error %q should explain the problem (%q)", err, tc.want)
+			}
+			if !strings.Contains(err.Error(), url) {
+				t.Fatalf("error %q should name the sidecar URL %s", err, url)
+			}
+		})
+	}
+}
+
+func TestParseMD5Sidecar_WellFormedBodiesParse(t *testing.T) {
+	const digest = "d41d8cd98f00b204e9800998ecf8427e"
+	const url = "http://34.143.247.77/backup20250101/LiteFullNode_output-directory.tgz.md5sum"
+
+	cases := []struct {
+		name string
+		body string
+		want string
+	}{
+		// What the live mirrors publish: coreutils `md5sum` output.
+		{"coreutils two-field form", digest + "  LiteFullNode_output-directory.tgz\n", digest},
+		{"single space separator", digest + " LiteFullNode_output-directory.tgz\n", digest},
+		{"binary mode marker", digest + " *LiteFullNode_output-directory.tgz\n", digest},
+		{"no trailing newline", digest + "  LiteFullNode_output-directory.tgz", digest},
+		{"bare digest", digest, digest},
+		{"surrounding whitespace", "\n  " + digest + "  LiteFullNode_output-directory.tgz  \n", digest},
+		{"uppercase digest", strings.ToUpper(digest) + "  LiteFullNode_output-directory.tgz\n", strings.ToUpper(digest)},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := parseMD5Sidecar([]byte(tc.body), url)
+			if err != nil {
+				t.Fatalf("well-formed sidecar %q rejected: %v", tc.body, err)
+			}
+			if got != tc.want {
+				t.Fatalf("digest = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// startSidecarMirror serves a small tarball plus a .md5sum sidecar whose
+// body the test controls, so Download's sidecar handling is exercised
+// over the real HTTP path (HEAD probe + GET) rather than in isolation.
+func startSidecarMirror(t *testing.T, tgz []byte, sidecar string) Source {
+	t.Helper()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/backup20250101/LiteFullNode_output-directory.tgz",
+		func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Length", strconv.Itoa(len(tgz)))
+			w.Write(tgz) // body is discarded by net/http on HEAD
+		})
+	mux.HandleFunc("/backup20250101/LiteFullNode_output-directory.tgz.md5sum",
+		func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Length", strconv.Itoa(len(sidecar)))
+			w.Write([]byte(sidecar))
+		})
+
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	return Source{
+		Network:       NetworkMainnet,
+		DBKind:        DBKindLite,
+		DBEngine:      EngineLevelDB,
+		Region:        RegionSingapore,
+		Domain:        "test",
+		BaseURL:       srv.URL,
+		IndexStrategy: "html",
+	}
+}
+
+// A mirror (or a network attacker on the plain-http path to one) that
+// answers the sidecar HEAD with 200 and the GET with an empty body used
+// to crash the process here. It must be a clean error instead.
+func TestDownload_EmptySidecarErrorsInsteadOfPanicking(t *testing.T) {
+	bodies := map[string]string{
+		"empty":           "",
+		"whitespace only": "   \n",
+		"html error page": "<html><body>403 Forbidden</body></html>\n",
+		"truncated hex":   "d41d8cd98f00\n",
+	}
+
+	for name, body := range bodies {
+		t.Run(name, func(t *testing.T) {
+			dest := t.TempDir()
+			src := startSidecarMirror(t, buildTGZ(t, map[string]string{
+				"output-directory/database/CURRENT": "ok",
+			}), body)
+
+			res, err := Download(context.Background(), DownloadOptions{
+				Source:  src,
+				Backup:  "backup20250101",
+				Kind:    DBKindLite,
+				DestDir: dest,
+			})
+			if err == nil {
+				t.Fatalf("expected a malformed-sidecar error, got result %+v", res)
+			}
+			if res != nil {
+				t.Fatalf("expected no result alongside the error, got %+v", res)
+			}
+			if !strings.Contains(err.Error(), "malformed md5 sidecar") {
+				t.Fatalf("error should name the malformed sidecar, got: %v", err)
+			}
+			if !strings.Contains(err.Error(), ".tgz.md5sum") {
+				t.Fatalf("error should carry the sidecar URL, got: %v", err)
+			}
+			// The refusal happens before the transfer, so nothing landed.
+			if isNonEmptyDir(databasePath(dest)) {
+				t.Fatal("nothing should have been extracted after a sidecar refusal")
+			}
+		})
+	}
+}
+
+// The happy path is unchanged: a coreutils-form sidecar still yields the
+// same digest and still gates the download on a match.
+func TestDownload_WellFormedSidecarStillVerifies(t *testing.T) {
+	dest := t.TempDir()
+	tgz := buildTGZ(t, map[string]string{"output-directory/database/CURRENT": "ok"})
+	sum := md5.Sum(tgz) //nolint:gosec // matches the upstream .md5sum sidecar format
+	digest := hex.EncodeToString(sum[:])
+
+	src := startSidecarMirror(t, tgz, digest+"  LiteFullNode_output-directory.tgz\n")
+
+	res, err := Download(context.Background(), DownloadOptions{
+		Source:  src,
+		Backup:  "backup20250101",
+		Kind:    DBKindLite,
+		DestDir: dest,
+	})
+	if err != nil {
+		t.Fatalf("download with a well-formed sidecar: %v", err)
+	}
+	if !res.MD5Verified {
+		t.Fatal("expected MD5Verified = true")
+	}
+	if res.ExpectedMD5 != digest {
+		t.Fatalf("ExpectedMD5 = %q, want %q", res.ExpectedMD5, digest)
+	}
+	if res.ActualMD5 != digest {
+		t.Fatalf("ActualMD5 = %q, want %q", res.ActualMD5, digest)
+	}
+	if res.FilesExtracted != 1 {
+		t.Fatalf("FilesExtracted = %d, want 1", res.FilesExtracted)
+	}
+}
+
+// A sidecar that parses but doesn't match must still fail — the new
+// validation must not have turned verification into a no-op.
+func TestDownload_SidecarMismatchStillFails(t *testing.T) {
+	dest := t.TempDir()
+	tgz := buildTGZ(t, map[string]string{"output-directory/database/CURRENT": "ok"})
+	wrong := strings.Repeat("0", md5HexLen)
+
+	src := startSidecarMirror(t, tgz, wrong+"  LiteFullNode_output-directory.tgz\n")
+
+	if _, err := Download(context.Background(), DownloadOptions{
+		Source:  src,
+		Backup:  "backup20250101",
+		Kind:    DBKindLite,
+		DestDir: dest,
+	}); err == nil || !strings.Contains(err.Error(), "md5 mismatch") {
+		t.Fatalf("expected an md5 mismatch error, got: %v", err)
+	}
+}

--- a/internal/snapshot/snapshot_test.go
+++ b/internal/snapshot/snapshot_test.go
@@ -124,6 +124,164 @@ func TestExtractTar_RejectsTraversal(t *testing.T) {
 	}
 }
 
+func TestExtractTar_RejectsAbsoluteEntry(t *testing.T) {
+	tgz := buildTGZ(t, map[string]string{"/etc/cron.d/pwn": "nope"})
+	dest := t.TempDir()
+	_, err := extractTar(mustGunzip(t, tgz), dest, true)
+	if err == nil {
+		t.Fatal("expected absolute-path rejection")
+	}
+	if !strings.Contains(err.Error(), "traversal") {
+		t.Fatalf("wrong error: %v", err)
+	}
+}
+
+// TestExtractTar_RefusesEntriesOutsideSnapshotRoot is the regression test
+// for the hostile-mirror case: the destination directory is NOT ours
+// alone. With `--node <name>` it is a jar node's install_path, which also
+// holds FullNode.jar (executed by the systemd unit's ExecStart),
+// config.conf and userdata/. Staying inside destDir is therefore not
+// enough — an entry has to live under output-directory/ as well.
+func TestExtractTar_RefusesEntriesOutsideSnapshotRoot(t *testing.T) {
+	cases := []struct {
+		what  string
+		entry string
+	}{
+		{"jar the systemd unit executes", "FullNode.jar"},
+		{"rendered node config", "config.conf"},
+		{"systemd unit", "tron-fn0.service"},
+		{"operator state beside the db", "userdata/keystore/key.json"},
+		{"nested, but not under the snapshot root", "conf/config.conf"},
+		{"sibling sharing the string prefix", "output-directory-evil/FullNode.jar"},
+		{"dotfile in the destination", ".bashrc"},
+		{"re-rooted after a lexical clean", "output-directory/../FullNode.jar"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.what, func(t *testing.T) {
+			dest := t.TempDir()
+			tgz := buildTGZ(t, map[string]string{tc.entry: "pwned"})
+			// force=true is the dangerous mode: O_EXCL is dropped, so an
+			// accepted entry would O_TRUNC whatever already sits there.
+			_, err := extractTar(mustGunzip(t, tgz), dest, true)
+			if err == nil {
+				t.Fatalf("entry %q was accepted", tc.entry)
+			}
+			// The error must name the offending entry — a refused hostile
+			// archive has to be distinguishable from a benign one.
+			if !strings.Contains(err.Error(), tc.entry) {
+				t.Fatalf("error should name entry %q, got: %v", tc.entry, err)
+			}
+			if _, statErr := os.Stat(filepath.Join(dest, filepath.Clean(tc.entry))); !os.IsNotExist(statErr) {
+				t.Fatalf("entry %q reached disk (stat err: %v)", tc.entry, statErr)
+			}
+		})
+	}
+}
+
+// TestExtractTar_HostileJarEntryLeavesInstalledJarUntouched walks the
+// exploit scenario end to end: a plausible snapshot payload followed by a
+// FullNode.jar entry, extracted with --force into a jar node's
+// install_path. The jar on disk must survive byte-for-byte.
+func TestExtractTar_HostileJarEntryLeavesInstalledJarUntouched(t *testing.T) {
+	dest := t.TempDir() // stands in for a jar node's install_path
+	jar := filepath.Join(dest, "FullNode.jar")
+	if err := os.WriteFile(jar, []byte("the real jar"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	tgz := buildTGZTyped(t, []tarEntry{
+		{name: "output-directory/database/CURRENT", body: "MANIFEST-000001\n"},
+		{name: "FullNode.jar", body: "malicious jar"},
+	})
+	_, err := extractTar(mustGunzip(t, tgz), dest, true)
+	if err == nil {
+		t.Fatal("expected the FullNode.jar entry to be refused")
+	}
+	if !strings.Contains(err.Error(), "FullNode.jar") {
+		t.Fatalf("error should name the entry, got: %v", err)
+	}
+	got, err := os.ReadFile(jar)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "the real jar" {
+		t.Fatalf("FullNode.jar was overwritten: %q", got)
+	}
+}
+
+// Symlink entries were (and stay) skipped inside the snapshot root, but a
+// symlink aimed at a control file must be refused loudly rather than
+// silently dropped.
+func TestExtractTar_SymlinkEntries(t *testing.T) {
+	t.Run("outside the snapshot root is refused", func(t *testing.T) {
+		dest := t.TempDir()
+		tgz := buildTGZTyped(t, []tarEntry{
+			{name: "FullNode.jar", typeflag: tar.TypeSymlink, linkname: "/tmp/evil.jar"},
+		})
+		_, err := extractTar(mustGunzip(t, tgz), dest, true)
+		if err == nil {
+			t.Fatal("expected symlink entry outside the snapshot root to be refused")
+		}
+		if !strings.Contains(err.Error(), "FullNode.jar") {
+			t.Fatalf("error should name the entry, got: %v", err)
+		}
+	})
+
+	t.Run("inside the snapshot root is still skipped", func(t *testing.T) {
+		dest := t.TempDir()
+		tgz := buildTGZTyped(t, []tarEntry{
+			{name: "output-directory/database/LINK", typeflag: tar.TypeSymlink, linkname: "CURRENT"},
+			{name: "output-directory/database/CURRENT", body: "ok"},
+		})
+		n, err := extractTar(mustGunzip(t, tgz), dest, true)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if n != 1 {
+			t.Fatalf("expected 1 regular file extracted, got %d", n)
+		}
+		if _, err := os.Lstat(filepath.Join(dest, "output-directory", "database", "LINK")); !os.IsNotExist(err) {
+			t.Fatalf("symlink entry should have been skipped, stat err: %v", err)
+		}
+	})
+}
+
+// A legitimate snapshot archive must extract exactly as before: both the
+// `output-directory/...` and the `./output-directory/...` spellings, plus
+// the bare `./` root entry that `tar -C <parent> -czf - .` emits.
+func TestExtractTar_AcceptsLegitimateSnapshotLayout(t *testing.T) {
+	dest := t.TempDir()
+	tgz := buildTGZTyped(t, []tarEntry{
+		{name: "./", typeflag: tar.TypeDir},
+		{name: "output-directory/", typeflag: tar.TypeDir},
+		{name: "output-directory/database/", typeflag: tar.TypeDir},
+		{name: "output-directory/database/CURRENT", body: "MANIFEST-000001\n"},
+		{name: "./output-directory/database/000001.sst", body: "sst bytes"},
+		{name: "output-directory/index/CURRENT", body: "index"},
+	})
+
+	n, err := extractTar(mustGunzip(t, tgz), dest, true)
+	if err != nil {
+		t.Fatalf("legitimate archive rejected: %v", err)
+	}
+	if n != 3 {
+		t.Fatalf("expected 3 regular files extracted, got %d", n)
+	}
+	for path, want := range map[string]string{
+		"output-directory/database/CURRENT":    "MANIFEST-000001\n",
+		"output-directory/database/000001.sst": "sst bytes",
+		"output-directory/index/CURRENT":       "index",
+	} {
+		got, err := os.ReadFile(filepath.Join(dest, path))
+		if err != nil {
+			t.Fatalf("read %s: %v", path, err)
+		}
+		if string(got) != want {
+			t.Fatalf("%s = %q, want %q", path, got, want)
+		}
+	}
+}
+
 func TestDownload_RefusesExistingDatabaseWithoutForce(t *testing.T) {
 	dest := t.TempDir()
 	// Seed a non-empty database directory.
@@ -199,6 +357,57 @@ func buildTGZ(t *testing.T, entries map[string]string) []byte {
 		}
 		if _, err := tw.Write([]byte(body)); err != nil {
 			t.Fatal(err)
+		}
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := gz.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return buf.Bytes()
+}
+
+// tarEntry describes one archive member for buildTGZTyped. A zero
+// typeflag means a regular file. Unlike buildTGZ's map, the slice keeps
+// entry order, which matters when a test needs a hostile entry to follow
+// a legitimate one in the stream.
+type tarEntry struct {
+	name     string
+	body     string
+	typeflag byte
+	linkname string
+}
+
+func buildTGZTyped(t *testing.T, entries []tarEntry) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gz)
+	for _, e := range entries {
+		typ := e.typeflag
+		if typ == 0 {
+			typ = tar.TypeReg
+		}
+		hdr := &tar.Header{
+			Name:     e.name,
+			Typeflag: typ,
+			Linkname: e.linkname,
+			Mode:     0o644,
+		}
+		if typ == tar.TypeDir {
+			hdr.Mode = 0o755
+		}
+		if typ == tar.TypeReg {
+			hdr.Size = int64(len(e.body))
+		}
+		if err := tw.WriteHeader(hdr); err != nil {
+			t.Fatal(err)
+		}
+		if typ == tar.TypeReg {
+			if _, err := tw.Write([]byte(e.body)); err != nil {
+				t.Fatal(err)
+			}
 		}
 	}
 	if err := tw.Close(); err != nil {

--- a/internal/snapshot/sources.go
+++ b/internal/snapshot/sources.go
@@ -80,6 +80,25 @@ type Source struct {
 // IMPORTANT: when refreshing this list, prefer adding new entries over
 // rewriting existing ones — automation may key off `Domain`. Mark old
 // entries with a Description hint when they're being decommissioned.
+//
+// Transport, probed 2026-07-31 (`curl` to :443 and :80 on every entry):
+//
+//   - snapshots.nileex.io serves HTTPS (HTTP/2 200 on a real sidecar path)
+//     and 301-redirects :80 → :443. Both nile rows already use https://
+//     and must stay that way.
+//   - All six mainnet rows are bare IPs with port 443 closed — the TLS
+//     connect times out while :80 answers 200 from the same host. A bare
+//     IP could not present a CA-issued certificate anyway, so there is no
+//     HTTPS to prefer and no upgrade to attempt: rewriting these to https://
+//     would break every mainnet download, and an opportunistic "try HTTPS
+//     first" would buy nothing but a connect timeout per transfer.
+//
+// So trond does not silently upgrade these. It makes the cleartext hop
+// visible instead: PreflightResult/DownloadResult carry
+// `plaintext_transport`, and Download emits PlaintextWarning through
+// DownloadOptions.WarnFn before any bytes move. Re-probe when this table
+// is refreshed; if a mirror gains HTTPS, switch its BaseURL here and the
+// warning stops firing on its own.
 var SourceTable = []Source{
 	{
 		Network:       NetworkMainnet,

--- a/internal/snapshot/transport_test.go
+++ b/internal/snapshot/transport_test.go
@@ -1,0 +1,296 @@
+package snapshot
+
+import (
+	"context"
+	"crypto/sha256"
+	"crypto/tls"
+	"encoding/hex"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// The mainnet mirrors in SourceTable are bare IPs with no HTTPS endpoint
+// (probed 2026-07-31: :80 answers 200, :443 times out). trond therefore
+// cannot upgrade those transfers — but it must never let the cleartext hop
+// pass silently, because the .md5sum sidecar rides the same connection and
+// so proves nothing about provenance. These tests pin that behaviour.
+
+func TestPlaintextTransport_ClassifiesScheme(t *testing.T) {
+	cases := []struct {
+		url  string
+		want bool
+	}{
+		{"http://34.143.247.77/backup20250115/LiteFullNode_output-directory.tgz", true},
+		{"https://snapshots.nileex.io/backup20260524/LiteFullNode_output-directory.tgz", false},
+		{"HTTPS://snapshots.nileex.io/x.tgz", false}, // scheme compare is case-insensitive
+		{"HTTP://34.143.247.77/x.tgz", true},
+		{"ftp://example.invalid/x.tgz", true}, // anything not https is unauthenticated
+		{"34.143.247.77/x.tgz", true},         // no scheme at all → fail safe to "warn"
+		{"://nonsense", true},                 // unparseable → fail safe to "warn"
+	}
+	for _, c := range cases {
+		if got := PlaintextTransport(c.url); got != c.want {
+			t.Errorf("PlaintextTransport(%q) = %v, want %v", c.url, got, c.want)
+		}
+	}
+}
+
+// TestSourceTable_NileUsesHTTPS guards the one part of the table that does
+// have a TLS endpoint. If someone downgrades these rows to http:// the
+// warning would start firing for nile and we'd have lost real protection.
+func TestSourceTable_NileUsesHTTPS(t *testing.T) {
+	for _, s := range SourceTable {
+		if s.Network != NetworkNile {
+			continue
+		}
+		if !strings.HasPrefix(s.BaseURL, "https://") {
+			t.Errorf("nile source %q has BaseURL %q; nile publishes HTTPS and must use it",
+				s.Domain, s.BaseURL)
+		}
+	}
+}
+
+func TestDownload_WarnsOnPlaintextMirror(t *testing.T) {
+	dest := t.TempDir()
+	srv := startTinyMirror(t, false)
+	defer srv.Close()
+
+	var warnings []string
+	res, err := Download(context.Background(), DownloadOptions{
+		Source:  sourceFor(srv.URL),
+		Backup:  "backup20250101",
+		Kind:    DBKindLite,
+		DestDir: dest,
+		WarnFn:  func(msg string) { warnings = append(warnings, msg) },
+	})
+	if err != nil {
+		t.Fatalf("download: %v", err)
+	}
+	if len(warnings) != 1 {
+		t.Fatalf("expected exactly one warning for an http:// mirror, got %d: %v", len(warnings), warnings)
+	}
+	w := warnings[0]
+	for _, want := range []string{"cleartext HTTP", "same unauthenticated", "--sha256"} {
+		if !strings.Contains(w, want) {
+			t.Errorf("warning missing %q; got:\n%s", want, w)
+		}
+	}
+	if !res.PlaintextTransport {
+		t.Error("DownloadResult.PlaintextTransport should be true for an http:// mirror")
+	}
+}
+
+func TestDownload_NoWarningOnHTTPSMirror(t *testing.T) {
+	dest := t.TempDir()
+	srv := startTinyMirror(t, true)
+	defer srv.Close()
+
+	var warnings []string
+	res, err := Download(context.Background(), DownloadOptions{
+		Source:  sourceFor(srv.URL),
+		Backup:  "backup20250101",
+		Kind:    DBKindLite,
+		DestDir: dest,
+		WarnFn:  func(msg string) { warnings = append(warnings, msg) },
+		// httptest's TLS server uses a self-signed cert; trusting it here
+		// keeps the test about scheme classification, not PKI.
+		HTTPClient: srv.Client(),
+	})
+	if err != nil {
+		t.Fatalf("download: %v", err)
+	}
+	if len(warnings) != 0 {
+		t.Fatalf("expected no warning for an https:// mirror, got: %v", warnings)
+	}
+	if res.PlaintextTransport {
+		t.Error("DownloadResult.PlaintextTransport should be false for an https:// mirror")
+	}
+}
+
+func TestPreflight_ReportsPlaintextTransport(t *testing.T) {
+	srv := startTinyMirror(t, false)
+	defer srv.Close()
+
+	pre, err := Preflight(context.Background(), DownloadOptions{
+		Source:  sourceFor(srv.URL),
+		Backup:  "backup20250101",
+		Kind:    DBKindLite,
+		DestDir: t.TempDir(),
+	})
+	if err != nil {
+		t.Fatalf("preflight: %v", err)
+	}
+	if !pre.PlaintextTransport {
+		t.Error("PreflightResult.PlaintextTransport should be true for an http:// mirror")
+	}
+}
+
+// TestDownload_NilWarnFnIsSafe — the warning is optional plumbing; a caller
+// that doesn't supply WarnFn must still download, and must still get the
+// fact on the result struct.
+func TestDownload_NilWarnFnIsSafe(t *testing.T) {
+	srv := startTinyMirror(t, false)
+	defer srv.Close()
+
+	res, err := Download(context.Background(), DownloadOptions{
+		Source:  sourceFor(srv.URL),
+		Backup:  "backup20250101",
+		Kind:    DBKindLite,
+		DestDir: t.TempDir(),
+	})
+	if err != nil {
+		t.Fatalf("download with nil WarnFn: %v", err)
+	}
+	if !res.PlaintextTransport {
+		t.Error("PlaintextTransport should be reported even with no WarnFn")
+	}
+}
+
+func TestDownload_SHA256PinMatches(t *testing.T) {
+	srv := startTinyMirror(t, false)
+	defer srv.Close()
+
+	sum := sha256.Sum256(tinyTGZ(t))
+	want := hex.EncodeToString(sum[:])
+
+	res, err := Download(context.Background(), DownloadOptions{
+		Source:         sourceFor(srv.URL),
+		Backup:         "backup20250101",
+		Kind:           DBKindLite,
+		DestDir:        t.TempDir(),
+		ExpectedSHA256: strings.ToUpper(want), // case-insensitive on input
+	})
+	if err != nil {
+		t.Fatalf("download with matching pin: %v", err)
+	}
+	if !res.SHA256Verified {
+		t.Error("SHA256Verified should be true when the pin matches")
+	}
+	if res.SHA256 != want {
+		t.Errorf("SHA256 = %s, want %s", res.SHA256, want)
+	}
+	if res.ExpectedSHA256 != want {
+		t.Errorf("ExpectedSHA256 should echo the normalised pin, got %s", res.ExpectedSHA256)
+	}
+}
+
+func TestDownload_SHA256PinMismatchFails(t *testing.T) {
+	srv := startTinyMirror(t, false)
+	defer srv.Close()
+
+	_, err := Download(context.Background(), DownloadOptions{
+		Source:         sourceFor(srv.URL),
+		Backup:         "backup20250101",
+		Kind:           DBKindLite,
+		DestDir:        t.TempDir(),
+		ExpectedSHA256: strings.Repeat("ab", 32), // valid hex, wrong value
+	})
+	if err == nil {
+		t.Fatal("expected a mismatching --sha256 pin to fail the download")
+	}
+	if !strings.Contains(err.Error(), "sha256 mismatch") {
+		t.Fatalf("wrong error for a bad pin: %v", err)
+	}
+}
+
+// TestDownload_SHA256PinRejectedBeforeTransfer — a malformed pin must fail
+// immediately, not after an operator has waited out a multi-hour transfer.
+// The mirror is never started, so any network use would fail differently.
+func TestDownload_MalformedSHA256PinFailsEarly(t *testing.T) {
+	for _, bad := range []string{"deadbeef", strings.Repeat("z", 64)} {
+		_, err := Download(context.Background(), DownloadOptions{
+			Source:         sourceFor("http://127.0.0.1:1"), // nothing listening
+			Backup:         "backup20250101",
+			Kind:           DBKindLite,
+			DestDir:        t.TempDir(),
+			ExpectedSHA256: bad,
+		})
+		if err == nil {
+			t.Fatalf("expected malformed pin %q to be rejected", bad)
+		}
+		if !strings.Contains(err.Error(), "invalid --sha256") {
+			t.Fatalf("pin %q should be rejected before any network use, got: %v", bad, err)
+		}
+	}
+}
+
+// TestDownload_NoPinLeavesSHA256Unverified — computing the digest is not
+// the same as verifying it. Without an out-of-band pin there is nothing to
+// verify against, and the result must not claim otherwise.
+func TestDownload_NoPinLeavesSHA256Unverified(t *testing.T) {
+	srv := startTinyMirror(t, false)
+	defer srv.Close()
+
+	res, err := Download(context.Background(), DownloadOptions{
+		Source:  sourceFor(srv.URL),
+		Backup:  "backup20250101",
+		Kind:    DBKindLite,
+		DestDir: t.TempDir(),
+	})
+	if err != nil {
+		t.Fatalf("download: %v", err)
+	}
+	if res.SHA256Verified {
+		t.Error("SHA256Verified must be false when no pin was supplied")
+	}
+	if res.SHA256 == "" {
+		t.Error("SHA256 should still be computed so the operator can pin it next time")
+	}
+	if res.ExpectedSHA256 != "" {
+		t.Errorf("ExpectedSHA256 should be empty with no pin, got %q", res.ExpectedSHA256)
+	}
+}
+
+// Helpers ----------------------------------------------------------------
+
+func sourceFor(baseURL string) Source {
+	return Source{
+		Network:       NetworkMainnet,
+		DBKind:        DBKindLite,
+		DBEngine:      EngineLevelDB,
+		Domain:        "test",
+		BaseURL:       baseURL,
+		IndexStrategy: "html",
+	}
+}
+
+// tinyTGZ is the exact byte stream the test mirrors serve, so a test can
+// compute the digest the downloader is expected to report.
+func tinyTGZ(t *testing.T) []byte {
+	t.Helper()
+	return buildTGZ(t, map[string]string{"output-directory/database/CURRENT": "ok"})
+}
+
+// startTinyMirror serves the tiny tarball (no .md5sum sidecar) over plain
+// HTTP or TLS depending on tlsMode, so the scheme-dependent behaviour can
+// be exercised with the same fixture.
+func startTinyMirror(t *testing.T, tlsMode bool) *httptest.Server {
+	t.Helper()
+	tgz := tinyTGZ(t)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/backup20250101/LiteFullNode_output-directory.tgz",
+		func(w http.ResponseWriter, _ *http.Request) {
+			// Let net/http set Content-Length from the body. (The older
+			// startMirror fixture pins it to 0, which is fine there because
+			// that test never reaches the GET.)
+			_, _ = w.Write(tgz)
+		})
+	mux.HandleFunc("/backup20250101/LiteFullNode_output-directory.tgz.md5sum",
+		func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusNotFound)
+		})
+
+	if !tlsMode {
+		return httptest.NewServer(mux)
+	}
+	srv := httptest.NewTLSServer(mux)
+	// httptest.Server.Client() already trusts the server's cert; assert it
+	// so a future change to the helper can't silently downgrade the test.
+	if tr, ok := srv.Client().Transport.(*http.Transport); ok && tr.TLSClientConfig == nil {
+		tr.TLSClientConfig = &tls.Config{MinVersion: tls.VersionTLS12}
+	}
+	return srv
+}

--- a/knowledge/snapshots.md
+++ b/knowledge/snapshots.md
@@ -92,7 +92,31 @@ Two adjacent directories under the destination get special treatment:
 Pre-existing symlinks at any target path are refused, never followed.
 Any tar entry containing `..` is rejected before `open()`.
 
-## MD5 verification
+## Transport: the mainnet mirrors are cleartext
+
+Probed 2026-07-31, and worth knowing before you trust a snapshot:
+
+| Mirror | Transport |
+|---|---|
+| `snapshots.nileex.io` (both nile rows) | **HTTPS.** Port 443 serves HTTP/2; `:80` 301-redirects to it. |
+| The six mainnet mirrors (`34.143.247.77`, `35.247.128.170`, `34.86.86.229`, `34.48.6.163`, `35.197.17.205`) | **Cleartext HTTP only.** Port 443 is closed on every one; `:80` answers. They are bare IPs, so they could not present a CA-issued certificate anyway. |
+
+trond does not pretend otherwise. It will not rewrite those URLs to
+`https://` (every mainnet download would break) and it does not try HTTPS
+opportunistically (that buys a connect timeout per transfer and nothing
+else). Instead it makes the cleartext hop visible:
+
+- A warning on **stderr** before any bytes move — including under
+  `--detach`, where the child's stderr is the job log.
+- `"plaintext_transport": true` in `-o json`, on both the completion
+  payload and the `--dry-run` `preflight` object, so an agent can branch
+  on it.
+- A `transport:` row in the human `--dry-run` table.
+
+If a mirror ever gains HTTPS, switch its `BaseURL` in
+`internal/snapshot/sources.go` and the warning stops on its own.
+
+## What the MD5 sidecar does and does not buy
 
 Mainnet mirrors publish `<tarball>.tgz.md5sum` sidecars. trond:
 
@@ -102,10 +126,51 @@ Mainnet mirrors publish `<tarball>.tgz.md5sum` sidecars. trond:
 4. Compares — mismatch fails the operation with the database in whatever
    partial state extraction reached.
 
+**Read this before treating `md5 ✓` as a security control.** The sidecar
+comes down the same cleartext connection as the tarball. Anyone in a
+position to substitute the archive — hostile Wi-Fi, an upstream ISP or
+transparent proxy, a BGP hijack of the mirror's IP — is equally able to
+substitute the sidecar, and the two will agree. MD5 is also collision-prone
+on its own merits. So the sidecar check proves the transfer was not
+*corrupted*; it proves nothing about where the bytes came from.
+
 Nile and the occasional outage may leave the sidecar absent. trond will
 still extract; the result message reads `(md5 sidecar absent — not
 verified)`. Pass `--no-verify` to suppress that note when you've made
 the choice deliberately.
+
+## `--sha256`: the check that can detect substitution
+
+A digest is only worth as much as the channel you got it from. trond
+computes the SHA-256 of every download and reports it (`sha256:` in the
+text output, `"sha256"` in JSON) whether or not you asked for one.
+
+```bash
+# First fetch: record the digest trond reports.
+trond snapshot download --network mainnet --to /srv/chain -o json | jq -r .sha256
+
+# Every later fetch of that same backup: pin it.
+trond snapshot download --network mainnet --backup backup20250115 \
+  --to /srv/chain2 --sha256 <hex>
+```
+
+A mismatching pin fails the download (`sha256 mismatch: expected ..., got
+...`); a malformed pin is rejected up front rather than after a multi-hour
+transfer. `"sha256_verified": true` appears in the JSON only when a pin was
+supplied **and** matched — computing a digest is not verifying it.
+
+The pin is worth exactly as much as the path you obtained it over. A digest
+you read off the same cleartext mirror is worth nothing; one you got from a
+trusted operator, a previous verified fetch, or a peer who independently
+downloaded the same backup is worth a great deal. The MCP
+`snapshot_download` tool takes the same value as its `sha256` argument.
+
+`--no-verify` skips only the MD5 sidecar. It does **not** disable a
+`--sha256` pin: if you asked for that check explicitly, you get it.
+
+Neither `--sha256` nor the MD5 sidecar changes *when* verification happens:
+the stream is extracted as it arrives, so a failed check leaves partially
+extracted data behind. Re-run with `--force` to replace it.
 
 ## Long downloads: `--detach`
 
@@ -222,6 +287,19 @@ version change.
   - The tarball got corrupted in flight or the mirror is serving a
     different file than its sidecar advertises. Retry; if the mismatch
     persists, switch `--region` or `--domain`.
+
+`sha256 mismatch: expected ..., got ...`
+  - The archive is not the one your pinned digest describes. Unlike an md5
+    mismatch this is not routine corruption — on a cleartext mirror it is
+    exactly what a substituted archive looks like. Do not `--no-verify`
+    around it. Re-check that the pin belongs to this `--backup` (digests
+    are per-backup), then retry from a different `--domain`; if a second
+    mirror produces the same unexpected digest, the pin is probably stale
+    rather than the download hostile.
+
+`invalid --sha256 "...": expected 64 hex characters`
+  - Malformed pin, rejected before the transfer starts. SHA-256 digests are
+    64 hex characters; you may have pasted an MD5 (32).
 
 ## Local database backup with `db_cp`
 

--- a/schemas/output/snapshot-download.schema.json
+++ b/schemas/output/snapshot-download.schema.json
@@ -23,11 +23,15 @@
         "duration_ms":      { "type": "integer", "minimum": 0 },
         "actual_md5":       { "type": "string", "pattern": "^[0-9a-f]{32}$" },
         "expected_md5":     { "type": "string", "pattern": "^[0-9a-f]{32}$" },
-        "md5_verified":     { "type": "boolean" },
+        "md5_verified":     { "type": "boolean", "description": "The upstream .md5sum sidecar matched. On a plaintext_transport mirror the sidecar arrives over the same unauthenticated channel as the tarball, so this attests transfer integrity only — not provenance." },
         "dest":             { "type": "string" },
         "userdata_present": { "type": "boolean" },
         "source":           { "type": "object" },
-        "backup":           { "type": "string" }
+        "backup":           { "type": "string" },
+        "sha256":           { "type": "string", "pattern": "^[0-9a-f]{64}$", "description": "SHA-256 of the downloaded tarball, always computed. Record it to pin --sha256 on later fetches of the same backup." },
+        "expected_sha256":  { "type": "string", "pattern": "^[0-9a-f]{64}$", "description": "The out-of-band digest the operator pinned via --sha256, when one was supplied." },
+        "sha256_verified":  { "type": "boolean", "description": "True only when an out-of-band --sha256 pin was supplied AND matched. This is the only verification in this output that can detect a substituted archive." },
+        "plaintext_transport": { "type": "boolean", "description": "True when the tarball was fetched over cleartext http://. The six mainnet mirrors publish no HTTPS endpoint; the nile mirror does." }
       }
     },
     {
@@ -56,7 +60,8 @@
         "userdata_present":    { "type": "boolean" },
         "database_present":    { "type": "boolean" },
         "would_overwrite":     { "type": "boolean" },
-        "has_md5_sidecar":     { "type": "boolean" }
+        "has_md5_sidecar":     { "type": "boolean" },
+        "plaintext_transport": { "type": "boolean", "description": "True when the tarball URL is cleartext http://, meaning neither the tarball nor its .md5sum sidecar is authenticated in transit." }
       }
     }
   }


### PR DESCRIPTION
Three fixes to the snapshot download path, found by an audit of `develop` at `0c654cd`.

## What is fixed

**`require snapshot tar entries to stay under output-directory/`** — `extractTar` proved only that an entry stayed *inside* the destination. With `--node <name>` that destination is the jar node's `install_path`, which also holds the `FullNode.jar` the systemd unit executes, so an entry named `FullNode.jar` was "inside destDir" and accepted. With `--force` the `O_EXCL` guard is dropped and `O_TRUNC` overwrote the jar before the md5 comparison ran — code execution as the node's `User=` on the next restart, and the comparison happens too late to prevent it.

Entries must now resolve under the archive's own `output-directory/` root, and anything else aborts naming the offending entry. Verified against all eight mirrors in `SourceTable` by ranged GET of the real tarballs: every live archive is `FormatGNU`, single-rooted at `output-directory/`, carrying only directory and regular-file entries. A 21-name bypass probe (`output-directory/../FullNode.jar`, `./output-directory/../…`, case variants on case-insensitive filesystems, `output-directory-evil/`, long names, hardlink and symlink entries) found no hole.

**`guard the md5 sidecar parse`** — `strings.Fields(...)[0]` with no length check, so an empty or whitespace-only sidecar panicked. The MCP go-sdk has no `recover()` in its request path, so that killed the whole `trond mcp` process along with the agent's session. Reachable from a truncated sidecar publish, or from an on-path attacker on the cleartext mainnet mirrors.

**`disclose cleartext snapshot transport and support a --sha256 pin`** — trond presented a same-channel MD5 as though it were verification and never disclosed the hop was cleartext.

All eight mirrors were probed: both Nile rows already serve HTTPS; all five mainnet IPs time out on 443 and answer only on 80, and a bare IP could not present a CA-issued certificate anyway. So there is no HTTPS to prefer — nothing was rewritten, and the probe is recorded in `sources.go` with its date so the next refresh re-checks rather than re-litigates. Instead the transport is made visible (stderr warning before both GETs, `plaintext_transport` in preflight and download output) and pinnable (`--sha256`, validated before any request and enforced even under `--no-verify`).

## Behaviour changes worth reviewing

- New stderr warning on every mainnet download; `-o json` stdout is unaffected.
- New `sha256` line in text output, and a `transport:` row in the dry-run table.
- An archive carrying a stray top-level entry now fails loudly instead of writing it into the node's install directory. No live publisher emits one; a future switch to `tar --format=posix` would emit a `pax_global_header` and trip this.
- Adds two additive optional fields to `snapshot-download.schema.json`, so `SchemaVersion` goes 1.12.2 → 1.12.3.

## Testing

`go test ./... -race -count=1`, `go vet ./...` and `gofmt` clean on the branch. Each fix ships regression tests that fail against the unpatched tree, and the tar-entry and sidecar fixes were both reproduced A/B against binaries built from `develop`.

## Ordering

Two sibling PRs also bump `SchemaVersion` to 1.12.3 independently, and a fourth touches this same file. Suggested merge order is this PR, then the fail-closed one, which will need a rebase and a bump to 1.12.4 via `make snapshot-schema-baseline`.
