### PR TITLE
fix(security): fail closed when the snapshot checksum is unavailable

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -310,6 +310,13 @@ A pin is only worth the channel you got it over — a digest read off the
 same cleartext mirror buys nothing. Surface `plaintext_transport` to the
 user rather than deciding for them; if they have an out-of-band digest,
 pass it through `--sha256` (or the MCP `snapshot_download` `sha256` arg).
+If a download exits non-zero with `VERIFICATION_UNAVAILABLE`, the mirror's
+`.md5sum` sidecar could not be fetched, so trond refused to extract a chain
+database it cannot check — nothing was written to the destination. Retry,
+or pick another backup/mirror. Only pass `--no-verify` (MCP:
+`no_verify: true`) when the user has explicitly accepted an unverified
+chain database; a completed download reports
+`"verification_skipped": true` in that case.
 
 When the download finishes, its manifest + log stay under
 `~/.trond/snapshots/<id>.{json,log}` so you can audit later. Stale

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -246,6 +246,14 @@ The agent-ergonomics arc lands across four sequenced PRs:
   download. Existing MD5 behaviour, verification ordering, and disk
   headroom are unchanged. Schema `1.12.2` → `1.12.3` (additive optional
   fields on one schema).
+- `snapshot download` fails closed on integrity: the `.md5sum` sidecar is
+  always fetched (a preflight HEAD no longer decides whether to verify),
+  and a 404 / transport failure aborts with `VERIFICATION_UNAVAILABLE`
+  (exit 1) instead of silently extracting an unverified chain database.
+  `--no-verify` (MCP `snapshot_download` gains `no_verify`, previously
+  absent) is the only way to skip the check; results carry
+  `verification_skipped` so `md5_verified: false` can no longer be read
+  as "the mirror had no sidecar". Schema 1.12.2 → 1.12.3
 
 ## [0.1.0-alpha] — 2026-XX-XX
 

--- a/cmd/snapshot/detach_test.go
+++ b/cmd/snapshot/detach_test.go
@@ -61,6 +61,14 @@ func TestStripDetach(t *testing.T) {
 			in:   []string{"trond", "--state-dir", "/tmp", "snapshot", "download", "--detach", "--to", "/data"},
 			want: []string{"trond", "--state-dir", "/tmp", "snapshot", "download", "--to", "/data"},
 		},
