### PR TITLE
fix(security): bind Grafana to loopback instead of publishing admin/admin on all interfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -254,6 +254,13 @@ The agent-ergonomics arc lands across four sequenced PRs:
   absent) is the only way to skip the check; results carry
   `verification_skipped` so `md5_verified: false` can no longer be read
   as "the mirror had no sidecar". Schema 1.12.2 → 1.12.3
+- **Breaking:** the rendered monitoring stack binds Grafana's host port
+  to `127.0.0.1` instead of `0.0.0.0`; it previously published the
+  grafana-oss default `admin/admin` login to every network that could
+  reach the deployment host. Use an SSH tunnel, or opt back in with
+  `monitoring.grafana.expose: true`, which now requires
+  `monitoring.grafana.admin_password_env` (the NAME of an env var
+  feeding `GF_SECURITY_ADMIN_PASSWORD`)
 
 ## [0.1.0-alpha] — 2026-XX-XX
 

--- a/README.md
+++ b/README.md
@@ -370,7 +370,20 @@ trond network status
 | `trond status` / `trond inspect <node> -o json` | Expose the stack's `prometheus_port` / `grafana_port` so agents can discover it |
 | `trond remove <node>` / `trond network destroy` | Automatically cleans up the monitoring stack |
 
-After deployment, Grafana is available at http://localhost:3000 (admin/admin) with 5 dashboards: java-tron-server, java-tron-api, java-tron-api-statistic, java-tron-mechanism, and node-exporter-full. Prometheus is at http://localhost:9090.
+After deployment, Grafana is available at http://localhost:3000 — **on the deployment host's loopback interface only** — with 5 dashboards: java-tron-server, java-tron-api, java-tron-api-statistic, java-tron-mechanism, and node-exporter-full. Prometheus is at http://localhost:9090.
+
+Grafana keeps the image's default `admin/admin` login until you give it a password, so it is bound to `127.0.0.1`: reach it from your workstation over an SSH tunnel (`ssh -L 3000:127.0.0.1:3000 user@host`) or a reverse proxy you control. To publish it on all interfaces instead, opt in explicitly — which requires an admin password:
+
+```yaml
+monitoring:
+  enabled: true
+  grafana:
+    port: 3000
+    expose: true                              # bind 0.0.0.0 instead of 127.0.0.1
+    admin_password_env: GRAFANA_ADMIN_PASSWORD  # NAME of an env var, not the password
+```
+
+`GRAFANA_ADMIN_PASSWORD` must be set in the environment that runs `trond apply` (compose refuses to start the stack otherwise). Grafana applies it when it first initialises its database, so rotate the password in Grafana itself for a stack that is already running.
 
 **Limitations**: The single Prometheus instance loses visibility into nodes isolated by `trond partition`; metrics resume after `trond heal`. Monitoring is Docker-only (Prometheus and Grafana run as containers), so jar-runtime targets need Docker on the trond machine for the monitoring stack.
 

--- a/examples/monitoring.yaml
+++ b/examples/monitoring.yaml
@@ -3,7 +3,11 @@
 #       trond apply --intent examples/monitoring.yaml --no-monitor  (skip monitoring)
 #
 # Default behaviour:
-#   - Grafana is exposed on port 3000.
+#   - Grafana is published on port 3000 of the deployment host's loopback
+#     interface (127.0.0.1) only, because the image ships with the
+#     well-known admin/admin login.  Reach it over an SSH tunnel, or set
+#     grafana.expose (which requires grafana.admin_password_env) to
+#     publish it on all interfaces.
 #   - Prometheus is NOT exposed on the host by default; it is reachable
 #     inside the Docker network by Grafana.  To expose Prometheus add
 #     monitoring.prometheus.port explicitly.
@@ -25,6 +29,10 @@ monitoring:
     retention: 7d
   grafana:
     port: 3000
+    # Uncomment BOTH lines to publish Grafana on every interface with an
+    # admin password taken from the named environment variable:
+    # expose: true
+    # admin_password_env: GRAFANA_ADMIN_PASSWORD
 
 nodes:
   - type: fullnode

