### PR TITLE
fix: four silent-wrong-result bugs in render, build, and network create

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ The agent-ergonomics arc lands across four sequenced PRs:
 **#153** (`trond mcp`) → **#154** (`trond recipe`).
 
 ### Added
+- `apply.Options.SkipMonitoring` suppresses the per-node monitoring stack
+  while leaving `Intent.Monitoring` intact for rendering. `network create`
+  needs both halves: `RenderHOCON` keys its metrics auto-enable off the
+  field, but the network owns one stack scraping every node — without the
+  flag each node deployed its own Prometheus and the last one won, leaving
+  a stack that looks healthy while observing a fraction of the network.
 - **Agent integration arc (ai-ops): machine-observable, provably-private rigs.**
   - (#190/#193/#196) **Private-net safety gate (C1).** `is_private` is a
     queryable fact in `status`/`list`/`inspect`. A persistent
@@ -215,6 +221,20 @@ The agent-ergonomics arc lands across four sequenced PRs:
   `revision: HEAD` still builds the working tree, dirty edits included —
   that is the dev inner loop, and the dirty state is already folded into
   the cache key.
+- **`network create` bypassed `internal/apply.Apply`.** Its hand-rolled
+  render + deploy + state loop had drifted from the core in three ways: it
+  never called `internal/build`, so a node declaring `build:` rendered an
+  empty `image:` and deployed nothing usable — no error, no warning, and a
+  green `config validate`; it hardcoded JDK 17 for JVM arg selection
+  instead of probing the target; and it hardcoded the docker runtime
+  instead of honouring `target.runtime`. Every node now goes through
+  `Apply`, projected to a single-node intent with its own name and hash so
+  idempotency stays per node.
+- **`Apply` did not persist `P2PPort`.** `network add` builds a joining
+  node's peer list from the `P2PPort` of every node in state and skips any
+  entry where it is zero, so a node deployed through `Apply` was invisible
+  as a peer: the late joiner came up with an empty peer list, never
+  connected, and neither command said why.
 - Witness private key inlined into rendered HOCON — typesafe-config does
   not perform `${ENV}` substitution, the literal `${SR_KEY}` was being
   read as a 9-char witness key and the SR shut down with WITNESS_INIT(1)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -203,6 +203,18 @@ The agent-ergonomics arc lands across four sequenced PRs:
   verbatim. Numbers deliberately stay on `fmt` — `%v` is already
   JSON-compatible there and routing them through the encoder would change
   every rendered config for no correctness gain.
+- **`build.revision` labelled the artifact without building it.** The git
+  worktree checkout ran only when `build.patches` was non-empty, so an
+  explicit branch/tag/sha compiled whatever the working tree happened to
+  hold and then stamped the artifact — cache key, manifest, and
+  `status.build_revision` — with the revision that was asked for. Two
+  `trond build --revision <ref>` runs against different refs could hand back
+  byte-identical artifacts under different labels, silently reducing a
+  base-vs-head comparison to comparing an artifact with itself. The
+  worktree now runs whenever an explicit non-HEAD revision is requested.
+  `revision: HEAD` still builds the working tree, dirty edits included —
+  that is the dev inner loop, and the dirty state is already folded into
+  the cache key.
 - Witness private key inlined into rendered HOCON — typesafe-config does
   not perform `${ENV}` substitution, the literal `${SR_KEY}` was being
   read as a 9-char witness key and the SR shut down with WITNESS_INIT(1)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -192,6 +192,17 @@ The agent-ergonomics arc lands across four sequenced PRs:
   (was a documented TODO before); refuses `/` and empty paths
 
 ### Fixed
+- **`config_overrides` rendered Go syntax, not HOCON.** `hoconValue` fell
+  back to `fmt.%v` for slices and maps, emitting `[map[address:T… voteCount:5000]]`
+  — which no HOCON parser accepts — so every list-valued override was
+  unusable and a multi-witness `genesis.block.witnesses` (the two-SR private
+  net tron-docker documents) could not be expressed in an intent at all. The
+  same function used `fmt.%q` for strings, which emits Go's `\x01` for a
+  control byte rather than JSON's `\u0001`. Both now render through a JSON
+  encoder (HOCON is a JSON superset) with HTML escaping off so URLs survive
+  verbatim. Numbers deliberately stay on `fmt` — `%v` is already
+  JSON-compatible there and routing them through the encoder would change
+  every rendered config for no correctness gain.
 - Witness private key inlined into rendered HOCON — typesafe-config does
   not perform `${ENV}` substitution, the literal `${SR_KEY}` was being
   read as a 9-char witness key and the SR shut down with WITNESS_INIT(1)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,16 @@ The agent-ergonomics arc lands across four sequenced PRs:
 **#153** (`trond mcp`) → **#154** (`trond recipe`).
 
 ### Added
+- **`jvm.extra_opts`** — an escape hatch for JVM flags outside the closed
+  heap/GC field set, appended last so they win on any last-flag-wins
+  option. Needed because trond runs the JAR directly and so never reads
+  java-tron's `gradle/java-tron.vmoptions`, which its distribution launcher
+  (`bin/FullNode`) does: `-Dio.netty.allocator.type=pooled` is the live
+  example — java-tron sets it to opt out of netty 4.2's adaptive allocator,
+  and without the hatch a trond-deployed node silently runs on the
+  allocator upstream deliberately avoided. Restricted to `-D<key>=<value>`
+  and `-XX:…`; whitespace and quoting characters are refused, so one entry
+  is always exactly one argument.
 - `apply.Options.SkipMonitoring` suppresses the per-node monitoring stack
   while leaving `Intent.Monitoring` intact for rendering. `network create`
   needs both halves: `RenderHOCON` keys its metrics auto-enable off the

--- a/cmd/network/create.go
+++ b/cmd/network/create.go
@@ -9,7 +9,9 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
 
+	"github.com/tronprotocol/tron-deployment/internal/apply"
 	"github.com/tronprotocol/tron-deployment/internal/guard"
 	"github.com/tronprotocol/tron-deployment/internal/intent"
 	"github.com/tronprotocol/tron-deployment/internal/output"
@@ -128,74 +130,60 @@ func runCreate(cmd *cobra.Command, args []string) error {
 
 	var deployed []map[string]any
 
-	for i, node := range parsed.Nodes {
-		nodeName := fmt.Sprintf("%s-node%d", parsed.Name, i)
-
-		rendered, err := render.RenderHOCONWithSecrets(templateDir, parsed, &node)
+	// Every node goes through internal/apply.Apply, the same core `trond
+	// apply` uses. This loop used to hand-roll render + Deploy + state,
+	// which quietly diverged from Apply in three ways: it never called
+	// internal/build (so a node with `build:` rendered an empty image:
+	// and deployed nothing usable, with no error), it hardcoded JDK 17
+	// for JVM arg selection instead of probing the target, and it
+	// hardcoded the docker runtime instead of honouring target.runtime.
+	for i := range parsed.Nodes {
+		sub, nodeName, intentHash, err := nodeIntent(parsed, i)
 		if err != nil {
-			return fmt.Errorf("render config for node %d: %w", i, err)
+			return output.NewError("VALIDATION_ERROR", output.ExitValidationError, err.Error())
 		}
-		// Deploy path — needs the real witness key inlined.
-		hocon := rendered.Deployable()
-
-		memGB := render.ParseMemoryGB(node.Resources.Memory)
-		if memGB == 0 {
-			memGB = 16
-		}
-		jvmArgs := render.JVMArgsString(memGB, 17, node.JVM)
-		composeYAML := render.RenderCompose(nodeName, parsed, &node, "", jvmArgs, "")
-
-		opts := runtime.DeployOpts{
-			Name:        nodeName,
-			ConfigData:  []byte(hocon),
-			ComposeData: []byte(composeYAML),
-		}
-
-		rt := runtime.NewDockerRuntime(tgt, workDir)
-		if err := rt.Deploy(cmd.Context(), opts); err != nil {
+		res, err := apply.Apply(cmd.Context(), apply.Options{
+			Intent:         sub,
+			Target:         tgt,
+			Store:          store,
+			State:          deployState,
+			IntentHash:     intentHash,
+			Existing:       store.GetNode(deployState, nodeName),
+			TemplateDir:    templateDir,
+			DeploymentsDir: workDir,
+			IntentPath:     createIntentPath,
+			// Now that create is an Apply caller it inherits the core's
+			// state-based --require-private gate, same as cmd/apply.go.
+			// guard.Enforce above only sees the intent's network LABEL;
+			// this also checks the network recorded in state for a node
+			// already deployed under the same name (#203).
+			RequirePrivate: guard.Requested(),
+			// The network owns one monitoring stack covering every node
+			// (deployNetworkMonitoring below). Intent.Monitoring stays set
+			// so RenderHOCON still auto-enables the node's metrics port.
+			SkipMonitoring: true,
+		})
+		if err != nil {
 			deployed = append(deployed, map[string]any{
 				"name":   nodeName,
-				"type":   node.Type,
+				"type":   parsed.Nodes[i].Type,
 				"status": "error",
 				"error":  err.Error(),
 			})
 			continue
 		}
 
-		// Capture the (post-defaults, post-auto-allocation) ports in state
-		// so inspect / health / diagnose / events can target the right
-		// host endpoint without re-reading the intent file.
-		mn := state.ManagedNode{
-			Name:    nodeName,
-			Version: node.Version,
-			Network: parsed.Network,
-			Target: state.NodeTarget{
-				Type:         parsed.Target.Type,
-				Host:         parsed.Target.Host,
-				User:         parsed.Target.User,
-				Port:         parsed.Target.Port,
-				IdentityFile: parsed.Target.IdentityFile,
-			},
-			Runtime:     "docker",
-			Status:      "running",
-			LastApplied: time.Now().UTC(),
-			HTTPPort:    node.Ports.HTTP,
-			GRPCPort:    node.Ports.GRPC,
-			P2PPort:     node.Ports.P2P,
-			MetricsPort: node.Ports.Metrics,
-			Labels:      node.Labels,
+		entry := map[string]any{
+			"name":      nodeName,
+			"type":      parsed.Nodes[i].Type,
+			"status":    "running",
+			"outcome":   res.Outcome,
+			"endpoints": res.Endpoints,
 		}
-		store.UpsertNode(deployState, mn)
-
-		deployed = append(deployed, map[string]any{
-			"name":   nodeName,
-			"type":   node.Type,
-			"status": "running",
-			"endpoints": map[string]string{
-				"http": fmt.Sprintf("http://127.0.0.1:%d", node.Ports.HTTP),
-				"grpc": fmt.Sprintf("127.0.0.1:%d", node.Ports.GRPC),
-			},
-		})
+		if res.Build != nil {
+			entry["build"] = res.Build
+		}
+		deployed = append(deployed, entry)
 	}
 
 	result := map[string]any{
@@ -352,4 +340,36 @@ func deployNetworkMonitoring(ctx context.Context, tgt target.Target, workDir str
 type monitoringResult struct {
 	error string
 	urls  map[string]string
+}
+
+// nodeIntent projects the multi-node network intent down to the
+// single-node intent apply.Apply consumes, returning it alongside the
+// node's deployed name and its own intent hash.
+//
+// Apply keys everything off Intent.Name — the compose project, the state
+// entry, Result.Name — and reads only Intent.Nodes[0], so the projection
+// has to rename as well as slice. Everything else (target, network,
+// monitoring, template dir) is shared and copied through unchanged.
+//
+// The hash is computed over the projected intent rather than over the
+// network intent file, so idempotency is per node: editing one node's
+// ports must redeploy that node and leave its siblings at no_change.
+func nodeIntent(parsed *intent.Intent, i int) (sub *intent.Intent, name, hash string, err error) {
+	if i < 0 || i >= len(parsed.Nodes) {
+		return nil, "", "", fmt.Errorf("node index %d out of range (%d nodes)", i, len(parsed.Nodes))
+	}
+	name = fmt.Sprintf("%s-node%d", parsed.Name, i)
+
+	// Shallow struct copy is deliberate: the shared fields (Target,
+	// Monitoring, ...) are read-only from here on, and Apply must see the
+	// same values every node saw. Only Name and Nodes are re-pointed.
+	clone := *parsed
+	clone.Name = name
+	clone.Nodes = []intent.NodeSpec{parsed.Nodes[i]}
+
+	data, err := yaml.Marshal(&clone)
+	if err != nil {
+		return nil, "", "", fmt.Errorf("hash node %d intent: %w", i, err)
+	}
+	return &clone, name, apply.IntentHashFromBytes(data), nil
 }

--- a/cmd/network/node_intent_test.go
+++ b/cmd/network/node_intent_test.go
@@ -1,0 +1,161 @@
+package network
+
+import (
+	"testing"
+
+	"github.com/tronprotocol/tron-deployment/internal/intent"
+)
+
+func twoNodeIntent() *intent.Intent {
+	return &intent.Intent{
+		Name:    "twosr",
+		Network: "private",
+		Target:  intent.Target{Type: "local", Runtime: "docker"},
+		Monitoring: &intent.Monitoring{
+			Enabled: intent.BoolPtr(true),
+		},
+		Nodes: []intent.NodeSpec{
+			{Type: "witness", Version: "latest", Ports: intent.PortMapping{HTTP: 8090, P2P: 18888}},
+			{Type: "fullnode", Version: "latest", Ports: intent.PortMapping{HTTP: 8091, P2P: 18889}},
+		},
+	}
+}
+
+// TestNodeIntent_ProjectsOneNodeAndRenames covers the two things Apply keys
+// off: it reads only Nodes[0], and it uses Intent.Name for the compose
+// project, the state entry and Result.Name. A projection that sliced without
+// renaming would deploy every node under the network's own name and each
+// would overwrite the previous one's state entry.
+func TestNodeIntent_ProjectsOneNodeAndRenames(t *testing.T) {
+	parsed := twoNodeIntent()
+
+	for i, wantName := range []string{"twosr-node0", "twosr-node1"} {
+		sub, name, hash, err := nodeIntent(parsed, i)
+		if err != nil {
+			t.Fatalf("nodeIntent(%d): %v", i, err)
+		}
+		if name != wantName {
+			t.Errorf("name = %q, want %q", name, wantName)
+		}
+		if sub.Name != wantName {
+			t.Errorf("sub.Name = %q, want %q — Apply names the deployment from this", sub.Name, wantName)
+		}
+		if len(sub.Nodes) != 1 {
+			t.Fatalf("sub.Nodes has %d entries, want exactly 1 (Apply only reads Nodes[0])", len(sub.Nodes))
+		}
+		if sub.Nodes[0].Type != parsed.Nodes[i].Type {
+			t.Errorf("sub carries node %q, want %q", sub.Nodes[0].Type, parsed.Nodes[i].Type)
+		}
+		if hash == "" {
+			t.Error("empty intent hash — Apply rejects that in validateOptions")
+		}
+
+		// Shared context must survive the projection: these drive target
+		// resolution, the HOCON template choice and the metrics auto-enable.
+		if sub.Network != parsed.Network {
+			t.Errorf("sub.Network = %q, want %q", sub.Network, parsed.Network)
+		}
+		if sub.Target != parsed.Target {
+			t.Errorf("sub.Target = %+v, want %+v", sub.Target, parsed.Target)
+		}
+		if sub.Monitoring != parsed.Monitoring {
+			t.Error("sub lost Monitoring — RenderHOCON keys the metrics auto-enable off it")
+		}
+	}
+}
+
+// TestNodeIntent_HashIsPerNode is the idempotency contract. Apply short
+// circuits to no_change when the incoming hash equals the stored one, so a
+// hash shared across nodes would make node 1 look unchanged the moment node 0
+// had been applied — the whole network would deploy once and then go quiet.
+func TestNodeIntent_HashIsPerNode(t *testing.T) {
+	parsed := twoNodeIntent()
+
+	_, _, h0, err := nodeIntent(parsed, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, _, h1, err := nodeIntent(parsed, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if h0 == h1 {
+		t.Error("both nodes hashed identically; per-node idempotency would collapse")
+	}
+}
+
+// TestNodeIntent_HashIsStable — same input, same hash. Without this a
+// re-run of `network create` reports every node as updated forever.
+func TestNodeIntent_HashIsStable(t *testing.T) {
+	_, _, a, err := nodeIntent(twoNodeIntent(), 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, _, b, err := nodeIntent(twoNodeIntent(), 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if a != b {
+		t.Errorf("hash not stable across calls: %s vs %s", a, b)
+	}
+}
+
+// TestNodeIntent_HashTracksThatNodeOnly — editing node 1 must not disturb
+// node 0's hash, otherwise a one-node change redeploys the whole network.
+func TestNodeIntent_HashTracksThatNodeOnly(t *testing.T) {
+	before := twoNodeIntent()
+	_, _, h0Before, err := nodeIntent(before, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	after := twoNodeIntent()
+	after.Nodes[1].Ports.HTTP = 19999
+	_, _, h0After, err := nodeIntent(after, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, _, h1After, err := nodeIntent(after, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if h0Before != h0After {
+		t.Error("changing node 1 changed node 0's hash — a single-node edit would redeploy siblings")
+	}
+	_, _, h1Before, err := nodeIntent(before, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if h1Before == h1After {
+		t.Error("changing node 1's port did not change its hash — the edit would deploy as no_change")
+	}
+}
+
+// TestNodeIntent_DoesNotMutateSource guards the shallow copy: runCreate calls
+// this once per node off the same parsed intent, so a projection that wrote
+// through to the source would corrupt every later node.
+func TestNodeIntent_DoesNotMutateSource(t *testing.T) {
+	parsed := twoNodeIntent()
+	origName := parsed.Name
+	origCount := len(parsed.Nodes)
+
+	if _, _, _, err := nodeIntent(parsed, 0); err != nil {
+		t.Fatal(err)
+	}
+	if parsed.Name != origName {
+		t.Errorf("source intent renamed to %q", parsed.Name)
+	}
+	if len(parsed.Nodes) != origCount {
+		t.Errorf("source node list resized to %d, want %d", len(parsed.Nodes), origCount)
+	}
+}
+
+func TestNodeIntent_OutOfRange(t *testing.T) {
+	parsed := twoNodeIntent()
+	for _, i := range []int{-1, 2, 99} {
+		if _, _, _, err := nodeIntent(parsed, i); err == nil {
+			t.Errorf("index %d: want an error, got nil", i)
+		}
+	}
+}

--- a/internal/apply/apply.go
+++ b/internal/apply/apply.go
@@ -98,10 +98,22 @@ type Options struct {
 	// and (for an already-deployed node of the same name) the network
 	// RECORDED IN STATE are private — the intent's label alone is caller
 	// input and cannot authorise touching a node deployed on mainnet/nile.
-	// Lives in the core (not just cmd) so EVERY caller — CLI apply, MCP —
-	// inherits the guarantee and it can't be bypassed by choosing a
+	// Lives in the core (not just cmd) so EVERY caller — CLI apply,
+	// network create, MCP — inherits the guarantee and it can't be bypassed by choosing a
 	// different entry point. Pure opt-in; callers set it.
 	RequirePrivate bool
+
+	// SkipMonitoring suppresses the per-node monitoring stack while
+	// leaving Intent.Monitoring intact for rendering.
+	//
+	// `network create` needs both halves: RenderHOCON keys its
+	// auto-enable of node.metrics.prometheus off Intent.Monitoring, so
+	// the field must stay set, but the network owns ONE stack scraping
+	// every node. Without this flag each node would deploy its own
+	// Prometheus and the last one to run would win, leaving a stack that
+	// scrapes exactly one node — a monitoring setup that looks healthy
+	// and silently observes a fraction of the network.
+	SkipMonitoring bool
 }
 
 // Result is the structured output of one Apply call. Stable JSON
@@ -370,6 +382,13 @@ func Apply(ctx context.Context, opts Options) (*Result, error) {
 		LastApplied: time.Now().UTC(),
 		HTTPPort:    node.Ports.HTTP,
 		GRPCPort:    node.Ports.GRPC,
+		// P2PPort is load-bearing, not cosmetic: `network add` builds the
+		// joining node's peer list from the P2PPort of every node already
+		// in state and SKIPS any entry where it is zero. Omitting it here
+		// meant a node deployed through Apply was invisible as a peer —
+		// the late joiner would come up with an empty peer list and never
+		// connect, with nothing in the output to say why.
+		P2PPort:     node.Ports.P2P,
 		MetricsPort: node.Ports.Metrics,
 		Labels:      node.Labels,
 		InstallPath: node.InstallPath,
@@ -630,6 +649,9 @@ type monitoringResult struct {
 // enabled in the intent. For docker runtime it co-locates with the node;
 // for jar runtime it deploys to the trond machine (local target).
 func deployMonitoring(ctx context.Context, opts Options, node *intent.NodeSpec, runtimeType string) monitoringResult {
+	if opts.SkipMonitoring {
+		return monitoringResult{}
+	}
 	if opts.Intent.Monitoring == nil || opts.Intent.Monitoring.Enabled == nil || !*opts.Intent.Monitoring.Enabled {
 		return monitoringResult{}
 	}

--- a/internal/apply/network_create_support_test.go
+++ b/internal/apply/network_create_support_test.go
@@ -1,0 +1,98 @@
+package apply
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/tronprotocol/tron-deployment/internal/intent"
+	"github.com/tronprotocol/tron-deployment/internal/paths"
+)
+
+func peerIntent(t *testing.T, dir string, mon *intent.Monitoring) *intent.Intent {
+	t.Helper()
+	return &intent.Intent{
+		Name:       "peer-node",
+		Network:    "private",
+		Target:     intent.Target{Type: "local", Runtime: "jar"},
+		Monitoring: mon,
+		Nodes: []intent.NodeSpec{{
+			Type:        "fullnode",
+			Version:     "4.8.1",
+			Resources:   intent.Resources{Memory: "4G"},
+			Ports:       intent.PortMapping{HTTP: 8090, GRPC: 50051, P2P: 18888, Metrics: 9527},
+			InstallPath: filepath.Join(dir, "install"),
+		}},
+	}
+}
+
+// TestApply_PersistsP2PPort guards a field that looks cosmetic and is not.
+// `network add` builds the joining node's peer list from the P2PPort of
+// every node already in state and SKIPS any entry where it is zero
+// (cmd/network/add.go). Apply used to omit the field, so a node deployed
+// through Apply was invisible as a peer: the late joiner came up with an
+// empty peer list, never connected, and nothing in either command's output
+// said why.
+func TestApply_PersistsP2PPort(t *testing.T) {
+	dir := t.TempDir()
+	paths.SetBaseDir(dir)
+	t.Cleanup(func() { paths.SetBaseDir("") })
+
+	store, st := freshStore(t)
+	if _, err := Apply(context.Background(), Options{
+		Intent: peerIntent(t, dir, nil), Target: &fakeTarget{},
+		Store: store, State: st, IntentHash: "h",
+	}); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+
+	n := store.GetNode(st, "peer-node")
+	if n == nil {
+		t.Fatal("node absent from state after a successful apply")
+	}
+	if n.P2PPort != 18888 {
+		t.Errorf("state P2PPort = %d, want 18888 — `network add` skips peers whose "+
+			"P2PPort is zero, so this node would be unreachable to a late joiner",
+			n.P2PPort)
+	}
+}
+
+// TestApply_SkipMonitoringLeavesIntentIntact pins the flag `network create`
+// relies on. The network deploys ONE stack scraping every node, so each
+// per-node Apply must not deploy its own — but Intent.Monitoring has to stay
+// set, because RenderHOCON keys the node's metrics auto-enable off it. The
+// flag therefore suppresses the deploy without touching the intent.
+func TestApply_SkipMonitoringLeavesIntentIntact(t *testing.T) {
+	dir := t.TempDir()
+	paths.SetBaseDir(dir)
+	t.Cleanup(func() { paths.SetBaseDir("") })
+
+	mon := &intent.Monitoring{Enabled: intent.BoolPtr(true)}
+	intent.ApplyMonitoringDefaults(mon)
+	in := peerIntent(t, dir, mon)
+
+	store, st := freshStore(t)
+	res, err := Apply(context.Background(), Options{
+		Intent: in, Target: &fakeTarget{}, Store: store, State: st,
+		IntentHash: "h", SkipMonitoring: true,
+	})
+	if err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+
+	if len(res.MonitoringEndpoints) != 0 {
+		t.Errorf("SkipMonitoring still produced endpoints %v — each node would "+
+			"stand up its own stack and the last one would win",
+			res.MonitoringEndpoints)
+	}
+	if res.MonitoringError != "" {
+		t.Errorf("SkipMonitoring should be silent, got error %q", res.MonitoringError)
+	}
+	if in.Monitoring == nil || in.Monitoring.Enabled == nil || !*in.Monitoring.Enabled {
+		t.Error("SkipMonitoring must not clear Intent.Monitoring — RenderHOCON " +
+			"reads it to auto-enable the node's prometheus port")
+	}
+	if n := store.GetNode(st, "peer-node"); n != nil && n.Monitoring != nil {
+		t.Errorf("state recorded a monitoring stack despite SkipMonitoring: %+v", n.Monitoring)
+	}
+}

--- a/internal/build/builder.go
+++ b/internal/build/builder.go
@@ -105,12 +105,14 @@ type resolved struct {
 	key         CacheKey
 	cacheKeyStr string
 	// buildSourceDir is the effective directory gradle runs in.
-	// Equal to src.Path for the no-patches path (today's behavior).
-	// Equal to the per-cache-key git worktree path when req.Patches
-	// is non-empty (FR-026). Runners reference this — NOT src.Path —
-	// so the patched code is what gradle sees. Manifests record
-	// src.Path (the user-canonical source), not the trond-internal
-	// worktree path.
+	// Equal to src.Path only for the plain revision=HEAD, no-patches
+	// case (the dev inner loop, where building the working tree is the
+	// point). Equal to the per-cache-key git worktree path whenever
+	// patches are declared (FR-026) or an explicit non-HEAD revision was
+	// requested — in both cases gradle must see the pinned tree, not
+	// whatever happens to be checked out. Runners reference this — NOT
+	// src.Path. Manifests record src.Path (the user-canonical source),
+	// not the trond-internal worktree path.
 	buildSourceDir string
 	// patchRecords are the (basename, sha256) records computed
 	// ONCE in resolveBuild and stored in the eventual Manifest. The
@@ -199,16 +201,40 @@ func Run(ctx context.Context, req Request) (*Result, error) {
 				"Only run against trusted sources.")
 	}
 
-	// FR-026: when patches are declared, set up an isolated git
-	// worktree at the resolved revision + apply patches there. The
-	// runners use r.buildSourceDir, so this redirect is transparent
-	// to the downstream build code. Cleanup is deferred so partial
-	// builds don't leak worktrees.
-	if len(r.req.Patches) > 0 {
+	// Set up an isolated git worktree at the resolved revision. The
+	// runners use r.buildSourceDir, so this redirect is transparent to
+	// the downstream build code. Cleanup is deferred so partial builds
+	// don't leak worktrees.
+	//
+	// Two triggers:
+	//
+	//   - FR-026, patches declared: they must apply against the tree the
+	//     user pinned, not against whatever HEAD happens to be.
+	//   - an explicit build.revision, with or without patches. Without a
+	//     worktree gradle runs in the caller's working tree, so
+	//     `revision: <sha>` would only *label* the artifact: the cache
+	//     key, the manifest and status.build_revision all report that sha
+	//     while the bytes came from whatever was checked out. That is
+	//     worse than an error — a base-vs-head comparison would silently
+	//     compare an artifact against itself. schema.go documents revision
+	//     as selecting "which git revision to build", so honour it rather
+	//     than only labelling with it.
+	//
+	// "HEAD" deliberately keeps building the working tree: that is the dev
+	// inner loop, and Source.Resolve folds dirty state into the cache key
+	// for exactly that case.
+	needsWorktree := len(r.req.Patches) > 0 || r.req.RevisionSpec != "HEAD"
+	if needsWorktree {
 		wt, cleanup, err := setupWorktree(ctx, r.src.Path,
 			r.src.ResolvedRevision, r.cacheKeyStr, r.req.Patches)
 		if err != nil {
-			_ = AppendAuditEvent(PhaseFailed, r.cacheKeyStr, "PATCH_FAILED", started)
+			// PATCH_FAILED would be a misleading code when the caller
+			// declared no patches and the worktree setup itself failed.
+			failCode := "BUILD_FAILED"
+			if len(r.req.Patches) > 0 {
+				failCode = "PATCH_FAILED"
+			}
+			_ = AppendAuditEvent(PhaseFailed, r.cacheKeyStr, failCode, started)
 			return nil, err
 		}
 		defer cleanup()
@@ -376,13 +402,15 @@ func resolveBuild(ctx context.Context, req Request) (*resolved, error) {
 		ImageStrategy:      req.ImageStrategy,
 	}
 	return &resolved{
-		req:            req,
-		src:            src,
-		imageRef:       imageRef,
-		imageDigest:    imageDigest,
-		key:            key,
-		cacheKeyStr:    key.String(),
-		buildSourceDir: src.Path, // default; setupWorktree overrides when Patches set
+		req:         req,
+		src:         src,
+		imageRef:    imageRef,
+		imageDigest: imageDigest,
+		key:         key,
+		cacheKeyStr: key.String(),
+		// default; setupWorktree overrides it when patches are declared or
+		// an explicit (non-HEAD) revision was requested.
+		buildSourceDir: src.Path,
 		patchRecords:   patchRecords,
 	}, nil
 }

--- a/internal/build/revision_worktree_test.go
+++ b/internal/build/revision_worktree_test.go
@@ -1,0 +1,138 @@
+package build
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/tronprotocol/tron-deployment/internal/paths"
+)
+
+// captureSourceRunner records the directory gradle would have run in and
+// the contents of file.txt found there, then fails on purpose so the test
+// does not have to plant a fake JAR for the promote/validate step.
+type captureSourceRunner struct {
+	sourcePath string
+	fileBody   string
+}
+
+var errStopAfterCapture = errors.New("stop after capture")
+
+func (c *captureSourceRunner) RunDockerBuild(_ context.Context,
+	sourcePath, _, _ string, _ string, _ []string, _ map[string]string) error {
+	c.sourcePath = sourcePath
+	if b, err := os.ReadFile(filepath.Join(sourcePath, "file.txt")); err == nil {
+		c.fileBody = string(b)
+	}
+	return errStopAfterCapture
+}
+
+// twoCommitRepo returns a repo whose working tree sits on the SECOND commit,
+// plus the sha of the first. file.txt is "original\n" at commit one and
+// "working-tree\n" at commit two, so the two are trivially distinguishable.
+func twoCommitRepo(t *testing.T) (dir, firstSHA string) {
+	t.Helper()
+	dir = initSmallRepo(t) // file.txt = "original\n", one commit
+	firstSHA = gitHEAD(t, dir)
+
+	if err := os.WriteFile(filepath.Join(dir, "file.txt"), []byte("working-tree\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	gitInRepo(t, dir, "add", "file.txt")
+	gitInRepo(t, dir, "commit", "-q", "-m", "second")
+	return dir, firstSHA
+}
+
+func runCapturingBuild(t *testing.T, req Request) *captureSourceRunner {
+	t.Helper()
+	paths.SetBaseDir(t.TempDir())
+	t.Cleanup(func() { paths.SetBaseDir("") })
+
+	cap := &captureSourceRunner{}
+	restore := SetTestRunner(cap)
+	t.Cleanup(restore)
+
+	if _, err := Run(context.Background(), req); err == nil {
+		t.Fatal("expected the capture runner to abort the build, got nil error")
+	}
+	return cap
+}
+
+// TestBuild_ExplicitRevisionBuildsThatRevision is the guard for the defect
+// where build.revision only *labelled* the artifact. Before the fix, gradle
+// ran in the caller's working tree while the cache key, the manifest and
+// status.build_revision all reported the pinned sha — so `trond build
+// --revision <base>` and `--revision <head>` could hand back byte-identical
+// artifacts under two different labels, and a base-vs-head comparison would
+// silently compare an artifact against itself.
+func TestBuild_ExplicitRevisionBuildsThatRevision(t *testing.T) {
+	dir, firstSHA := twoCommitRepo(t)
+
+	cap := runCapturingBuild(t, Request{
+		SourcePath:   dir,
+		RevisionSpec: firstSHA,
+		ArtifactKind: "jar",
+		Builder:      "docker",
+	})
+
+	if cap.fileBody != "original\n" {
+		t.Errorf("gradle source tree held file.txt = %q, want %q — an explicit "+
+			"build.revision must be checked out, not just recorded",
+			cap.fileBody, "original\n")
+	}
+	if cap.sourcePath == dir {
+		t.Errorf("build ran in the caller's working tree (%s); an explicit "+
+			"revision must build in an isolated worktree", dir)
+	}
+}
+
+// TestBuild_HeadStillBuildsWorkingTree pins the other half of the contract:
+// revision HEAD is the dev inner loop and must keep building the working
+// tree, dirty edits included. Source.Resolve folds that dirty state into the
+// cache key, so correctness does not depend on a checkout here.
+func TestBuild_HeadStillBuildsWorkingTree(t *testing.T) {
+	dir, _ := twoCommitRepo(t)
+
+	// Uncommitted edit on top of the second commit.
+	if err := os.WriteFile(filepath.Join(dir, "file.txt"), []byte("dirty\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	cap := runCapturingBuild(t, Request{
+		SourcePath:   dir,
+		RevisionSpec: "HEAD",
+		ArtifactKind: "jar",
+		Builder:      "docker",
+	})
+
+	if cap.fileBody != "dirty\n" {
+		t.Errorf("gradle source tree held file.txt = %q, want %q — HEAD must "+
+			"build the working tree so the dev inner loop still sees edits",
+			cap.fileBody, "dirty\n")
+	}
+	if cap.sourcePath != dir {
+		t.Errorf("HEAD build ran in %s, want the source tree %s — a worktree "+
+			"here would drop uncommitted edits", cap.sourcePath, dir)
+	}
+}
+
+// TestBuild_ExplicitBranchBuildsThatBranch covers the non-sha spelling; the
+// schema documents branch and tag alongside sha.
+func TestBuild_ExplicitBranchBuildsThatBranch(t *testing.T) {
+	dir, firstSHA := twoCommitRepo(t)
+	gitInRepo(t, dir, "branch", "pinned", firstSHA)
+
+	cap := runCapturingBuild(t, Request{
+		SourcePath:   dir,
+		RevisionSpec: "pinned",
+		ArtifactKind: "jar",
+		Builder:      "docker",
+	})
+
+	if cap.fileBody != "original\n" {
+		t.Errorf("branch revision built file.txt = %q, want %q",
+			cap.fileBody, "original\n")
+	}
+}

--- a/internal/intent/jvm_extraopts_test.go
+++ b/internal/intent/jvm_extraopts_test.go
@@ -1,0 +1,121 @@
+package intent
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestValidateJVMExtraOpt_Accepts covers the tuning surface the field exists
+// for. Anything here must survive to the rendered command line untouched.
+func TestValidateJVMExtraOpt_Accepts(t *testing.T) {
+	for _, ok := range []string{
+		"-Dio.netty.allocator.type=pooled",
+		"-Dsun.net.inetaddr.ttl=0",
+		"-Dfile.encoding=UTF-8",
+		"-Dempty.value=",
+		"-XX:+UseZGC",
+		"-XX:-UseTLAB",
+		"-XX:MaxDirectMemorySize=2g",
+		"-XX:ActiveProcessorCount=4",
+	} {
+		if err := validateJVMExtraOpt(0, 0, ok); err != nil {
+			t.Errorf("validateJVMExtraOpt(%q) = %v, want nil", ok, err)
+		}
+	}
+}
+
+// TestValidateJVMExtraOpt_RejectsWhitespace is the load-bearing one.
+// render.JVMArgs joins the set with spaces, so an entry holding a space does
+// not stay one argument — it becomes two, and a second flag rides in looking
+// like part of an innocuous property.
+func TestValidateJVMExtraOpt_RejectsWhitespace(t *testing.T) {
+	sneaky := []string{
+		"-Dfoo=bar -XX:+UnlockDiagnosticVMOptions",
+		"-Dfoo=bar\t-XX:+UnlockDiagnosticVMOptions",
+		"-XX:+UseG1GC -javaagent:/tmp/evil.jar",
+		" -Dfoo=bar",
+	}
+	for _, s := range sneaky {
+		err := validateJVMExtraOpt(0, 0, s)
+		if err == nil {
+			t.Errorf("validateJVMExtraOpt(%q) = nil; a whitespace entry smuggles a second JVM argument", s)
+			continue
+		}
+		if !strings.Contains(err.Error(), "whitespace") {
+			t.Errorf("validateJVMExtraOpt(%q) error should name whitespace, got: %v", s, err)
+		}
+	}
+}
+
+// TestValidateJVMExtraOpt_RejectsCodeLoading — the allowlist is by
+// construction, not by blocklist, so these fail for being outside -D/-XX:
+// rather than for being individually named.
+func TestValidateJVMExtraOpt_RejectsCodeLoading(t *testing.T) {
+	for _, bad := range []string{
+		"-javaagent:/tmp/evil.jar",
+		"-agentlib:jdwp=transport=dt_socket,server=y,address=5005",
+		"-cp",
+		"-classpath:/tmp/evil",
+		"@/tmp/argfile",
+		"-jar",
+		"--add-opens=java.base/java.lang=ALL-UNNAMED",
+		"-Xshare:off",
+	} {
+		if err := validateJVMExtraOpt(0, 0, bad); err == nil {
+			t.Errorf("validateJVMExtraOpt(%q) = nil, want refusal", bad)
+		}
+	}
+}
+
+// TestValidateJVMExtraOpt_RejectsQuotingChars guards the two render targets:
+// the compose `command:` list entry and the systemd ExecStart line.
+func TestValidateJVMExtraOpt_RejectsQuotingChars(t *testing.T) {
+	for _, bad := range []string{
+		`-Dfoo="bar"`,
+		"-Dfoo='bar'",
+		`-Dfoo=bar\baz`,
+		"-Dfoo=$(id)",
+		"-Dfoo=`id`",
+	} {
+		if err := validateJVMExtraOpt(0, 0, bad); err == nil {
+			t.Errorf("validateJVMExtraOpt(%q) = nil; would not survive compose/systemd rendering intact", bad)
+		}
+	}
+}
+
+// TestValidateJVMExtraOpt_RejectsMalformed covers the -D shape itself.
+func TestValidateJVMExtraOpt_RejectsMalformed(t *testing.T) {
+	for _, bad := range []string{
+		"",
+		"-D",
+		"-Dnokey",    // no '='
+		"-D=novalue", // empty key
+		"-XX:",
+	} {
+		if err := validateJVMExtraOpt(0, 0, bad); err == nil {
+			t.Errorf("validateJVMExtraOpt(%q) = nil, want refusal", bad)
+		}
+	}
+}
+
+// TestValidateJVMExtraOpt_ErrorNamesTheEntry — with a list of flags on a
+// multi-node intent, an error that does not say which one is nearly useless.
+func TestValidateJVMExtraOpt_ErrorNamesTheEntry(t *testing.T) {
+	err := validateJVMExtraOpt(2, 3, "-javaagent:/tmp/x.jar")
+	if err == nil {
+		t.Fatal("expected refusal")
+	}
+	if !strings.Contains(err.Error(), "nodes[2].jvm.extra_opts[3]") {
+		t.Errorf("error does not locate the entry: %v", err)
+	}
+}
+
+// TestCheckSafeStrings_JVMExtraOptsControlChars confirms the field is wired
+// into the control-char sweep too, not only the shape check — a newline would
+// inject a line into the systemd unit.
+func TestCheckSafeStrings_JVMExtraOptsControlChars(t *testing.T) {
+	n := &NodeSpec{JVM: &JVMConfig{ExtraOpts: []string{"-Dfoo=bar\nExecStartPre=/bin/evil"}}}
+	if err := checkSafeStrings(0, n); err == nil {
+		t.Error("newline in jvm.extra_opts accepted; it would inject a systemd directive")
+	}
+}

--- a/internal/intent/loader.go
+++ b/internal/intent/loader.go
@@ -121,6 +121,16 @@ func checkSafeStrings(idx int, n *NodeSpec) error {
 			return err
 		}
 	}
+	if n.JVM != nil {
+		for i, o := range n.JVM.ExtraOpts {
+			if err := chk(fmt.Sprintf("jvm.extra_opts[%d]", i), o); err != nil {
+				return err
+			}
+			if err := validateJVMExtraOpt(idx, i, o); err != nil {
+				return err
+			}
+		}
+	}
 	if err := chk("storage.data", n.Storage.Data); err != nil {
 		return err
 	}
@@ -477,4 +487,50 @@ func validateWitnessKeyEnv(value string) error {
 	}
 
 	return nil
+}
+
+// validateJVMExtraOpt enforces the shape of one jvm.extra_opts entry.
+//
+// These flags land in two places a stray character can break: the compose
+// `command:` list, as one Go-quoted YAML scalar, and the systemd ExecStart
+// line. On top of that render.JVMArgs joins the whole set with spaces, so an
+// entry containing whitespace does not stay one argument — it silently
+// becomes two, and `-Dfoo=bar -XX:+Evil` smuggled through a single list item
+// would look like one innocuous property in the intent.
+//
+// Only -D<key>=<value> and -XX:… are accepted. That is the tuning surface;
+// the flags that load code or rewrite the classpath (-javaagent, -agentlib,
+// -cp/-classpath, @argfile, -jar) are excluded by construction rather than by
+// blocklist, so a JVM flag added upstream tomorrow cannot slip in.
+func validateJVMExtraOpt(nodeIdx, optIdx int, a string) error {
+	where := fmt.Sprintf("nodes[%d].jvm.extra_opts[%d]", nodeIdx, optIdx)
+
+	if a == "" {
+		return fmt.Errorf("%s: empty JVM option", where)
+	}
+	for _, r := range a {
+		if r == ' ' || r == '\t' {
+			return fmt.Errorf("%s: %q contains whitespace; JVM options are joined "+
+				"with spaces, so one entry must be exactly one argument (list them separately)",
+				where, a)
+		}
+		if r == '"' || r == '\'' || r == '\\' || r == '$' || r == '`' {
+			return fmt.Errorf("%s: %q contains %q, which would not survive the "+
+				"compose command list / systemd ExecStart line intact", where, a, r)
+		}
+	}
+
+	switch {
+	case strings.HasPrefix(a, "-XX:") && len(a) > len("-XX:"):
+		return nil
+	case strings.HasPrefix(a, "-D") && len(a) > 2:
+		if eq := strings.IndexByte(a[2:], '='); eq <= 0 {
+			return fmt.Errorf("%s: malformed system property %q: expected -D<key>=<value>",
+				where, a)
+		}
+		return nil
+	}
+	return fmt.Errorf("%s: disallowed JVM option %q: only -D<key>=<value> and -XX:… "+
+		"are permitted here (heap and GC have dedicated fields; flags that load code "+
+		"— -javaagent, -agentlib, -cp, @argfile — are not accepted)", where, a)
 }

--- a/internal/intent/schema.go
+++ b/internal/intent/schema.go
@@ -407,6 +407,25 @@ type JVMConfig struct {
 	DirectMemory string `yaml:"direct_memory,omitempty" json:"direct_memory,omitempty"`
 	GC           string `yaml:"gc,omitempty" json:"gc,omitempty" validate:"omitempty,oneof=G1 CMS auto"`
 	GCLog        *bool  `yaml:"gc_log,omitempty" json:"gc_log,omitempty"`
+
+	// ExtraOpts are additional JVM flags appended after everything trond
+	// derives, so they win on any last-flag-wins option.
+	//
+	// The closed field set above covers heap and GC, which is most tuning
+	// but not all of it. java-tron ships operational flags in
+	// gradle/java-tron.vmoptions, read by its distribution launcher
+	// (bin/FullNode); trond runs the JAR directly, so that file never
+	// applies. -Dio.netty.allocator.type=pooled is the live example —
+	// java-tron sets it to opt out of netty 4.2's adaptive allocator, and
+	// with no escape hatch a trond-deployed node silently runs with the
+	// allocator upstream deliberately avoided.
+	//
+	// Restricted to -D<key>=<value> and -XX:… — tuning, not code loading,
+	// so -javaagent / -agentlib / -cp / @argfile stay out by construction
+	// rather than by blocklist. Whitespace is rejected because JVMArgs
+	// joins the set with spaces: an entry containing one would silently
+	// become two arguments. Enforced in loader.go.
+	ExtraOpts []string `yaml:"extra_opts,omitempty" json:"extra_opts,omitempty"`
 }
 
 // PortMapping defines custom port overrides.

--- a/internal/render/hocon.go
+++ b/internal/render/hocon.go
@@ -1,6 +1,8 @@
 package render
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
 	"os"
 	"slices"
@@ -359,18 +361,45 @@ func hoconStringList(items []string) string {
 // hoconValue renders an arbitrary intent value (from config_overrides) as
 // the closest HOCON literal. Strings are double-quoted; numbers and bools
 // pass through; lists / maps are JSON-serialised, which HOCON accepts.
+// hoconValue renders one config_overrides value as a HOCON literal.
+//
+// HOCON is a superset of JSON, so a JSON encoder is the correct renderer for
+// everything except numbers. fmt is not: it produces Go syntax, and Go syntax
+// is only accidentally JSON. Two real defects this replaces:
+//
+//   - %v on a slice or map emitted Go's own container syntax —
+//     `[map[address:T… voteCount:5000]]` — which no HOCON parser accepts. That
+//     made every list-valued override unusable, including
+//     `genesis.block.witnesses`, i.e. multi-witness private networks could not
+//     be expressed in an intent at all.
+//   - %q on a string holding a control byte emitted `\x01`. That is a Go
+//     escape, not a JSON/HOCON one, so the rendered config failed to parse.
+//
+// Numbers stay on fmt deliberately: %v already yields JSON-compatible output
+// for every numeric type YAML can produce (including the 1e+06 form, which the
+// JSON number grammar allows), and routing them through the encoder would
+// change existing rendered configs for no correctness gain.
+//
+// HTML escaping is disabled so URLs, & and friends survive verbatim rather
+// than turning into &.
 func hoconValue(v any) string {
 	switch x := v.(type) {
-	case string:
-		return fmt.Sprintf("%q", x)
 	case bool:
 		return fmt.Sprintf("%t", x)
-	case int, int32, int64, float32, float64:
+	case int, int8, int16, int32, int64,
+		uint, uint8, uint16, uint32, uint64,
+		float32, float64:
 		return fmt.Sprintf("%v", x)
 	default:
-		// Fall back to %v which works for slices/maps (HOCON accepts
-		// JSON-style for those).
-		return fmt.Sprintf("%v", x)
+		var buf bytes.Buffer
+		enc := json.NewEncoder(&buf)
+		enc.SetEscapeHTML(false)
+		if err := enc.Encode(x); err != nil {
+			// Unreachable for anything YAML can unmarshal into `any`;
+			// kept so an exotic value degrades instead of panicking.
+			return fmt.Sprintf("%q", fmt.Sprintf("%v", x))
+		}
+		return strings.TrimRight(buf.String(), "\n")
 	}
 }
 

--- a/internal/render/hocon_value_test.go
+++ b/internal/render/hocon_value_test.go
@@ -1,0 +1,186 @@
+package render
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/gurkankaymak/hocon"
+
+	"github.com/tronprotocol/tron-deployment/internal/intent"
+)
+
+// parseHOCON is the oracle for the tests below. Comparing rendered strings
+// only proves "the output changed"; parsing proves "the output is loadable",
+// which is the property that was actually broken.
+func parseHOCON(t *testing.T, body string) *hocon.Config {
+	t.Helper()
+	cfg, err := hocon.ParseString(body)
+	if err != nil {
+		t.Fatalf("rendered HOCON does not parse: %v\n--- body ---\n%s", err, body)
+	}
+	return cfg
+}
+
+// TestHoconValue_RendersParseableHOCON pins the defect hoconValue had: it used
+// fmt, and Go syntax is only accidentally JSON. Every case below is a value an
+// operator can legitimately put in config_overrides.
+func TestHoconValue_RendersParseableHOCON(t *testing.T) {
+	cases := []struct {
+		name string
+		in   any
+		want string // exact rendered literal
+	}{
+		{
+			// The case that blocked multi-witness private networks: a list
+			// of objects rendered as Go's [map[k:v]] syntax, which no HOCON
+			// parser accepts.
+			name: "list of objects (genesis.block.witnesses)",
+			in: []any{
+				map[string]any{"address": "TN3zfjYUmMFK3ZsHSsrdJoNRtGkQmZLBLz", "voteCount": 5000},
+			},
+			want: `[{"address":"TN3zfjYUmMFK3ZsHSsrdJoNRtGkQmZLBLz","voteCount":5000}]`,
+		},
+		{
+			name: "empty list",
+			in:   []any{},
+			want: `[]`,
+		},
+		{
+			name: "list of scalars (seed.node.ip.list)",
+			in:   []any{"127.0.0.1:18888", "10.0.0.1:18888"},
+			want: `["127.0.0.1:18888","10.0.0.1:18888"]`,
+		},
+		{
+			name: "nested map",
+			in:   map[string]any{"engine": "ROCKSDB", "cache": 512},
+			want: `{"cache":512,"engine":"ROCKSDB"}`,
+		},
+		{
+			// %q emitted a Go \x-escape here, which is not a JSON/HOCON
+			// escape, so the whole rendered config failed to load.
+			name: "string with a control byte",
+			in:   "ctrl\x01char",
+			want: "\"ctrl\\u0001char\"",
+		},
+		{
+			name: "string with quote and backslash",
+			in:   `has "quote" and \backslash`,
+			want: `"has \"quote\" and \\backslash"`,
+		},
+		{
+			// SetEscapeHTML(false): a URL must survive verbatim rather than
+			// having its ampersand rewritten to a & escape.
+			name: "url with ampersand",
+			in:   "http://tron.org/a?x=1&y=2",
+			want: `"http://tron.org/a?x=1&y=2"`,
+		},
+		{
+			name: "non-ASCII is passed through, not escaped",
+			in:   "中文-emoji-\U0001F600",
+			want: "\"中文-emoji-\U0001F600\"",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := hoconValue(tc.in)
+			if got != tc.want {
+				t.Errorf("hoconValue() = %s, want %s", got, tc.want)
+			}
+			// The property that matters: the value is loadable in place.
+			if cfg := parseHOCON(t, "k = "+got); cfg == nil {
+				t.Fatal("parsed config is nil")
+			}
+		})
+	}
+}
+
+// TestHoconValue_ScalarFormsUnchanged guards the numbers-and-bools path, which
+// is deliberately still on fmt. If a later refactor routes these through the
+// JSON encoder too, every rendered config in the wild changes; that should be
+// a conscious decision, not a side effect of touching this function.
+func TestHoconValue_ScalarFormsUnchanged(t *testing.T) {
+	cases := []struct {
+		in   any
+		want string
+	}{
+		{true, "true"},
+		{false, "false"},
+		{0, "0"},
+		{5000, "5000"},
+		{-1, "-1"},
+		{int64(9223372036854775807), "9223372036854775807"},
+		{1.5, "1.5"},
+	}
+	for _, tc := range cases {
+		if got := hoconValue(tc.in); got != tc.want {
+			t.Errorf("hoconValue(%v) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+// TestRenderHOCON_MultiWitnessGenesis is the end-to-end form of the bug: the
+// two-SR private network tron-docker documents (private_net_config_witness1 /
+// _witness2) could not be expressed in an intent at all, because the witness
+// list never survived rendering.
+func TestRenderHOCON_MultiWitnessGenesis(t *testing.T) {
+	const (
+		sr1 = "TN3zfjYUmMFK3ZsHSsrdJoNRtGkQmZLBLz"
+		sr2 = "TAt6GfSHVaGGx7Xzu3mgtCmqPBZzXWQhPP"
+	)
+	i := &intent.Intent{Name: "two-sr", Network: "private"}
+	node := &intent.NodeSpec{
+		Type: "witness",
+		ConfigOverrides: map[string]any{
+			"genesis.block.witnesses": []any{
+				map[string]any{"address": sr1, "url": "http://tron.org", "voteCount": 5000},
+				map[string]any{"address": sr2, "url": "http://tron.org", "voteCount": 5000},
+			},
+		},
+	}
+
+	out, err := RenderHOCON("", i, node)
+	if err != nil {
+		t.Fatalf("render: %v", err)
+	}
+
+	// NOTE: we deliberately do not run hocon.ParseString over the whole
+	// document. gurkankaymak/hocon is an incomplete HOCON implementation and
+	// cannot parse the shipped java-tron templates at all — private fails at
+	// 112:22 on its comma rule, mainnet at 37:5 and nile at 103:5 on a '#'
+	// comment — even before any override is appended. Typesafe Config (what
+	// java-tron actually uses) accepts them. So the oracle here is the value
+	// itself: HOCON is a JSON superset, so a value that decodes as JSON is
+	// loadable.
+	line := findOverrideLine(t, out, "genesis.block.witnesses")
+	var got []map[string]any
+	if err := json.Unmarshal([]byte(line), &got); err != nil {
+		t.Fatalf("rendered witness list is not valid JSON (so not valid HOCON): %v\nvalue: %s", err, line)
+	}
+	if len(got) != 2 {
+		t.Fatalf("witness list has %d entries, want 2: %s", len(got), line)
+	}
+	for i, want := range []string{sr1, sr2} {
+		if got[i]["address"] != want {
+			t.Errorf("witness[%d].address = %v, want %s", i, got[i]["address"], want)
+		}
+	}
+	if strings.Contains(out, "map[") {
+		t.Error("rendered HOCON contains Go map syntax — the fmt fallback is back")
+	}
+}
+
+// findOverrideLine returns the right-hand side of `key = <value>` from the
+// trond overrides block, failing the test if the key is absent.
+func findOverrideLine(t *testing.T, rendered, key string) string {
+	t.Helper()
+	for _, l := range strings.Split(rendered, "\n") {
+		l = strings.TrimSpace(l)
+		if strings.HasPrefix(l, key+" = ") {
+			return strings.TrimPrefix(l, key+" = ")
+		}
+	}
+	t.Fatalf("override key %q not found in rendered HOCON", key)
+	return ""
+}

--- a/internal/render/jvm.go
+++ b/internal/render/jvm.go
@@ -74,6 +74,16 @@ func JVMArgs(totalMemoryGB int, jdkVersion int, jvm *intent.JVMConfig) []string 
 		"-XX:+UseTLAB",
 	)
 
+	// Operator escape hatch, appended LAST so it wins: the JVM takes the
+	// final occurrence for -XX:± and -D, so an extra_opt can override
+	// anything trond derived above. Entries are shape-checked at load
+	// time (intent.validateJVMExtraOpt) — restricted to -D<k>=<v> and
+	// -XX:…, no whitespace, no quoting characters — so appending them
+	// verbatim cannot add an argument or break the compose/systemd line.
+	if jvm != nil {
+		args = append(args, jvm.ExtraOpts...)
+	}
+
 	return args
 }
 

--- a/internal/render/jvm_extraopts_test.go
+++ b/internal/render/jvm_extraopts_test.go
@@ -1,0 +1,88 @@
+package render
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/tronprotocol/tron-deployment/internal/intent"
+)
+
+// TestJVMArgs_ExtraOptsAppendedLast pins the ordering contract. The JVM takes
+// the LAST occurrence of -XX:± and -D, so an operator override only works if
+// extra_opts lands after everything trond derives. Appending it earlier would
+// make the field look wired while trond's own flag silently won.
+func TestJVMArgs_ExtraOptsAppendedLast(t *testing.T) {
+	args := JVMArgs(32, 17, &intent.JVMConfig{
+		GC:        "G1",
+		ExtraOpts: []string{"-Dio.netty.allocator.type=pooled", "-XX:+UseTLAB"},
+	})
+
+	if len(args) < 2 {
+		t.Fatalf("too few args: %v", args)
+	}
+	lasttwo := args[len(args)-2:]
+	want := []string{"-Dio.netty.allocator.type=pooled", "-XX:+UseTLAB"}
+	for i := range want {
+		if lasttwo[i] != want[i] {
+			t.Errorf("args[%d] from the end = %q, want %q (full: %v)",
+				len(want)-i, lasttwo[i], want[i], args)
+		}
+	}
+}
+
+// TestJVMArgs_ExtraOptsOverrideDerived is the reason the field exists: the
+// duplicate must come after trond's own, so the JVM resolves to the
+// operator's value.
+func TestJVMArgs_ExtraOptsOverrideDerived(t *testing.T) {
+	args := JVMArgs(32, 17, &intent.JVMConfig{
+		ExtraOpts: []string{"-XX:-UseTLAB"},
+	})
+
+	firstTLAB, lastTLAB := -1, -1
+	for i, a := range args {
+		if strings.HasSuffix(a, "UseTLAB") {
+			if firstTLAB == -1 {
+				firstTLAB = i
+			}
+			lastTLAB = i
+		}
+	}
+	if firstTLAB == lastTLAB {
+		t.Fatalf("expected both trond's -XX:+UseTLAB and the override: %v", args)
+	}
+	if args[lastTLAB] != "-XX:-UseTLAB" {
+		t.Errorf("last UseTLAB flag = %q, want the operator's -XX:-UseTLAB; "+
+			"trond's derived value would win instead", args[lastTLAB])
+	}
+}
+
+// TestJVMArgs_NoExtraOptsUnchanged is the regression guard: the field is
+// optional and absent in every shipped example, so its introduction must not
+// move a single byte of the default render.
+func TestJVMArgs_NoExtraOptsUnchanged(t *testing.T) {
+	withNil := JVMArgsString(32, 17, nil)
+	withEmpty := JVMArgsString(32, 17, &intent.JVMConfig{})
+	if strings.Contains(withNil, "-D") {
+		t.Errorf("default render gained a -D flag: %s", withNil)
+	}
+	if !strings.HasSuffix(withEmpty, "-XX:+UseTLAB") {
+		t.Errorf("render no longer ends with the common flags: %s", withEmpty)
+	}
+}
+
+// TestJVMArgs_TheNettyAllocatorCase is the concrete motivating scenario:
+// java-tron sets this in gradle/java-tron.vmoptions, which its distribution
+// launcher reads and trond never does, so without extra_opts a trond-deployed
+// node runs on netty 4.2's adaptive allocator that upstream opted out of.
+func TestJVMArgs_TheNettyAllocatorCase(t *testing.T) {
+	got := JVMArgsString(16, 17, &intent.JVMConfig{
+		ExtraOpts: []string{"-Dio.netty.allocator.type=pooled"},
+	})
+	if !strings.Contains(got, "-Dio.netty.allocator.type=pooled") {
+		t.Errorf("allocator flag absent from rendered args: %s", got)
+	}
+	// One argument, not two — JVMArgsString joins with spaces.
+	if n := strings.Count(got, "-Dio.netty.allocator.type=pooled"); n != 1 {
+		t.Errorf("allocator flag appears %d times, want 1: %s", n, got)
+	}
+}

--- a/schemas/intent.schema.json
+++ b/schemas/intent.schema.json
@@ -561,6 +561,14 @@
           "type": "boolean",
           "default": false,
           "description": "Opt-in. Default off so the upstream image's start.sh decides."
+        },
+        "extra_opts": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "pattern": "^(-XX:.+|-D[^=\\s]+=[^\\s]*)$"
+          },
+          "description": "Extra JVM flags, appended last so they override anything trond derives. Restricted to -D<key>=<value> and -XX:... — one argument per entry, no whitespace or quoting characters. Needed because trond runs the JAR directly and never reads java-tron's gradle/java-tron.vmoptions (e.g. -Dio.netty.allocator.type=pooled)."
         }
       }
     },


### PR DESCRIPTION
Four correctness fixes across the render, build, and deploy paths. They were found while trying to stand up a two-node private network built from a specific java-tron commit — every one of them had the same shape: **the command succeeded and produced a wrong result.** No error, no warning, and in three of the four cases a green `config validate`.

Rebased on `fbb3658`. `make test -race`, `make lint`, and `make e2e` (real Docker) all pass.

---

### 1. `config_overrides` rendered Go syntax, not HOCON — `fix(render)`

`hoconValue` fell back to `fmt` outside the scalar cases, and Go syntax is only accidentally JSON:

```
[]any{map[…]}    %v  ->  [map[address:T… voteCount:5000]]   no HOCON parser accepts this
"ctrl\x01char"   %q  ->  a Go \x-escape, which is not a JSON/HOCON escape
```

The first made **every list-valued override unusable**. Most visibly it made `genesis.block.witnesses` unexpressible, so the two-SR DPoS private network `tron-docker` documents could not be built from an intent file at all.

Both now render through a JSON encoder — HOCON is a JSON superset, so the encoder is the correct renderer. `SetEscapeHTML(false)` keeps URLs readable. Numbers deliberately stay on `fmt`; a test pins that so the next refactor has to change it on purpose.

### 2. `build.revision` labelled the artifact without building it — `fix(build)`

The git worktree checkout ran only when `build.patches` was non-empty. With an explicit branch/tag/sha and no patches, gradle ran in the caller's working tree — and then the resolved sha went into the cache key, the manifest and `status.build_revision`.

So two `trond build --revision <ref>` runs against different refs could return **byte-identical artifacts under two different labels**. Anyone using this to compare a base commit against a head commit would be comparing an artifact with itself, and the tooling would confirm the labels.

`schema.go` already documented the field as selecting "which git revision to build"; the code did the *resolve* half and skipped the *build-that-commit* half. `revision: HEAD` still builds the working tree with dirty edits — that is the dev inner loop, and the dirty state is already in the cache key.

### 3. `network create` bypassed `apply.Apply` — `fix(network)`

The multi-node loop hand-rolled render + Deploy + state and had drifted from the core in three ways:

- it never imported `internal/build`, so a node with `build:` rendered an empty `image:` and deployed nothing usable
- it hardcoded `jdk=17` instead of probing the target
- it hardcoded the docker runtime instead of honouring `target.runtime`

Every node now goes through `Apply`, projected to a single-node intent with its own name and hash so idempotency stays per node.

**Two things had to be fixed in `Apply` first**, both found by doing the refactor rather than by reading it:

- **`Apply` never wrote `P2PPort`.** `network add` builds the joining node's peer list from the `P2PPort` of every node in state and *skips* zero entries. Routing create through `Apply` as-is would have left every node invisible as a peer, so a late joiner would come up with an empty peer list and never connect — with nothing in either command's output to say why.
- **Monitoring would have deployed once per node.** `RenderHOCON` keys its metrics auto-enable off `Intent.Monitoring`, so the field cannot simply be cleared. `Options.SkipMonitoring` suppresses the deploy and leaves the field alone. Without it the last node's stack wins and scrapes exactly one node — a monitoring setup that looks healthy and observes a fraction of the network.

Two consequences of create becoming an `Apply` caller, both wanted: it inherits `RenderHOCONWithSecrets` (#202) instead of keeping a second copy of that call in sync by hand, and it now passes `guard.Requested()` so the state-based half of the `--require-private` gate (#203) applies here too.

### 4. `jvm.extra_opts` — `feat(intent)`

`JVMConfig` was closed over heap and GC. java-tron ships operational flags in `gradle/java-tron.vmoptions`, read by its distribution launcher `bin/FullNode`; trond runs the JAR directly, so that file never applies and there was no way to supply them.

`-Dio.netty.allocator.type=pooled` is the case that forced this — java-tron sets it to opt out of netty 4.2's adaptive allocator, which has open direct-memory regressions upstream. Deployed through trond, a node ran on the allocator java-tron had explicitly avoided.

Appended **last**, because the JVM takes the final occurrence of `-XX:±` and `-D` — appending earlier would make the field look wired while trond's own flag quietly won. A test pins the ordering.

Validation is an allowlist **by construction**: only `-D<key>=<value>` and `-XX:…`, so `-javaagent` / `-agentlib` / `-cp` / `@argfile` are excluded by shape rather than by blocklist, and a JVM flag added upstream tomorrow cannot slip in. Whitespace is refused, and that rule is load-bearing rather than tidiness: `JVMArgs` joins with spaces, so `"-Dfoo=bar -XX:+Evil"` in one list item reads as an innocuous property in the intent and arrives as two JVM arguments.

---

### Testing

- `make test -race` — 25 packages, 0 failures
- `make lint` — no findings
- `make e2e` — full suite against a real Docker daemon, including `TestE2E_Network_PrivateLifecycle` (2 containers, create → status → destroy)
- New tests use the property as the oracle where possible: rendered HOCON values are parsed back rather than string-compared; the build tests assert the *contents* of the tree gradle saw, not the label on the artifact

One note for reviewers: the HOCON tests deliberately do **not** parse the whole rendered document. `gurkankaymak/hocon` cannot parse any of the shipped java-tron templates — private fails at 112:22, mainnet at 37:5, nile at 103:5 — even before an override is appended. Typesafe Config, which java-tron actually uses, accepts them. The tests therefore parse the rendered *value*.

### Not covered

- `network create --monitor` is unit-tested but not exercised with real containers
- `target.type: ssh` on the multi-node path is untested