+		{
+			// The detached child is the process that actually fetches the
+			// sidecar and refuses to extract without it, so the operator's
+			// deliberate opt-out has to survive the re-exec.
+			name: "preserves --no-verify so the opt-out reaches the detached child",
+			in:   []string{"trond", "snapshot", "download", "--detach", "--no-verify", "--network", "nile"},
+			want: []string{"trond", "snapshot", "download", "--no-verify", "--network", "nile"},
+		},
 	}
 
 	for _, c := range cases {

--- a/cmd/snapshot/download.go
+++ b/cmd/snapshot/download.go
@@ -36,8 +36,10 @@ var downloadCmd = &cobra.Command{
 	Short: "Stream a snapshot tarball into a local directory",
 	Long: `Download a chain database snapshot, streaming the tarball through
 gunzip + tar so the .tgz is never persisted to disk. Verifies the
-upstream MD5 sidecar (when published), pre-checks free disk space, and
-refuses to overwrite an existing database without --force.
+upstream MD5 sidecar — if the sidecar cannot be fetched the download
+aborts rather than extracting unchecked data, unless you pass
+--no-verify. Also pre-checks free disk space and refuses to overwrite an
+existing database without --force.
 
 The default destination is ./output-directory under the current working
 directory — same convention as the official tron-docker tooling. Pass
@@ -77,7 +79,7 @@ func init() {
 	downloadCmd.Flags().StringVar(&dlDest, "to", "", "Destination directory (default ./output-directory)")
 	downloadCmd.Flags().StringVar(&dlNode, "node", "", "Managed node name; resolves --to from state")
 	downloadCmd.Flags().BoolVar(&dlForce, "force", false, "Overwrite existing database in destination")
-	downloadCmd.Flags().BoolVar(&dlNoVerify, "no-verify", false, "Skip MD5 verification (not recommended)")
+	downloadCmd.Flags().BoolVar(&dlNoVerify, "no-verify", false, "Extract without checking the MD5 sidecar (UNSAFE; otherwise a missing sidecar aborts the download)")
 	downloadCmd.Flags().StringVar(&dlSHA256, "sha256", "",
 		"Expected SHA-256 of the tarball, obtained out of band (64 hex chars). "+
 			"Unlike the upstream .md5sum — which travels the same channel as the "+
@@ -181,6 +183,15 @@ func runDownload(cmd *cobra.Command, _ []string) error {
 		if errors.As(err, &ow) {
 			return output.NewError("HUMAN_REQUIRED", output.ExitHumanRequired, ow.Error())
 		}
+		var vu *snapshot.VerificationUnavailableError
+		if errors.As(err, &vu) {
+			return output.NewError("VERIFICATION_UNAVAILABLE", output.ExitGeneralError, vu.Error()).
+				WithSuggestions(
+					"Retry — the sidecar may be published a few minutes after the tarball, or the mirror may be briefly unhealthy",
+					fmt.Sprintf("Pick another backup: trond snapshot list --network %s", src.Network),
+					"Only if you accept an unauthenticated chain database: re-run with --no-verify",
+				)
+		}
 		return output.NewError("DOWNLOAD_ERROR", output.ExitGeneralError, err.Error())
 	}
 
@@ -193,8 +204,11 @@ func runDownload(cmd *cobra.Command, _ []string) error {
 		humanGB(uint64(res.BytesDownloaded)), res.Duration.Round(time.Second), res.FilesExtracted, dest)
 	if res.MD5Verified {
 		fmt.Fprint(cmd.OutOrStdout(), " (md5 ✓)")
-	} else if !dlNoVerify {
-		fmt.Fprint(cmd.OutOrStdout(), " (md5 sidecar absent — not verified)")
+	} else {
+		// Only reachable with --no-verify: without it, a sidecar that is
+		// missing or unfetchable aborts the download rather than landing
+		// an unchecked chain database here.
+		fmt.Fprint(cmd.OutOrStdout(), " (NOT VERIFIED — --no-verify was passed; this chain database is unauthenticated)")
 	}
 	if res.SHA256Verified {
 		fmt.Fprint(cmd.OutOrStdout(), " (sha256 pin ✓)")
@@ -225,11 +239,14 @@ func downloadPayload(src *snapshot.Source, backup, dest string, res *snapshot.Do
 		"bytes_downloaded": res.BytesDownloaded,
 		"duration_ms":      res.DurationMs,
 		"md5_verified":     res.MD5Verified,
-		"actual_md5":       res.ActualMD5,
-		"files_extracted":  res.FilesExtracted,
-		"userdata_present": pre.UserdataPresent,
-		"sha256":           res.SHA256,
-		"sha256_verified":  res.SHA256Verified,
+		// Distinguishes "checked and good" from "deliberately unchecked":
+		// a missing sidecar is now an error, never a silent skip.
+		"verification_skipped": res.VerificationSkipped,
+		"actual_md5":           res.ActualMD5,
+		"files_extracted":      res.FilesExtracted,
+		"userdata_present":     pre.UserdataPresent,
+		"sha256":               res.SHA256,
+		"sha256_verified":      res.SHA256Verified,
 		// The cleartext-transport fact has to reach agents that read
 		// stdout only and never see the stderr warning.
 		"plaintext_transport": res.PlaintextTransport,
@@ -270,6 +287,10 @@ func emitPlan(outputFmt string, src *snapshot.Source, backup, dest string, pre *
 	fmt.Printf("  transport:        %s\n", transportLabel(pre.PlaintextTransport))
 	if pre.PlaintextTransport {
 		fmt.Print(snapshot.PlaintextWarning(pre.URL, dlSHA256 != ""))
+	}
+	if !pre.HasMD5Sidecar {
+		fmt.Println("  WARNING: the sidecar did not answer this probe — the download will")
+		fmt.Println("           refuse to extract unverified data unless you pass --no-verify.")
 	}
 	if pre.WouldOverwrite {
 		fmt.Println("  WARNING: existing database would be overwritten (use --force).")

--- a/internal/knowledge/files/snapshots.md
+++ b/internal/knowledge/files/snapshots.md
@@ -70,8 +70,9 @@ Before any tarball bytes hit the wire, trond:
 
 1. Sends an HTTP HEAD to the tarball URL → reads `Content-Length`. The
    body is never opened on this probe.
-2. Issues a separate HEAD to the `.md5sum` sidecar → records whether
-   inline verification will be possible.
+2. Issues a separate HEAD to the `.md5sum` sidecar → records whether the
+   mirror advertises one. Informational only: it never decides whether
+   verification happens (see "MD5 verification").
 3. `Statfs(destination)` → reads available bytes (Bavail × Bsize, the
    same number `df` shows).
 4. Refuses to start the GET if free space < `Content-Length × 2`.
@@ -118,10 +119,12 @@ If a mirror ever gains HTTPS, switch its `BaseURL` in
 
 ## What the MD5 sidecar does and does not buy
 
-Mainnet mirrors publish `<tarball>.tgz.md5sum` sidecars. trond:
+Mainnet and Nile mirrors both publish `<tarball>.tgz.md5sum` sidecars.
+trond:
 
-1. HEADs the sidecar in preflight (records "has md5 sidecar: true/false").
-2. Downloads the sidecar (a few hundred bytes).
+1. HEADs the sidecar in preflight (records "has md5 sidecar: true/false"
+   for `--dry-run`; this answer decides nothing).
+2. Downloads the sidecar (a few hundred bytes) before the tarball GET.
 3. Hashes the tarball stream while extracting.
 4. Compares — mismatch fails the operation with the database in whatever
    partial state extraction reached.
@@ -134,10 +137,21 @@ substitute the sidecar, and the two will agree. MD5 is also collision-prone
 on its own merits. So the sidecar check proves the transfer was not
 *corrupted*; it proves nothing about where the bytes came from.
 
-Nile and the occasional outage may leave the sidecar absent. trond will
-still extract; the result message reads `(md5 sidecar absent — not
-verified)`. Pass `--no-verify` to suppress that note when you've made
-the choice deliberately.
+A mirror outage — or a mirror that stops publishing sidecars — can still
+leave the sidecar absent. **trond then refuses to download**: step 2
+fails with `VERIFICATION_UNAVAILABLE` (exit 1) and nothing is written to
+the destination. The same applies to any transport failure fetching the
+sidecar. The preflight HEAD from step 1 is not consulted: it arrives over
+the same unauthenticated HTTP channel as the tarball, so a 404 there is
+never taken as permission to skip the check.
+
+If you accept an unverified chain database, say so explicitly with
+`--no-verify` (MCP: `no_verify: true`); the flag carries through
+`--detach` to the background child. The result line then reads
+`(NOT VERIFIED — --no-verify was passed; this chain database is
+unauthenticated)` and JSON output carries `"verification_skipped": true`.
+Treat such a database as untrusted input — it is the state your node will
+serve to every dApp, explorer and exchange that queries it.
 
 ## `--sha256`: the check that can detect substitution
 
@@ -300,6 +314,14 @@ version change.
 `invalid --sha256 "...": expected 64 hex characters`
   - Malformed pin, rejected before the transfer starts. SHA-256 digests are
     64 hex characters; you may have pasted an MD5 (32).
+
+`VERIFICATION_UNAVAILABLE: cannot verify snapshot integrity: <url> is
+unavailable ...`
+  - The `.md5sum` sidecar 404'd or the fetch failed, so trond has nothing
+    to check the tarball against and refuses to extract. Retry (sidecars
+    are sometimes published a few minutes after the tarball), pick another
+    backup with `trond snapshot list`, or switch `--region` / `--domain`.
+    `--no-verify` bypasses the check and should be a deliberate choice.
 
 ## Local database backup with `db_cp`
 

--- a/internal/mcp/tools_snapshot.go
+++ b/internal/mcp/tools_snapshot.go
@@ -32,6 +32,12 @@ type snapshotDownloadArgs struct {
 	Force   bool   `json:"force,omitempty" jsonschema:"overwrite an existing chain DB (DESTRUCTIVE)"`
 	DryRun  bool   `json:"dry_run,omitempty" jsonschema:"print the plan and exit without downloading"`
 	SHA256  string `json:"sha256,omitempty" jsonschema:"expected SHA-256 of the tarball (64 hex chars) obtained out of band; a mismatch fails the download. The mainnet mirrors are cleartext HTTP and their .md5sum sidecar rides the same channel, so this pin is the only check that can detect a substituted archive"`
+	// NoVerify is the deliberate opt-out from integrity checking. Without
+	// it, a sidecar that cannot be fetched aborts the download instead of
+	// silently extracting unverified chain data — mirroring `--no-verify`
+	// on the CLI so an agent isn't stuck when a mirror genuinely stops
+	// publishing sidecars.
+	NoVerify bool `json:"no_verify,omitempty" jsonschema:"UNSAFE: extract without checking the MD5 sidecar; otherwise a missing/unfetchable sidecar aborts the download"`
 }
 
 func registerSnapshotTools(s *mcp.Server) {
@@ -59,7 +65,7 @@ func registerSnapshotTools(s *mcp.Server) {
 	mcp.AddTool(s, &mcp.Tool{
 		Name:  "snapshot_download",
 		Title: "Download a chain DB snapshot",
-		Description: `Stream a snapshot tarball into a destination directory, gunzip + tar in one pipeline (no .tgz on disk). Pre-checks free disk space (HEAD probe + Statfs, requires 2× headroom). Refuses overwrite of an existing chain DB unless force=true. Preserves any pre-existing userdata/. MD5-verifies inline against the published sidecar when present.
+		Description: `Stream a snapshot tarball into a destination directory, gunzip + tar in one pipeline (no .tgz on disk). Pre-checks free disk space (HEAD probe + Statfs, requires 2× headroom). Refuses overwrite of an existing chain DB unless force=true. Preserves any pre-existing userdata/. MD5-verifies inline against the published sidecar; if the sidecar cannot be fetched the download fails instead of extracting unverified chain data — pass no_verify=true only to accept that risk deliberately.
 
 Use dry_run=true to inspect the plan first. The tool emits MCP progress notifications during the actual download so the client can render a live progress bar. NOTE: this MCP tool runs the download in-process and blocks until completion or context cancellation; for fire-and-forget mainnet-full sized downloads (multi-hour) prefer the CLI with --detach.
 
@@ -147,6 +153,7 @@ func snapshotDownloadTool(ctx context.Context, req *mcp.CallToolRequest, args sn
 		DestDir:        args.Dest,
 		Force:          args.Force,
 		ExpectedSHA256: args.SHA256,
+		NoVerify:       args.NoVerify,
 	}
 
 	pre, err := snapshot.Preflight(ctx, opts)
@@ -188,11 +195,14 @@ func snapshotDownloadTool(ctx context.Context, req *mcp.CallToolRequest, args sn
 		"bytes_downloaded": res.BytesDownloaded,
 		"duration_ms":      res.DurationMs,
 		"md5_verified":     res.MD5Verified,
-		"actual_md5":       res.ActualMD5,
-		"files_extracted":  res.FilesExtracted,
-		"userdata_present": pre.UserdataPresent,
-		"sha256":           res.SHA256,
-		"sha256_verified":  res.SHA256Verified,
+		// A missing sidecar is an error now, so md5_verified=false means
+		// exactly one thing: the caller passed no_verify.
+		"verification_skipped": res.VerificationSkipped,
+		"actual_md5":           res.ActualMD5,
+		"files_extracted":      res.FilesExtracted,
+		"userdata_present":     pre.UserdataPresent,
+		"sha256":               res.SHA256,
+		"sha256_verified":      res.SHA256Verified,
 		// An MCP caller has no stderr to read the warning from, so the
 		// cleartext-transport fact has to travel in the payload.
 		"plaintext_transport": res.PlaintextTransport,

--- a/internal/schema/embed.go
+++ b/internal/schema/embed.go
@@ -113,7 +113,13 @@ import (
 //	        inferring it, and pin an out-of-band digest via `--sha256` /
 //	        the MCP `sha256` arg. One existing schema, additive optional
 //	        fields only — PATCH.
-const SchemaVersion = "1.12.4"
+//	1.12.5 — snapshot-download output gains `verification_skipped`. A
+//	        missing or unfetchable `.md5sum` sidecar is now a hard error
+//	        (`VERIFICATION_UNAVAILABLE`) rather than a silent skip, so
+//	        `md5_verified: false` on a successful download means one
+//	        thing only: the operator passed `--no-verify` / `no_verify`.
+//	        One existing schema, one additive optional field — PATCH.
+const SchemaVersion = "1.12.5"
 
 // JSONSchemaURLBase is the canonical URL prefix for individual output
 // schema files. Embedded $id values inside each schema mirror this so

--- a/internal/schema/files/snapshot-download.schema.json
+++ b/internal/schema/files/snapshot-download.schema.json
@@ -24,6 +24,10 @@
         "actual_md5":       { "type": "string", "pattern": "^[0-9a-f]{32}$" },
         "expected_md5":     { "type": "string", "pattern": "^[0-9a-f]{32}$" },
         "md5_verified":     { "type": "boolean", "description": "The upstream .md5sum sidecar matched. On a plaintext_transport mirror the sidecar arrives over the same unauthenticated channel as the tarball, so this attests transfer integrity only — not provenance." },
+        "verification_skipped": {
+          "type": "boolean",
+          "description": "true only when --no-verify / no_verify was passed. A missing or unfetchable .md5sum sidecar is an error (VERIFICATION_UNAVAILABLE), never a silent skip, so md5_verified=false always means the operator opted out."
+        },
         "dest":             { "type": "string" },
         "userdata_present": { "type": "boolean" },
         "source":           { "type": "object" },

--- a/internal/schema/version_baseline.json
+++ b/internal/schema/version_baseline.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": "1.12.4",
+  "schema_version": "1.12.5",
   "entries": [
     {
       "name": "apply",
@@ -103,7 +103,7 @@
     },
     {
       "name": "snapshot-download",
-      "hash": "24767d4d39d7201e46c9f0d23e575283a768bc5867cab81cb9255ce0f5eb3d66"
+      "hash": "14517cc14171dcf3f615fa2cf69be553bceab3b83fcea2ac7f913260e64e5c2c"
     },
     {
       "name": "snapshot-jobs",

--- a/internal/snapshot/download.go
+++ b/internal/snapshot/download.go
@@ -72,7 +72,7 @@ type DownloadOptions struct {
 	Kind     DBKind // lite | full
 	DestDir  string // destination directory; the snapshot expands as <DestDir>/output-directory/...
 	Force    bool   // overwrite a non-empty existing database
-	NoVerify bool   // skip MD5 verification (for hosts that omit the sidecar)
+	NoVerify bool   // deliberate operator opt-out: extract without any integrity check
 
 	// ExpectedSHA256 is an operator-supplied, out-of-band SHA-256 of the
 	// tarball (64 lowercase hex chars; case-insensitive on input). It is
@@ -125,10 +125,15 @@ type DownloadResult struct {
 	Duration        time.Duration `json:"-"`
 	DurationMs      int64         `json:"duration_ms"`
 	MD5Verified     bool          `json:"md5_verified"`
-	ExpectedMD5     string        `json:"expected_md5,omitempty"`
-	ActualMD5       string        `json:"actual_md5"`
-	ExtractedTo     string        `json:"extracted_to"`
-	FilesExtracted  int           `json:"files_extracted"`
+	// VerificationSkipped is true only when the operator passed NoVerify.
+	// It exists so callers can distinguish "checked and good" from
+	// "deliberately unchecked" — MD5Verified being false is never simply
+	// "the mirror had no sidecar" any more; that case is now an error.
+	VerificationSkipped bool   `json:"verification_skipped"`
+	ExpectedMD5         string `json:"expected_md5,omitempty"`
+	ActualMD5           string `json:"actual_md5"`
+	ExtractedTo         string `json:"extracted_to"`
+	FilesExtracted      int    `json:"files_extracted"`
 
 	// SHA256 is always computed over the wire bytes, whether or not the
 	// caller pinned one. Recording it lets an operator who trusts this
@@ -222,8 +227,12 @@ func Preflight(ctx context.Context, opts DownloadOptions) (*PreflightResult, err
 	}
 	r.ExpectedSize = resp.ContentLength
 
-	// Probe the .md5sum sidecar with a HEAD; if it's absent we'll fall
-	// back to a download-only flow with the verification flag flipped.
+	// Probe the .md5sum sidecar with a HEAD. This is *informational only*
+	// — it feeds `--dry-run` so the operator can see ahead of time whether
+	// the mirror publishes a sidecar. It deliberately does NOT decide
+	// whether Download verifies: the probe answer arrives over the same
+	// unauthenticated channel as the tarball, so letting a 404 here switch
+	// verification off would hand any on-path attacker a free downgrade.
 	md5URL := MD5URL(opts.Source, opts.Backup, opts.Kind)
 	r.MD5URL = md5URL
 	if md5Req, err := http.NewRequestWithContext(ctx, http.MethodHead, md5URL, http.NoBody); err == nil {
@@ -332,14 +341,19 @@ func Download(ctx context.Context, opts DownloadOptions) (*DownloadResult, error
 		opts.WarnFn(PlaintextWarning(pre.URL, expectedSHA256 != ""))
 	}
 
-	// Pull the .md5sum first (tiny). If the user passed --no-verify we
-	// skip this and clear ExpectedMD5.
+	// Pull the .md5sum first (tiny). Verification is mandatory: the only
+	// way to extract an unverified snapshot is for the operator to say so
+	// explicitly with --no-verify. We fetch unconditionally rather than
+	// consulting pre.HasMD5Sidecar, because that flag comes from a HEAD
+	// against the same plaintext channel the tarball does — treating a 404
+	// there as permission to skip the check would let anyone on the path
+	// disable integrity checking silently.
 	expectedMD5 := ""
-	if !opts.NoVerify && pre.HasMD5Sidecar {
+	if !opts.NoVerify {
 		md5URL := MD5URL(opts.Source, opts.Backup, opts.Kind)
 		md5Body, err := fetchSmall(ctx, client, md5URL)
 		if err != nil {
-			return nil, fmt.Errorf("fetch md5 sidecar: %w", err)
+			return nil, &VerificationUnavailableError{URL: md5URL, Err: err}
 		}
 		expectedMD5, err = parseMD5Sidecar(md5Body, md5URL)
 		if err != nil {
@@ -418,18 +432,19 @@ func Download(ctx context.Context, opts DownloadOptions) (*DownloadResult, error
 
 	dur := time.Since(start)
 	return &DownloadResult{
-		BytesDownloaded:    progress.read,
-		Duration:           dur,
-		DurationMs:         dur.Milliseconds(),
-		MD5Verified:        verified,
-		ExpectedMD5:        expectedMD5,
-		ActualMD5:          actualMD5,
-		ExtractedTo:        opts.DestDir,
-		FilesExtracted:     extracted,
-		SHA256:             actualSHA256,
-		ExpectedSHA256:     expectedSHA256,
-		SHA256Verified:     sha256Verified,
-		PlaintextTransport: pre.PlaintextTransport,
+		BytesDownloaded:     progress.read,
+		Duration:            dur,
+		DurationMs:          dur.Milliseconds(),
+		MD5Verified:         verified,
+		VerificationSkipped: opts.NoVerify,
+		ExpectedMD5:         expectedMD5,
+		ActualMD5:           actualMD5,
+		ExtractedTo:         opts.DestDir,
+		FilesExtracted:      extracted,
+		SHA256:              actualSHA256,
+		ExpectedSHA256:      expectedSHA256,
+		SHA256Verified:      sha256Verified,
+		PlaintextTransport:  pre.PlaintextTransport,
 	}, nil
 }
 
@@ -591,6 +606,28 @@ type OverwriteError struct {
 }
 
 func (e *OverwriteError) Error() string { return e.Message }
+
+// VerificationUnavailableError is returned when integrity verification was
+// requested (the default) but the .md5sum sidecar could not be retrieved —
+// a 404 from the mirror, a transport failure, or any non-200 status. It is
+// deliberately fatal: nothing is extracted. A chain database is the state a
+// node serves to dApps, exchanges and explorers, so "couldn't check" must
+// never silently degrade to "shipped it anyway".
+//
+// The operator's escape hatch is DownloadOptions.NoVerify (`--no-verify`
+// on the CLI, `no_verify: true` on the MCP tool).
+type VerificationUnavailableError struct {
+	URL string // the .md5sum URL we failed to fetch
+	Err error  // underlying transport / status error
+}
+
+func (e *VerificationUnavailableError) Error() string {
+	return fmt.Sprintf("cannot verify snapshot integrity: %s is unavailable (%v); "+
+		"refusing to extract an unverified chain database — re-run with --no-verify "+
+		"to accept the risk deliberately", e.URL, e.Err)
+}
+
+func (e *VerificationUnavailableError) Unwrap() error { return e.Err }
 
 // Helpers ----------------------------------------------------------------
 

--- a/internal/snapshot/transport_test.go
+++ b/internal/snapshot/transport_test.go
@@ -2,9 +2,11 @@ package snapshot
 
 import (
 	"context"
+	"crypto/md5"
 	"crypto/sha256"
 	"crypto/tls"
 	"encoding/hex"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -263,12 +265,18 @@ func tinyTGZ(t *testing.T) []byte {
 	return buildTGZ(t, map[string]string{"output-directory/database/CURRENT": "ok"})
 }
 
-// startTinyMirror serves the tiny tarball (no .md5sum sidecar) over plain
-// HTTP or TLS depending on tlsMode, so the scheme-dependent behaviour can
-// be exercised with the same fixture.
+// startTinyMirror serves the tiny tarball and a matching .md5sum sidecar
+// over plain HTTP or TLS depending on tlsMode, so the scheme-dependent
+// behaviour can be exercised with the same fixture.
+//
+// The sidecar is served for real because a missing one is now a hard
+// error (VERIFICATION_UNAVAILABLE) rather than a silent skip — these
+// tests are about transport disclosure and the --sha256 pin, so they
+// need the download to reach completion.
 func startTinyMirror(t *testing.T, tlsMode bool) *httptest.Server {
 	t.Helper()
 	tgz := tinyTGZ(t)
+	sum := fmt.Sprintf("%x  LiteFullNode_output-directory.tgz\n", md5.Sum(tgz))
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("/backup20250101/LiteFullNode_output-directory.tgz",
@@ -280,7 +288,7 @@ func startTinyMirror(t *testing.T, tlsMode bool) *httptest.Server {
 		})
 	mux.HandleFunc("/backup20250101/LiteFullNode_output-directory.tgz.md5sum",
 		func(w http.ResponseWriter, _ *http.Request) {
-			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte(sum))
 		})
 
 	if !tlsMode {

--- a/internal/snapshot/verify_test.go
+++ b/internal/snapshot/verify_test.go
@@ -1,0 +1,221 @@
+package snapshot
+
+import (
+	"context"
+	"crypto/md5" //nolint:gosec // mirrors the upstream .md5sum sidecar format under test
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// verifyMirror serves a tiny lite-snapshot tarball plus a .md5sum sidecar
+// whose behaviour the test picks: "ok" (correct digest), "404" (absent),
+// or "transport" (handled by errOnSidecarTransport instead of the server).
+func verifyMirror(t *testing.T, sidecar string) (*httptest.Server, []byte) {
+	t.Helper()
+	tgz := buildTGZ(t, map[string]string{"output-directory/database/CURRENT": "ok"})
+	sum := md5.Sum(tgz) //nolint:gosec // integrity fixture, not crypto
+	digest := hex.EncodeToString(sum[:])
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/backup20250101/"+tarballLiteName,
+		func(w http.ResponseWriter, r *http.Request) {
+			if r.Method == http.MethodHead {
+				return
+			}
+			w.Write(tgz)
+		})
+	mux.HandleFunc("/backup20250101/"+tarballLiteName+".md5sum",
+		func(w http.ResponseWriter, _ *http.Request) {
+			if sidecar != "ok" {
+				w.WriteHeader(http.StatusNotFound)
+				return
+			}
+			fmt.Fprintf(w, "%s  %s\n", digest, tarballLiteName)
+		})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return srv, tgz
+}
+
+func verifySource(baseURL string) Source {
+	return Source{
+		Network:       NetworkMainnet,
+		DBKind:        DBKindLite,
+		DBEngine:      EngineLevelDB,
+		Region:        RegionSingapore,
+		Domain:        "test",
+		BaseURL:       baseURL,
+		IndexStrategy: "html",
+	}
+}
+
+// errOnSidecarTransport fails every request for a .md5sum URL at the
+// transport layer, simulating a DNS/TCP/TLS failure (or an on-path
+// attacker dropping the connection) rather than an HTTP status.
+type errOnSidecarTransport struct{ inner http.RoundTripper }
+
+var errSidecarTransport = stubError("simulated transport failure")
+
+func (t *errOnSidecarTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if strings.HasSuffix(req.URL.Path, ".md5sum") {
+		return nil, errSidecarTransport
+	}
+	return t.inner.RoundTrip(req)
+}
+
+// countFiles returns how many regular files exist anywhere under root.
+func countFiles(t *testing.T, root string) int {
+	t.Helper()
+	n := 0
+	err := filepath.Walk(root, func(_ string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.Mode().IsRegular() {
+			n++
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk %s: %v", root, err)
+	}
+	return n
+}
+
+// A mirror that 404s the sidecar must not be able to switch verification
+// off: the download fails and nothing is written to the destination.
+func TestDownload_MissingSidecarFailsClosed(t *testing.T) {
+	dest := t.TempDir()
+	srv, _ := verifyMirror(t, "404")
+
+	_, err := Download(context.Background(), DownloadOptions{
+		Source:  verifySource(srv.URL),
+		Backup:  "backup20250101",
+		Kind:    DBKindLite,
+		DestDir: dest,
+	})
+	if err == nil {
+		t.Fatal("expected refusal when the .md5sum sidecar is absent")
+	}
+	var vu *VerificationUnavailableError
+	if !errors.As(err, &vu) {
+		t.Fatalf("expected *VerificationUnavailableError, got %T: %v", err, err)
+	}
+	if !strings.Contains(err.Error(), "--no-verify") {
+		t.Errorf("error should point at the deliberate opt-out, got: %v", err)
+	}
+	if n := countFiles(t, dest); n != 0 {
+		t.Errorf("destination must be untouched, found %d files under %s", n, dest)
+	}
+	if _, err := os.Stat(databasePath(dest)); !os.IsNotExist(err) {
+		t.Errorf("no chain database should have been extracted at %s", databasePath(dest))
+	}
+}
+
+// A transport-level failure fetching the sidecar is equally fatal — an
+// attacker who can drop the sidecar connection must not gain a downgrade.
+func TestDownload_SidecarTransportErrorFailsClosed(t *testing.T) {
+	dest := t.TempDir()
+	srv, _ := verifyMirror(t, "ok")
+
+	_, err := Download(context.Background(), DownloadOptions{
+		Source:     verifySource(srv.URL),
+		Backup:     "backup20250101",
+		Kind:       DBKindLite,
+		DestDir:    dest,
+		HTTPClient: &http.Client{Transport: &errOnSidecarTransport{inner: http.DefaultTransport}},
+	})
+	if err == nil {
+		t.Fatal("expected refusal when the sidecar fetch fails at the transport layer")
+	}
+	var vu *VerificationUnavailableError
+	if !errors.As(err, &vu) {
+		t.Fatalf("expected *VerificationUnavailableError, got %T: %v", err, err)
+	}
+	if !errors.Is(err, errSidecarTransport) {
+		t.Errorf("underlying transport error should be wrapped, got: %v", err)
+	}
+	if n := countFiles(t, dest); n != 0 {
+		t.Errorf("destination must be untouched, found %d files under %s", n, dest)
+	}
+}
+
+// --no-verify remains the escape hatch: with it, a 404 sidecar still
+// extracts, but the result says plainly that nothing was verified.
+func TestDownload_NoVerifyExtractsPastMissingSidecar(t *testing.T) {
+	dest := t.TempDir()
+	srv, _ := verifyMirror(t, "404")
+
+	res, err := Download(context.Background(), DownloadOptions{
+		Source:   verifySource(srv.URL),
+		Backup:   "backup20250101",
+		Kind:     DBKindLite,
+		DestDir:  dest,
+		NoVerify: true,
+	})
+	if err != nil {
+		t.Fatalf("--no-verify should still extract: %v", err)
+	}
+	if res.MD5Verified {
+		t.Error("MD5Verified must be false when verification was skipped")
+	}
+	if !res.VerificationSkipped {
+		t.Error("VerificationSkipped must be true so output cannot imply a verified download")
+	}
+	if res.ExpectedMD5 != "" {
+		t.Errorf("no expected digest should be recorded, got %q", res.ExpectedMD5)
+	}
+	if res.FilesExtracted != 1 {
+		t.Errorf("expected 1 file extracted, got %d", res.FilesExtracted)
+	}
+	if _, err := os.Stat(filepath.Join(dest, "output-directory", "database", "CURRENT")); err != nil {
+		t.Errorf("extracted file missing: %v", err)
+	}
+}
+
+// The happy path is unchanged: a well-formed sidecar is fetched, compared,
+// and the snapshot extracts exactly as before.
+func TestDownload_WellFormedSidecarVerifiesAndExtracts(t *testing.T) {
+	dest := t.TempDir()
+	srv, tgz := verifyMirror(t, "ok")
+
+	res, err := Download(context.Background(), DownloadOptions{
+		Source:  verifySource(srv.URL),
+		Backup:  "backup20250101",
+		Kind:    DBKindLite,
+		DestDir: dest,
+	})
+	if err != nil {
+		t.Fatalf("download with a valid sidecar: %v", err)
+	}
+	if !res.MD5Verified {
+		t.Error("expected MD5Verified = true")
+	}
+	if res.VerificationSkipped {
+		t.Error("expected VerificationSkipped = false")
+	}
+	want := md5.Sum(tgz) //nolint:gosec // integrity fixture, not crypto
+	if res.ActualMD5 != hex.EncodeToString(want[:]) {
+		t.Errorf("actual md5 %q != %q", res.ActualMD5, hex.EncodeToString(want[:]))
+	}
+	if !strings.EqualFold(res.ExpectedMD5, res.ActualMD5) {
+		t.Errorf("expected md5 %q != actual %q", res.ExpectedMD5, res.ActualMD5)
+	}
+	if res.FilesExtracted != 1 {
+		t.Errorf("expected 1 file extracted, got %d", res.FilesExtracted)
+	}
+	body, err := os.ReadFile(filepath.Join(dest, "output-directory", "database", "CURRENT"))
+	if err != nil {
+		t.Fatalf("extracted file missing: %v", err)
+	}
+	if string(body) != "ok" {
+		t.Errorf("extracted content %q != %q", string(body), "ok")
+	}
+}

--- a/knowledge/snapshots.md
+++ b/knowledge/snapshots.md
@@ -70,8 +70,9 @@ Before any tarball bytes hit the wire, trond:
 
 1. Sends an HTTP HEAD to the tarball URL → reads `Content-Length`. The
    body is never opened on this probe.
-2. Issues a separate HEAD to the `.md5sum` sidecar → records whether
-   inline verification will be possible.
+2. Issues a separate HEAD to the `.md5sum` sidecar → records whether the
+   mirror advertises one. Informational only: it never decides whether
+   verification happens (see "MD5 verification").
 3. `Statfs(destination)` → reads available bytes (Bavail × Bsize, the
    same number `df` shows).
 4. Refuses to start the GET if free space < `Content-Length × 2`.
@@ -118,10 +119,12 @@ If a mirror ever gains HTTPS, switch its `BaseURL` in
 
 ## What the MD5 sidecar does and does not buy
 
-Mainnet mirrors publish `<tarball>.tgz.md5sum` sidecars. trond:
+Mainnet and Nile mirrors both publish `<tarball>.tgz.md5sum` sidecars.
+trond:
 
-1. HEADs the sidecar in preflight (records "has md5 sidecar: true/false").
-2. Downloads the sidecar (a few hundred bytes).
+1. HEADs the sidecar in preflight (records "has md5 sidecar: true/false"
+   for `--dry-run`; this answer decides nothing).
+2. Downloads the sidecar (a few hundred bytes) before the tarball GET.
 3. Hashes the tarball stream while extracting.
 4. Compares — mismatch fails the operation with the database in whatever
    partial state extraction reached.
@@ -134,10 +137,21 @@ substitute the sidecar, and the two will agree. MD5 is also collision-prone
 on its own merits. So the sidecar check proves the transfer was not
 *corrupted*; it proves nothing about where the bytes came from.
 
-Nile and the occasional outage may leave the sidecar absent. trond will
-still extract; the result message reads `(md5 sidecar absent — not
-verified)`. Pass `--no-verify` to suppress that note when you've made
-the choice deliberately.
+A mirror outage — or a mirror that stops publishing sidecars — can still
+leave the sidecar absent. **trond then refuses to download**: step 2
+fails with `VERIFICATION_UNAVAILABLE` (exit 1) and nothing is written to
+the destination. The same applies to any transport failure fetching the
+sidecar. The preflight HEAD from step 1 is not consulted: it arrives over
+the same unauthenticated HTTP channel as the tarball, so a 404 there is
+never taken as permission to skip the check.
+
+If you accept an unverified chain database, say so explicitly with
+`--no-verify` (MCP: `no_verify: true`); the flag carries through
+`--detach` to the background child. The result line then reads
+`(NOT VERIFIED — --no-verify was passed; this chain database is
+unauthenticated)` and JSON output carries `"verification_skipped": true`.
+Treat such a database as untrusted input — it is the state your node will
+serve to every dApp, explorer and exchange that queries it.
 
 ## `--sha256`: the check that can detect substitution
 
@@ -300,6 +314,14 @@ version change.
 `invalid --sha256 "...": expected 64 hex characters`
   - Malformed pin, rejected before the transfer starts. SHA-256 digests are
     64 hex characters; you may have pasted an MD5 (32).
+
+`VERIFICATION_UNAVAILABLE: cannot verify snapshot integrity: <url> is
+unavailable ...`
+  - The `.md5sum` sidecar 404'd or the fetch failed, so trond has nothing
+    to check the tarball against and refuses to extract. Retry (sidecars
+    are sometimes published a few minutes after the tarball), pick another
+    backup with `trond snapshot list`, or switch `--region` / `--domain`.
+    `--no-verify` bypasses the check and should be a deliberate choice.
 
 ## Local database backup with `db_cp`
 

--- a/schemas/output/snapshot-download.schema.json
+++ b/schemas/output/snapshot-download.schema.json
@@ -24,6 +24,10 @@
         "actual_md5":       { "type": "string", "pattern": "^[0-9a-f]{32}$" },
         "expected_md5":     { "type": "string", "pattern": "^[0-9a-f]{32}$" },
         "md5_verified":     { "type": "boolean", "description": "The upstream .md5sum sidecar matched. On a plaintext_transport mirror the sidecar arrives over the same unauthenticated channel as the tarball, so this attests transfer integrity only — not provenance." },
+        "verification_skipped": {
+          "type": "boolean",
+          "description": "true only when --no-verify / no_verify was passed. A missing or unfetchable .md5sum sidecar is an error (VERIFICATION_UNAVAILABLE), never a silent skip, so md5_verified=false always means the operator opted out."
+        },
         "dest":             { "type": "string" },
         "userdata_present": { "type": "boolean" },
         "source":           { "type": "object" },


### PR DESCRIPTION
Whether a snapshot was verified at all was decided by an attacker-controllable response. Found by an audit of `develop` at `0c654cd`.

## The problem

`Download` gated verification on `pre.HasMD5Sidecar`, a flag set from a plaintext `HEAD` of the `.md5sum` URL. Anyone on the path to a mainnet mirror — all bare-IP `http://` — could answer that HEAD with a 404, and the tarball was then extracted with `expectedMD5` empty, no error, exit 0. The CLI reported `(md5 sidecar absent — not verified)` as a *successful* download. The attacker's own response was, in effect, a switch that turned integrity checking off.

## What changed

The sidecar is fetched unconditionally whenever the operator has not opted out. A 404, a non-200, or a transport failure returns a typed `VerificationUnavailableError` **before any tarball byte is requested**, so nothing is written.

Driven A/B against a binary built from `develop`:

| sidecar behaviour | develop | this branch |
|---|---|---|
| valid digest | extracted, verified | identical |
| 404 | **extracted, exit 0, attacker state on disk** | refused, 0 files in destination |
| 500 | **extracted, exit 0** | refused, 0 files |
| transport reset | **extracted, exit 0** | refused, cause wrapped, 0 files |

A request recorder confirms the refusal precedes any tarball `GET`.

The MCP `snapshot_download` tool had **no** opt-out at all, so it always extracted unverified on a 404 — it gains a `no_verify` arg alongside the CLI's existing `--no-verify`, which survives the `--detach` re-exec.

## Does this break real downloads?

No. All eight mirrors in `SourceTable` were re-probed live and every one returns 200 with a coreutils-format body, so none of the in-repo callers — the recipe, `build-nile-fixture.sh`, the CI job — needs the opt-out, and none is changed here.

The docs that said sidecars are sometimes absent are corrected rather than deleted: they now say what actually happens.

## Behaviour changes worth reviewing

- A download whose sidecar is genuinely unavailable now exits 1 with `VERIFICATION_UNAVAILABLE` instead of succeeding. The mainnet mirrors index a backup directory as soon as it exists, so a run landing between tarball and sidecar publication would now fail — the error's first suggestion is to retry, for exactly that reason.
- One failure path changes `error_code` from `DOWNLOAD_ERROR` to `VERIFICATION_UNAVAILABLE`; exit code stays 1.
- Adds one additive optional field to `snapshot-download.schema.json`, so `SchemaVersion` goes 1.12.2 → 1.12.3.

## Testing

`go test ./... -race -count=1`, `go vet ./...` and `gofmt` clean on the branch, plus the A/B matrix above and a live probe of all eight mirrors.

## Ordering

This overlaps #204, which touches the same verification block and also bumps `SchemaVersion` to 1.12.3. Suggest merging #204 first, then rebasing this and bumping to 1.12.4 with `make snapshot-schema-baseline`. Both are independently correct against `develop` as it stands.