--- a/internal/intent/fields_test.go
+++ b/internal/intent/fields_test.go
@@ -960,6 +960,70 @@ nodes:
 	}
 }
 
+func TestMonitoring_GrafanaExposeAndAdminPassword(t *testing.T) {
+	monitoringYAML := func(grafana string) []byte {
+		return []byte(fmt.Sprintf(`
+name: mon
+network: mainnet
+target: {type: local}
+monitoring:
+  enabled: true
+  grafana:
+%s
+nodes:
+  - type: fullnode
+`, grafana))
+	}
+
+	t.Run("defaults to not exposed", func(t *testing.T) {
+		i, err := Parse(monitoringYAML("    port: 3000"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if i.Monitoring.Grafana.Expose {
+			t.Error("grafana.expose should default to false")
+		}
+		if i.Monitoring.Grafana.AdminPasswordEnv != "" {
+			t.Errorf("grafana.admin_password_env = %q, want empty",
+				i.Monitoring.Grafana.AdminPasswordEnv)
+		}
+	})
+
+	t.Run("expose with admin_password_env parses", func(t *testing.T) {
+		i, err := Parse(monitoringYAML("    expose: true\n    admin_password_env: GRAFANA_ADMIN_PASSWORD"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !i.Monitoring.Grafana.Expose {
+			t.Error("grafana.expose not parsed")
+		}
+		if i.Monitoring.Grafana.AdminPasswordEnv != "GRAFANA_ADMIN_PASSWORD" {
+			t.Errorf("grafana.admin_password_env = %q, want GRAFANA_ADMIN_PASSWORD",
+				i.Monitoring.Grafana.AdminPasswordEnv)
+		}
+	})
+
+	// Exposing Grafana on every interface with the image's default
+	// admin login is the combination this rejects.
+	t.Run("expose without admin_password_env rejected", func(t *testing.T) {
+		_, err := Parse(monitoringYAML("    expose: true"))
+		if err == nil {
+			t.Fatal("expected error for expose without admin_password_env")
+		}
+		if !strings.Contains(err.Error(), "admin_password_env") {
+			t.Errorf("error %q should name the missing field", err)
+		}
+	})
+
+	// The intent carries the env var NAME, never the password.
+	t.Run("literal password rejected", func(t *testing.T) {
+		_, err := Parse(monitoringYAML(`    admin_password_env: "hunter2 !"`))
+		if err == nil {
+			t.Fatal("expected error for a non-env-name admin_password_env")
+		}
+	})
+}
+
 func TestMonitoring_InvalidRetention(t *testing.T) {
 	cases := []string{"7", "days", "1.5d", "week"}
 	for _, val := range cases {

--- a/internal/intent/loader.go
+++ b/internal/intent/loader.go
@@ -439,6 +439,22 @@ func validateMonitoring(m *Monitoring) error {
 			return fmt.Errorf("monitoring.prometheus.retention must match ^\\d+[dwh]$ (e.g. \"7d\", \"2w\"), got %q", m.Prometheus.Retention)
 		}
 	}
+	if m.Grafana.AdminPasswordEnv != "" {
+		// Same contract as witness_key.private_key_env: the intent holds
+		// the NAME of an env var, never the secret. The name is also
+		// interpolated into the rendered compose file, so restricting it
+		// to env-name characters keeps it from breaking out of ${...}.
+		envVarPattern := regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
+		if !envVarPattern.MatchString(m.Grafana.AdminPasswordEnv) {
+			return fmt.Errorf("monitoring.grafana.admin_password_env %q is not a valid environment variable name; it must be the NAME of an env var holding the Grafana admin password (e.g., GRAFANA_ADMIN_PASSWORD), not the password itself", m.Grafana.AdminPasswordEnv)
+		}
+	}
+	if m.Grafana.Expose && m.Grafana.AdminPasswordEnv == "" {
+		// Publishing Grafana beyond loopback with the image's default
+		// admin/admin login hands the dashboards and the datasource proxy
+		// to anyone who can reach the port.
+		return fmt.Errorf("monitoring.grafana.expose publishes Grafana on all host interfaces and therefore requires monitoring.grafana.admin_password_env: set it to the NAME of an environment variable holding the admin password (e.g., admin_password_env: GRAFANA_ADMIN_PASSWORD), or drop expose to keep Grafana bound to 127.0.0.1")
+	}
 	return nil
 }
 

--- a/internal/intent/schema.go
+++ b/internal/intent/schema.go
@@ -437,6 +437,27 @@ type PromConfig struct {
 // GrafConfig configures the Grafana visualizer.
 type GrafConfig struct {
 	Port int `yaml:"port,omitempty" json:"port,omitempty"`
+
+	// Expose publishes Grafana's host port on every interface (0.0.0.0)
+	// instead of loopback only. Off by default: the grafana-oss image
+	// ships a well-known default admin login, so a host-wide bind hands
+	// the dashboards — and Grafana's datasource proxy, which can be
+	// pointed at anything the host can reach — to whoever can reach the
+	// port. Requires AdminPasswordEnv (see validateMonitoring).
+	Expose bool `yaml:"expose,omitempty" json:"expose,omitempty"`
+
+	// AdminPasswordEnv is the NAME of an environment variable holding the
+	// Grafana admin password — never the password itself. The rendered
+	// compose references it as ${NAME:?...}, so the variable must be set
+	// in the environment that runs `docker compose up` (trond's own
+	// environment for local targets); compose refuses to start the stack
+	// when it is unset or empty.
+	//
+	// Grafana applies GF_SECURITY_ADMIN_PASSWORD when it initialises its
+	// database, i.e. on the first start of a fresh grafana_data volume.
+	// Setting it for an already-initialised stack does not rotate an
+	// existing admin password.
+	AdminPasswordEnv string `yaml:"admin_password_env,omitempty" json:"admin_password_env,omitempty"`
 }
 
 // BoolPtr is a helper for creating *bool values in intent construction.

--- a/internal/render/monitoring.go
+++ b/internal/render/monitoring.go
@@ -57,7 +57,11 @@ const monitoringComposeTmpl = `services:
         limits:
           memory: 2g
     ports:
-      - "{{.GrafanaPort}}:3000"
+      - "{{.GrafanaPortMapping}}"
+{{- if .GrafanaAdminPasswordRef }}
+    environment:
+      - GF_SECURITY_ADMIN_PASSWORD={{.GrafanaAdminPasswordRef}}
+{{- end }}
     volumes:
       - ./grafana_data:/var/lib/grafana
       - ./grafana/provisioning:/etc/grafana/provisioning
@@ -81,24 +85,68 @@ var composeTmpl = template.Must(template.New("monitoring").Parse(monitoringCompo
 type monitoringComposeData struct {
 	Name           string
 	PrometheusPort int
-	GrafanaPort    int
-	Retention      string
-	NetworkName    string
+	// GrafanaPortMapping is the full compose "ports" entry for Grafana,
+	// including the host bind address — see grafanaPortMapping.
+	GrafanaPortMapping string
+	// GrafanaAdminPasswordRef is the compose interpolation reference that
+	// supplies GF_SECURITY_ADMIN_PASSWORD, or "" when the operator did
+	// not configure one.
+	GrafanaAdminPasswordRef string
+	Retention               string
+	NetworkName             string
 }
 
 // RenderMonitoringCompose generates a docker-compose.yaml for the
 // Prometheus + Grafana monitoring stack.
 func RenderMonitoringCompose(name string, i *intent.Intent, targets []MonitoringTarget, networkName string) string {
 	var buf bytes.Buffer
+	g := i.Monitoring.Grafana
 	data := monitoringComposeData{
-		Name:           name,
-		PrometheusPort: i.Monitoring.Prometheus.Port,
-		GrafanaPort:    i.Monitoring.Grafana.Port,
-		Retention:      i.Monitoring.Prometheus.Retention,
-		NetworkName:    networkName,
+		Name:                    name,
+		PrometheusPort:          i.Monitoring.Prometheus.Port,
+		GrafanaPortMapping:      grafanaPortMapping(g),
+		GrafanaAdminPasswordRef: grafanaAdminPasswordRef(g),
+		Retention:               i.Monitoring.Prometheus.Retention,
+		NetworkName:             networkName,
 	}
 	_ = composeTmpl.Execute(&buf, data)
 	return buf.String()
+}
+
+// grafanaPortMapping builds Grafana's compose "ports" entry.
+//
+// A bare "<port>:3000" publishes on 0.0.0.0, which on any host with a
+// permissive firewall exposes the dashboard — and Grafana's datasource
+// proxy — to the network with the grafana-oss image's default admin
+// login. Bind to loopback instead; reaching it from elsewhere is then an
+// SSH tunnel (or a reverse proxy the operator controls) away.
+//
+// monitoring.grafana.expose opts back into the host-wide bind, and is
+// only honoured together with an admin password: intent validation
+// rejects that combination up front, and this stays fail-closed for any
+// caller that renders an unvalidated intent.
+func grafanaPortMapping(g intent.GrafConfig) string {
+	if g.Expose && g.AdminPasswordEnv != "" {
+		return fmt.Sprintf("%d:3000", g.Port)
+	}
+	return fmt.Sprintf("127.0.0.1:%d:3000", g.Port)
+}
+
+// grafanaAdminPasswordRef returns the compose interpolation that feeds
+// GF_SECURITY_ADMIN_PASSWORD from the operator's environment, keeping the
+// secret out of the rendered file (the same shape composeEnvLines uses
+// for the witness keystore password).
+//
+// The ":?" form makes `docker compose up` fail loudly when the variable
+// is unset or empty rather than silently starting Grafana with an empty
+// or default admin password. The name is constrained to env-name
+// characters by intent validation.
+func grafanaAdminPasswordRef(g intent.GrafConfig) string {
+	if g.AdminPasswordEnv == "" {
+		return ""
+	}
+	return fmt.Sprintf("${%s:?set %s to the Grafana admin password (monitoring.grafana.admin_password_env)}",
+		g.AdminPasswordEnv, g.AdminPasswordEnv)
 }
 
 // RenderPrometheusConfig generates prometheus.yml content.

--- a/internal/render/monitoring_test.go
+++ b/internal/render/monitoring_test.go
@@ -4,6 +4,8 @@ import (
 	"strings"
 	"testing"
 
+	"gopkg.in/yaml.v3"
+
 	"github.com/tronprotocol/tron-deployment/internal/intent"
 )
 
@@ -28,8 +30,10 @@ func TestRenderMonitoringCompose_Basic(t *testing.T) {
 	if !strings.Contains(out, "9090:9090") {
 		t.Error("missing prometheus port mapping")
 	}
-	if !strings.Contains(out, "3000:3000") {
-		t.Error("missing grafana port mapping")
+	// Grafana is bound to loopback unless the operator opts into a
+	// host-wide bind (which additionally requires an admin password).
+	if !strings.Contains(out, `"127.0.0.1:3000:3000"`) {
+		t.Errorf("missing loopback-bound grafana port mapping, got:\n%s", out)
 	}
 	if !strings.Contains(out, "test_default:") {
 		t.Error("missing external network reference")
@@ -54,6 +58,117 @@ func TestRenderMonitoringCompose_NoNetwork(t *testing.T) {
 	out := RenderMonitoringCompose("test", i, nil, "")
 	if strings.Contains(out, "networks:") {
 		t.Error("should not contain networks when networkName is empty")
+	}
+}
+
+// grafanaService parses the rendered compose and returns the grafana
+// service block, so the assertions below check what docker compose would
+// actually see rather than a substring of the template.
+func grafanaService(t *testing.T, compose string) map[string]any {
+	t.Helper()
+	var doc struct {
+		Services map[string]struct {
+			Ports       []string `yaml:"ports"`
+			Environment []string `yaml:"environment"`
+		} `yaml:"services"`
+	}
+	if err := yaml.Unmarshal([]byte(compose), &doc); err != nil {
+		t.Fatalf("rendered compose is not valid YAML: %v\n%s", err, compose)
+	}
+	g, ok := doc.Services["grafana"]
+	if !ok {
+		t.Fatalf("no grafana service in rendered compose:\n%s", compose)
+	}
+	return map[string]any{"ports": g.Ports, "environment": g.Environment}
+}
+
+func monitoringIntent(g intent.GrafConfig) *intent.Intent {
+	return &intent.Intent{
+		Name: "test",
+		Monitoring: &intent.Monitoring{
+			Enabled:    intent.BoolPtr(true),
+			Prometheus: intent.PromConfig{Retention: "7d"},
+			Grafana:    g,
+		},
+	}
+}
+
+// The grafana-oss image ships a default admin login, so the rendered
+// stack must not publish Grafana beyond the host's loopback interface
+// unless the operator explicitly opts in with an admin password set.
+func TestRenderMonitoringCompose_GrafanaBinding(t *testing.T) {
+	cases := []struct {
+		name     string
+		grafana  intent.GrafConfig
+		wantPort string
+		wantEnv  bool
+	}{
+		{
+			name:     "default is loopback only",
+			grafana:  intent.GrafConfig{Port: 3000},
+			wantPort: "127.0.0.1:3000:3000",
+		},
+		{
+			name:     "custom port stays loopback",
+			grafana:  intent.GrafConfig{Port: 13000},
+			wantPort: "127.0.0.1:13000:3000",
+		},
+		{
+			name:     "admin password alone does not widen the bind",
+			grafana:  intent.GrafConfig{Port: 3000, AdminPasswordEnv: "GRAFANA_ADMIN_PASSWORD"},
+			wantPort: "127.0.0.1:3000:3000",
+			wantEnv:  true,
+		},
+		{
+			name:     "expose with a password publishes on all interfaces",
+			grafana:  intent.GrafConfig{Port: 3000, Expose: true, AdminPasswordEnv: "GRAFANA_ADMIN_PASSWORD"},
+			wantPort: "3000:3000",
+			wantEnv:  true,
+		},
+		{
+			// Rejected by intent validation; the renderer stays
+			// fail-closed for any caller that skips it.
+			name:     "expose without a password falls back to loopback",
+			grafana:  intent.GrafConfig{Port: 3000, Expose: true},
+			wantPort: "127.0.0.1:3000:3000",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("GRAFANA_ADMIN_PASSWORD", "s3cret")
+			out := RenderMonitoringCompose("test", monitoringIntent(tc.grafana), nil, "")
+			svc := grafanaService(t, out)
+
+			ports := svc["ports"].([]string)
+			if len(ports) != 1 || ports[0] != tc.wantPort {
+				t.Errorf("grafana ports = %v, want [%s]", ports, tc.wantPort)
+			}
+
+			env := svc["environment"].([]string)
+			var adminPassword string
+			for _, e := range env {
+				if v, ok := strings.CutPrefix(e, "GF_SECURITY_ADMIN_PASSWORD="); ok {
+					adminPassword = v
+				}
+			}
+			switch {
+			case tc.wantEnv && adminPassword == "":
+				t.Errorf("GF_SECURITY_ADMIN_PASSWORD missing from grafana environment %v", env)
+			case tc.wantEnv && !strings.HasPrefix(adminPassword, "${GRAFANA_ADMIN_PASSWORD:?"):
+				// The value must reach the container from the
+				// operator's environment, and compose must refuse
+				// to start the stack when it is unset or empty.
+				t.Errorf("GF_SECURITY_ADMIN_PASSWORD = %q, want a required ${GRAFANA_ADMIN_PASSWORD:?...} reference", adminPassword)
+			case !tc.wantEnv && adminPassword != "":
+				t.Errorf("unexpected GF_SECURITY_ADMIN_PASSWORD = %q", adminPassword)
+			}
+
+			// The password itself never belongs in the rendered file.
+			if strings.Contains(out, "s3cret") {
+				t.Error("rendered compose inlined a secret value")
+			}
+		})
 	}
 }
 

--- a/schemas/intent.schema.json
+++ b/schemas/intent.schema.json
@@ -641,7 +641,18 @@
           "type": "integer",
           "default": 3000,
           "minimum": 1024,
-          "maximum": 65535
+          "maximum": 65535,
+          "description": "Host port for Grafana. Bound to 127.0.0.1 unless \"expose\" is true."
+        },
+        "expose": {
+          "type": "boolean",
+          "default": false,
+          "description": "Publish the Grafana port on all host interfaces (0.0.0.0) instead of loopback only. Requires admin_password_env, because the grafana-oss image otherwise keeps its default admin login."
+        },
+        "admin_password_env": {
+          "type": "string",
+          "pattern": "^[A-Za-z_][A-Za-z0-9_]*$",
+          "description": "NAME of an environment variable holding the Grafana admin password (never the password itself). It must be set in the environment that runs docker compose; Grafana applies it when it first initialises its database."
         }
       }
     }


### PR DESCRIPTION
`trond apply --monitor` deployed a Grafana reachable from anywhere that could route to the host, with the image's built-in credentials. Found by an audit of `develop` at `0c654cd`.

## The problem

`RenderMonitoringCompose` emitted the Grafana service with an unconditional `- "{{.GrafanaPort}}:3000"` and no `environment:` block at all — no `GF_SECURITY_ADMIN_PASSWORD`, no auth hardening — so the container kept grafana-oss's built-in `admin`/`admin` while docker published it on `0.0.0.0`. Nothing else in the repo supplies a password; `README.md:371` documents `admin/admin`.

On a cloud VM with a permissive security group that is the public internet. The payoff is not just metrics: a Grafana admin can create arbitrary datasources and query them through the backend proxy, which turns it into a server-side request primitive into the host's internal network and cloud metadata endpoints.

## What changed

Grafana binds to `127.0.0.1` by default.

A new `monitoring.grafana.expose` restores the all-interfaces bind, but is **rejected unless `monitoring.grafana.admin_password_env` is also set** — so the escape hatch cannot recreate the finding. The renderer independently falls back to loopback for an unvalidated intent, so it fails closed rather than honouring a request it cannot verify.

The password is named by env var, not embedded: it renders as a required compose variable reference, so the secret never enters the 0644 compose file, and an unset *or empty* value fails at interpolation before any container is created.

Verified against real Docker (`docker compose config` on four rendered configurations): the default resolves to `host_ip: 127.0.0.1`; `expose: true` with a password drops the bind address and passes the secret through as a reference; `expose: true` *without* a password stays on loopback.

Note the finding's premise that the Prometheus port already had loopback treatment turned out to be wrong — Prometheus is opt-in-published via a conditional, and there was no pre-existing bind-address idiom to follow.

## Behaviour changes worth reviewing

- **Breaking:** Grafana is no longer reachable off-host by default. An SSH tunnel (`ssh -L 3000:127.0.0.1:3000`), a reverse proxy, or the new `expose` opt-in. This mostly affects SSH/remote targets; for local targets trond already advertised `grafana_url` as `http://127.0.0.1:<port>`.
- New validation error for `expose: true` without `admin_password_env` — unreachable for any intent written today, since both fields are new.
- `GF_SECURITY_ADMIN_PASSWORD` only applies on first initialisation of the `grafana_data` volume. That is Grafana's behaviour, not ours; setting it for an already-running stack does not rotate an existing password.

## Testing

`go test ./... -race -count=1`, `go vet ./...` and `gofmt` clean on the branch. New tests parse the rendered compose as YAML rather than substring-matching, and assert a set password never appears in the rendered file.

## Unrelated bug noticed while tracing callers

`deployMonitoring` and `deployNetworkMonitoring` build the Grafana datasource URL as `http://prometheus:<host port>`, which is `http://prometheus:0` under the default unexposed-Prometheus config. Pre-existing and untouched here, but worth its own fix.
