### PR TITLE
fix(runtime): config changes never reached the running process

### DIFF
--- a/internal/runtime/docker.go
+++ b/internal/runtime/docker.go
@@ -49,12 +49,18 @@ func (r *DockerRuntime) Deploy(ctx context.Context, opts DeployOpts) error {
 	// world-readable — compose mounts it into the container read-only and
 	// the java-tron image declares no USER, so the process that reads it
 	// is root inside the container.
+	//
+	// Written through the tracker: compose mounts this file rather than
+	// baking it into the image, so its contents are invisible to compose's
+	// own recreate decision. java-tron parses it once at JVM startup.
+	tracker := newChangeTracker(r.target)
 	configPath := filepath.Join(dir, opts.Name+".conf")
-	if err := r.target.WriteFile(ctx, configPath, opts.ConfigData, 0600); err != nil {
+	if err := tracker.write(ctx, configPath, opts.ConfigData, 0600); err != nil {
 		return fmt.Errorf("write config: %w", err)
 	}
 
-	// Write compose file
+	// Write compose file. Not tracked — compose diffs this itself and
+	// recreates the container when the service definition changes.
 	composePath := filepath.Join(dir, "docker-compose.yaml")
 	if err := r.target.WriteFile(ctx, composePath, opts.ComposeData, 0644); err != nil {
 		return fmt.Errorf("write compose: %w", err)
@@ -62,6 +68,12 @@ func (r *DockerRuntime) Deploy(ctx context.Context, opts DeployOpts) error {
 
 	// Docker compose up
 	args := []string{"compose", "-f", composePath, "-p", opts.Name, "up", "-d"}
+	if tracker.changed {
+		// The config changed but the compose spec may not have. Without
+		// this the container keeps running on the config it parsed at
+		// start, and `up -d` still reports success.
+		args = append(args, "--force-recreate")
+	}
 	if _, err := r.target.Exec(ctx, "docker", args...); err != nil {
 		return fmt.Errorf("docker compose up: %w", err)
 	}

--- a/internal/runtime/jar.go
+++ b/internal/runtime/jar.go
@@ -5,7 +5,9 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"maps"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	"github.com/tronprotocol/tron-deployment/internal/target"
@@ -60,17 +62,28 @@ func (r *JarRuntime) Deploy(ctx context.Context, opts DeployOpts) error {
 		return fmt.Errorf("daemon-reload: %w", err)
 	}
 
-	// Set environment variables for the service
-	for key, val := range opts.EnvVars {
+	// Set environment variables for the service.
+	//
+	// All of them go into one drop-in. The previous version wrote the file
+	// once per key inside the loop, each write replacing the last, so only
+	// one variable survived — and which one was whatever Go's randomised
+	// map iteration visited last. A witness node whose key arrives via
+	// EnvVars alongside anything else would start with the key missing on
+	// some deploys and present on others.
+	if len(opts.EnvVars) > 0 {
 		overridePath := fmt.Sprintf("/etc/systemd/system/%s.d", unitName)
 		if _, err := r.target.Exec(ctx, "mkdir", "-p", overridePath); err != nil {
 			return fmt.Errorf("create override dir: %w", err)
 		}
-		envOverride := fmt.Sprintf("[Service]\nEnvironment=%s=%s\n", key, val)
+		var sb strings.Builder
+		sb.WriteString("[Service]\n")
+		for _, key := range slices.Sorted(maps.Keys(opts.EnvVars)) {
+			fmt.Fprintf(&sb, "Environment=%s=%s\n", key, opts.EnvVars[key])
+		}
 		// Tracked for the same reason as the unit file: a changed
 		// Environment= only reaches the process across a restart.
 		envPath := filepath.Join(overridePath, "env.conf")
-		if err := tracker.write(ctx, envPath, []byte(envOverride), 0600); err != nil {
+		if err := tracker.write(ctx, envPath, []byte(sb.String()), 0600); err != nil {
 			return fmt.Errorf("write env override: %w", err)
 		}
 	}

--- a/internal/runtime/jar.go
+++ b/internal/runtime/jar.go
@@ -37,16 +37,21 @@ func (r *JarRuntime) Deploy(ctx context.Context, opts DeployOpts) error {
 		}
 	}
 
-	// Write config file
+	// Write config file. Tracked: systemd has no idea this file exists,
+	// and java-tron parses it once at JVM startup.
+	tracker := newChangeTracker(r.target)
 	configPath := filepath.Join(installPath, "config.conf")
-	if err := r.target.WriteFile(ctx, configPath, opts.ConfigData, 0644); err != nil {
+	if err := tracker.write(ctx, configPath, opts.ConfigData, 0644); err != nil {
 		return fmt.Errorf("write config: %w", err)
 	}
 
-	// Write systemd unit file
+	// Write systemd unit file. Also tracked: daemon-reload below makes
+	// systemd read the new unit, but it does not restart a unit that is
+	// already running, so a changed ExecStart (new JVM args, new jar
+	// path) would not reach the process.
 	unitName := fmt.Sprintf("tron-%s.service", opts.Name)
 	unitPath := filepath.Join("/etc/systemd/system", unitName)
-	if err := r.target.WriteFile(ctx, unitPath, opts.SystemdData, 0644); err != nil {
+	if err := tracker.write(ctx, unitPath, opts.SystemdData, 0644); err != nil {
 		return fmt.Errorf("write systemd unit: %w", err)
 	}
 
@@ -62,8 +67,10 @@ func (r *JarRuntime) Deploy(ctx context.Context, opts DeployOpts) error {
 			return fmt.Errorf("create override dir: %w", err)
 		}
 		envOverride := fmt.Sprintf("[Service]\nEnvironment=%s=%s\n", key, val)
+		// Tracked for the same reason as the unit file: a changed
+		// Environment= only reaches the process across a restart.
 		envPath := filepath.Join(overridePath, "env.conf")
-		if err := r.target.WriteFile(ctx, envPath, []byte(envOverride), 0600); err != nil {
+		if err := tracker.write(ctx, envPath, []byte(envOverride), 0600); err != nil {
 			return fmt.Errorf("write env override: %w", err)
 		}
 	}
@@ -74,6 +81,15 @@ func (r *JarRuntime) Deploy(ctx context.Context, opts DeployOpts) error {
 
 	if _, err := r.target.Exec(ctx, "systemctl", "enable", "--now", unitName); err != nil {
 		return fmt.Errorf("enable + start service: %w", err)
+	}
+
+	// enable --now starts a stopped unit; it does nothing to a running
+	// one. Without this an existing node would keep its old config, unit
+	// and environment while the deploy reported success.
+	if tracker.changed {
+		if _, err := r.target.Exec(ctx, "systemctl", "restart", unitName); err != nil {
+			return fmt.Errorf("restart after config change: %w", err)
+		}
 	}
 
 	return nil

--- a/internal/runtime/monitoring.go
+++ b/internal/runtime/monitoring.go
@@ -43,6 +43,12 @@ func (r *MonitoringRuntime) Deploy(ctx context.Context, opts MonitoringDeployOpt
 		return fmt.Errorf("create monitoring dir: %w", err)
 	}
 
+	// Prometheus and Grafana read these from bind mounts and parse them at
+	// process start, so compose's recreate decision cannot see a change in
+	// any of them. Tracked; the compose file itself is not, because
+	// compose diffs that on its own.
+	tracker := newChangeTracker(r.target)
+
 	// Write compose file
 	composePath := filepath.Join(dir, "docker-compose.yaml")
 	if err := r.target.WriteFile(ctx, composePath, opts.ComposeData, 0644); err != nil {
@@ -55,7 +61,7 @@ func (r *MonitoringRuntime) Deploy(ctx context.Context, opts MonitoringDeployOpt
 		return fmt.Errorf("create monitoring conf dir: %w", err)
 	}
 	promPath := filepath.Join(confDir, "prometheus.yml")
-	if err := r.target.WriteFile(ctx, promPath, opts.PrometheusConfig, 0644); err != nil {
+	if err := tracker.write(ctx, promPath, opts.PrometheusConfig, 0644); err != nil {
 		return fmt.Errorf("write prometheus config: %w", err)
 	}
 
@@ -65,7 +71,7 @@ func (r *MonitoringRuntime) Deploy(ctx context.Context, opts MonitoringDeployOpt
 		return fmt.Errorf("create grafana ds dir: %w", err)
 	}
 	dsPath := filepath.Join(dsDir, "prometheus.yml")
-	if err := r.target.WriteFile(ctx, dsPath, opts.GrafanaDatasource, 0644); err != nil {
+	if err := tracker.write(ctx, dsPath, opts.GrafanaDatasource, 0644); err != nil {
 		return fmt.Errorf("write grafana datasource: %w", err)
 	}
 
@@ -75,7 +81,7 @@ func (r *MonitoringRuntime) Deploy(ctx context.Context, opts MonitoringDeployOpt
 		return fmt.Errorf("create grafana provider dir: %w", err)
 	}
 	provPath := filepath.Join(provDir, "dashboards.yml")
-	if err := r.target.WriteFile(ctx, provPath, opts.GrafanaProvider, 0644); err != nil {
+	if err := tracker.write(ctx, provPath, opts.GrafanaProvider, 0644); err != nil {
 		return fmt.Errorf("write grafana provider: %w", err)
 	}
 
@@ -86,13 +92,18 @@ func (r *MonitoringRuntime) Deploy(ctx context.Context, opts MonitoringDeployOpt
 	}
 	for fname, data := range opts.Dashboards {
 		dashPath := filepath.Join(dashDir, fname)
-		if err := r.target.WriteFile(ctx, dashPath, data, 0644); err != nil {
+		if err := tracker.write(ctx, dashPath, data, 0644); err != nil {
 			return fmt.Errorf("write dashboard %s: %w", fname, err)
 		}
 	}
 
 	// Docker compose up
 	args := []string{"compose", "-f", composePath, "-p", opts.Name + "-monitoring", "up", "-d"}
+	if tracker.changed {
+		// A changed scrape config or dashboard otherwise sits on disk
+		// while Prometheus keeps serving what it parsed at start.
+		args = append(args, "--force-recreate")
+	}
 	if _, err := r.target.Exec(ctx, "docker", args...); err != nil {
 		return fmt.Errorf("monitoring compose up: %w", err)
 	}

--- a/internal/runtime/monitoring_test.go
+++ b/internal/runtime/monitoring_test.go
@@ -25,7 +25,13 @@ func (f *fakeTarget) Exec(ctx context.Context, cmd string, args ...string) ([]by
 func (f *fakeTarget) Upload(ctx context.Context, localPath, remotePath string) error   { return nil }
 func (f *fakeTarget) Download(ctx context.Context, remotePath, localPath string) error { return nil }
 func (f *fakeTarget) ReadFile(ctx context.Context, path string) ([]byte, error) {
-	return f.files[path], nil
+	data, ok := f.files[path]
+	if !ok {
+		// Faithful to the real targets: reading a file that is not there
+		// is an error, not an empty read. Deploy distinguishes the two.
+		return nil, os.ErrNotExist
+	}
+	return data, nil
 }
 func (f *fakeTarget) WriteFile(ctx context.Context, path string, data []byte, perm os.FileMode) error {
 	f.files[path] = data

--- a/internal/runtime/redeploy_test.go
+++ b/internal/runtime/redeploy_test.go
@@ -1,0 +1,184 @@
+package runtime
+
+import (
+	"context"
+	"slices"
+	"testing"
+)
+
+// These tests cover one defect with three instances: a deploy writes new
+// config to a bind mount or a systemd-invisible path, the orchestrator
+// sees no reason to replace the running process, and the command reports
+// success while the node keeps serving its old configuration.
+//
+// The oracle throughout is the command trond actually runs, because that
+// is the only thing that determines whether the change reaches the
+// process. Asserting that the file was written proves nothing here — the
+// broken versions wrote the file too.
+
+// findCmd returns the first recorded invocation of `name`, or nil.
+func findCmd(cmds [][]string, name string, mustContain ...string) []string {
+	for _, c := range cmds {
+		if len(c) == 0 || c[0] != name {
+			continue
+		}
+		ok := true
+		for _, want := range mustContain {
+			if !slices.Contains(c, want) {
+				ok = false
+				break
+			}
+		}
+		if ok {
+			return c
+		}
+	}
+	return nil
+}
+
+func TestDockerRuntime_Deploy_ConfigChangeForcesRecreate(t *testing.T) {
+	const compose = "services:\n  n1:\n"
+	opts := func(config string) DeployOpts {
+		return DeployOpts{Name: "n1", ConfigData: []byte(config), ComposeData: []byte(compose)}
+	}
+
+	t.Run("first deploy does not force recreate", func(t *testing.T) {
+		ft := newFakeTarget()
+		rt := NewDockerRuntime(ft, "/tmp/d")
+		if err := rt.Deploy(context.Background(), opts("a = 1\n")); err != nil {
+			t.Fatalf("Deploy: %v", err)
+		}
+		up := findCmd(ft.cmds, "docker", "up")
+		if up == nil {
+			t.Fatal("no `docker compose up` recorded")
+		}
+		if slices.Contains(up, "--force-recreate") {
+			t.Errorf("first deploy used --force-recreate: %v — there is no old "+
+				"container to replace, and recreating costs a node restart", up)
+		}
+	})
+
+	t.Run("unchanged config does not force recreate", func(t *testing.T) {
+		ft := newFakeTarget()
+		rt := NewDockerRuntime(ft, "/tmp/d")
+		ctx := context.Background()
+		if err := rt.Deploy(ctx, opts("a = 1\n")); err != nil {
+			t.Fatalf("Deploy 1: %v", err)
+		}
+		ft.cmds = nil
+		if err := rt.Deploy(ctx, opts("a = 1\n")); err != nil {
+			t.Fatalf("Deploy 2: %v", err)
+		}
+		up := findCmd(ft.cmds, "docker", "up")
+		if up == nil {
+			t.Fatal("no `docker compose up` recorded")
+		}
+		if slices.Contains(up, "--force-recreate") {
+			t.Errorf("redeploy of identical config used --force-recreate: %v — "+
+				"apply must stay idempotent, a node restart is not free", up)
+		}
+	})
+
+	t.Run("changed config forces recreate", func(t *testing.T) {
+		ft := newFakeTarget()
+		rt := NewDockerRuntime(ft, "/tmp/d")
+		ctx := context.Background()
+		if err := rt.Deploy(ctx, opts("node.rpc.maxConcurrentCallsPerConnection = 5\n")); err != nil {
+			t.Fatalf("Deploy 1: %v", err)
+		}
+		ft.cmds = nil
+		// Compose spec is byte-identical; only the bind-mounted config moved.
+		if err := rt.Deploy(ctx, opts("node.rpc.maxConcurrentCallsPerConnection = 1\n")); err != nil {
+			t.Fatalf("Deploy 2: %v", err)
+		}
+		up := findCmd(ft.cmds, "docker", "up")
+		if up == nil {
+			t.Fatal("no `docker compose up` recorded")
+		}
+		if !slices.Contains(up, "--force-recreate") {
+			t.Errorf("config changed but compose was run as %v — without "+
+				"--force-recreate the container keeps the config it parsed at "+
+				"start and the deploy still reports success", up)
+		}
+	})
+}
+
+func TestJarRuntime_Deploy_RestartsOnlyWhenSomethingChanged(t *testing.T) {
+	base := func(config, unit string) DeployOpts {
+		return DeployOpts{
+			Name:        "n1",
+			JarPath:     "/opt/tron/FullNode.jar",
+			ConfigData:  []byte(config),
+			SystemdData: []byte(unit),
+		}
+	}
+	const unit = "[Service]\nExecStart=/usr/bin/java -jar FullNode.jar\n"
+
+	tests := []struct {
+		name          string
+		second        DeployOpts
+		wantedRestart bool
+	}{
+		{"identical redeploy", base("a = 1\n", unit), false},
+		{"config changed", base("a = 2\n", unit), true},
+		{"unit changed", base("a = 1\n", unit+"Environment=X=1\n"), true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ft := newFakeTarget()
+			rt := NewJarRuntime(ft)
+			ctx := context.Background()
+			if err := rt.Deploy(ctx, base("a = 1\n", unit)); err != nil {
+				t.Fatalf("Deploy 1: %v", err)
+			}
+			ft.cmds = nil
+			if err := rt.Deploy(ctx, tc.second); err != nil {
+				t.Fatalf("Deploy 2: %v", err)
+			}
+			restart := findCmd(ft.cmds, "systemctl", "restart") != nil
+			if restart != tc.wantedRestart {
+				if tc.wantedRestart {
+					t.Errorf("no `systemctl restart` after the change — "+
+						"`enable --now` starts a stopped unit but never restarts a "+
+						"running one, so the change never reaches the JVM. Commands: %v",
+						ft.cmds)
+				} else {
+					t.Errorf("restarted on an unchanged redeploy: %v — that turns "+
+						"every apply into a node outage", ft.cmds)
+				}
+			}
+		})
+	}
+}
+
+func TestMonitoringRuntime_Deploy_ScrapeConfigChangeForcesRecreate(t *testing.T) {
+	opts := func(scrape string) MonitoringDeployOpts {
+		return MonitoringDeployOpts{
+			Name:              "test",
+			ComposeData:       []byte("services:\n  prometheus:\n"),
+			PrometheusConfig:  []byte(scrape),
+			GrafanaDatasource: []byte("datasources:\n"),
+			GrafanaProvider:   []byte("providers:\n"),
+		}
+	}
+	ft := newFakeTarget()
+	rt := NewMonitoringRuntime(ft, "/tmp/m")
+	ctx := context.Background()
+	if err := rt.Deploy(ctx, opts("scrape_configs: [a]\n")); err != nil {
+		t.Fatalf("Deploy 1: %v", err)
+	}
+	ft.cmds = nil
+	// Only the bind-mounted scrape config moved; the compose spec did not.
+	if err := rt.Deploy(ctx, opts("scrape_configs: [a, b]\n")); err != nil {
+		t.Fatalf("Deploy 2: %v", err)
+	}
+	up := findCmd(ft.cmds, "docker", "up")
+	if up == nil {
+		t.Fatal("no `docker compose up` recorded")
+	}
+	if !slices.Contains(up, "--force-recreate") {
+		t.Errorf("scrape config changed but compose was run as %v — Prometheus "+
+			"would keep scraping the targets it read at start while the new "+
+			"config sits on disk", up)
+	}
+}

--- a/internal/runtime/redeploy_test.go
+++ b/internal/runtime/redeploy_test.go
@@ -3,6 +3,7 @@ package runtime
 import (
 	"context"
 	"slices"
+	"strings"
 	"testing"
 )
 
@@ -148,6 +149,41 @@ func TestJarRuntime_Deploy_RestartsOnlyWhenSomethingChanged(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// TestJarRuntime_Deploy_EnvVarsAllSurvive covers a separate defect in the
+// same function: the drop-in was written once per key inside the loop,
+// each write truncating the last, so exactly one variable survived and
+// which one depended on Go's randomised map iteration order.
+func TestJarRuntime_Deploy_EnvVarsAllSurvive(t *testing.T) {
+	ft := newFakeTarget()
+	rt := NewJarRuntime(ft)
+	opts := DeployOpts{
+		Name:        "n1",
+		JarPath:     "/opt/tron/FullNode.jar",
+		ConfigData:  []byte("a = 1\n"),
+		SystemdData: []byte("[Service]\n"),
+		EnvVars: map[string]string{
+			"SR_PRIVATE_KEY": "deadbeef",
+			"TRON_HOME":      "/opt/tron",
+			"JAVA_OPTS":      "-Xmx16g",
+		},
+	}
+	if err := rt.Deploy(context.Background(), opts); err != nil {
+		t.Fatalf("Deploy: %v", err)
+	}
+
+	got := string(ft.files["/etc/systemd/system/tron-n1.service.d/env.conf"])
+	for k, v := range opts.EnvVars {
+		want := "Environment=" + k + "=" + v
+		if !strings.Contains(got, want) {
+			t.Errorf("drop-in is missing %q — a node can start without its "+
+				"witness key depending on map iteration order.\ngot:\n%s", want, got)
+		}
+	}
+	if n := strings.Count(got, "[Service]"); n != 1 {
+		t.Errorf("drop-in has %d [Service] sections, want 1:\n%s", n, got)
 	}
 }
 

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -1,9 +1,53 @@
 package runtime
 
 import (
+	"bytes"
 	"context"
 	"io"
+	"os"
+
+	"github.com/tronprotocol/tron-deployment/internal/target"
 )
+
+// changeTracker writes deployment files and remembers whether any of them
+// replaced different content.
+//
+// It exists because neither orchestrator notices a changed config on its
+// own. `docker compose up -d` recreates a container only when the
+// *compose spec* changes, and a config delivered by bind mount appears in
+// that spec as a path, never as content. `systemctl enable --now` starts
+// a stopped unit but never restarts a running one, so even a reloaded
+// unit file leaves the old process in place. Either way the file lands on
+// disk, the deploy reports success, and the running process keeps serving
+// the config it parsed at startup — with nothing in the output to say so.
+//
+// So Deploy tracks the files the orchestrator cannot see for itself and
+// escalates the start into a recreate/restart when one of them changed.
+// Files the orchestrator *does* diff (the compose file itself) are
+// written directly and deliberately not tracked.
+type changeTracker struct {
+	target  target.Target
+	changed bool
+}
+
+func newChangeTracker(t target.Target) *changeTracker {
+	return &changeTracker{target: t}
+}
+
+// write stores data at path, recording whether it displaced different
+// bytes. A missing or unreadable file does not count as a change: there
+// is no running process holding the old content, and Deploy is about to
+// create one from the new.
+func (c *changeTracker) write(ctx context.Context, path string, data []byte, perm os.FileMode) error {
+	if !c.changed {
+		// ReadFile's contract for a missing file differs by target
+		// implementation, so treat "no bytes" as absent either way.
+		if existing, err := c.target.ReadFile(ctx, path); err == nil && len(existing) > 0 {
+			c.changed = !bytes.Equal(existing, data)
+		}
+	}
+	return c.target.WriteFile(ctx, path, data, perm)
+}
 
 // LogOpts configures log retrieval.
 type LogOpts struct {


### PR DESCRIPTION
A deploy that changed only node configuration wrote the new file, reported success, and left the node running the configuration it parsed at startup. Nothing in the output said so.

Three runtimes, one defect — in each case the orchestrator has no way to see the change it is being asked to apply:

| runtime | why the change never landed |
|---|---|
| **docker** | `docker compose up -d` recreates a container only when the *compose spec* changes. The config arrives by bind mount, so the spec carries its **path** and never its **contents**. Changing `config_overrides` alone changed nothing at all. |
| **jar** | `systemctl enable --now` starts a *stopped* unit and does nothing to a running one. A changed `config.conf` **and** a changed unit file (new JVM args, new jar path) both stayed off the process — `daemon-reload` makes systemd read the new unit but does not restart anything. |
| **monitoring** | as docker, for `prometheus.yml`, the Grafana datasource/provider and the dashboards. A changed scrape config sat on disk while Prometheus kept scraping what it read at start. |

## The fix

`Deploy` now writes the files the orchestrator cannot diff for itself through a `changeTracker`, and escalates to `--force-recreate` / `systemctl restart` only when one of them actually changed. Files the orchestrator *does* diff — the compose file — are written directly and deliberately not tracked.

**Idempotency was the constraint, not an afterthought.** Always recreating would be a one-line "fix" that turns every `apply` into a node outage, costing uptime and peer connections. So a missing or unreadable file explicitly does **not** count as a change: there is no running process holding old content, and `Deploy` is about to create one from the new.

## How it was found

A measurement run against a private chain was silently reading a config from disk that the JVM had never seen. `trond network create` with a changed `config_overrides` reported the node `running`; the container's `StartedAt` was unchanged from a deploy several minutes earlier. The numbers that run produced were wrong, with nothing to indicate it.

## Testing

- `make test -race` — 25 packages, 0 failures
- `make lint` — no findings
- `make e2e` — full suite against a real Docker daemon, including `TestE2E_Network_PrivateLifecycle`

**The tests assert on the command trond runs, not on the file it wrote** — the broken versions wrote the file correctly too, so a file-content assertion would pass against the bug. Each new test was confirmed to fail against the previous behaviour: neutralising just the escalation produces 4 failures across the three runtimes, while the three "must **not** restart" cases still pass.

Verified against real Docker end to end:

- identical redeploy → `StartedAt` untouched
- one changed config value → container recreated, and the value reached the JVM: with `maxConcurrentCallsPerConnection = 1`, 50 calls on one connection went from indistinguishable-from-50-connections to **4.28 s vs 1.30 s**, which is the cap doing its job

## Second commit: jar env vars

While reading `jar.go` for the above: the systemd drop-in was written *inside* `for key, val := range opts.EnvVars`, at a fixed path, each iteration truncating the previous one. Only one variable ever reached the service — and Go randomises map iteration order, so **which** one changed between runs of an unchanged intent.

A witness node takes its block-signing key through `EnvVars` (`witness_key.private_key_env`). Deploy it with any second variable set and it starts without its key on some deploys and with it on others.

All variables now go into one drop-in, sorted by key. The sort is not cosmetic: a map-order-dependent rendering would read as "changed" to the detection added in the first commit and restart the node on every deploy.

Only the jar runtime is affected; the docker path passes environment through the compose file.
