### PR TITLE
fix(security): --require-private skipped three node capabilities

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -695,7 +695,17 @@ An automated caller that should only ever touch a throwaway private chain
   var. When set, every mutating verb refuses a non-private node up front
   with `PRIVATE_NETWORK_REQUIRED` (exit 2): `apply`, `network create`, and
   the per-node mutators `start` / `stop` / `restart` / `remove` /
-  `rollback` / `upgrade` / `auto-heal`. The MCP `apply` tool takes the same
+  `rollback` / `upgrade` / `auto-heal`, plus the three that run caller-supplied
+  content against a node: `exec`, `wait --exec` (which is `sh -c <string>` on
+  the node) and `files put` (which writes caller bytes to a caller path,
+  on a jar node to the target host). Those three are gated regardless of
+  what the command or file happens to contain — the capability is the
+  thing being gated, not the payload. Their read counterparts stay
+  allowed: `wait --port` / `wait --http` / `files get` change nothing and
+  refusing them would only make the gate something people switch off.
+  A test derives this list from the source
+  (`cmd/require_private_coverage_test.go`), so a new command that resolves
+  a node must either take the guard or record why it needs none. The MCP `apply` tool takes the same
   gate via a `require_private` argument, and the MCP `auto_heal` tool honours
   the flag/env floor. Proposal-only calls stay allowed: `auto-heal --dry-run`
   / `auto_heal dry_run=true` never starts a node or writes state, so the

--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/spf13/cobra"
 
@@ -50,7 +51,30 @@ func runExec(cmd *cobra.Command, args []string) error {
 		nodeName = args[0]
 		rest = args[1:]
 	}
-	if nodeName == "" || len(rest) == 0 {
+	if nodeName == "" {
+		return output.NewError("VALIDATION_ERROR", output.ExitValidationError,
+			"usage: trond exec <node> -- <cmd> [args...]")
+	}
+
+	// exec runs a caller-supplied program against the node: on a jar node
+	// that is rest[0] on the target host, on a docker node it is
+	// `docker exec <node> ...` inside the container. Either way it is at
+	// least as capable as the verbs that already gate — `trond exec
+	// <mainnet-node> -- rm -rf <datadir>` is a mutation by any reading —
+	// so it takes the same gate.
+	//
+	// Placed here, at the earliest point the node name is known and ahead
+	// of the remaining usage check, so that `--require-private` reports
+	// "not private" rather than a usage error: an agent should learn the
+	// safety fact first. Ahead of resolveNodeContext for the reason
+	// documented on requirePrivateForNode — otherwise an unreachable
+	// mainnet node masks the gate with TARGET_UNREACHABLE.
+	start := time.Now()
+	if err := requirePrivateForNode(nodeName); err != nil {
+		return err
+	}
+
+	if len(rest) == 0 {
 		return output.NewError("VALIDATION_ERROR", output.ExitValidationError,
 			"usage: trond exec <node> -- <cmd> [args...]")
 	}
@@ -82,8 +106,16 @@ func runExec(cmd *cobra.Command, args []string) error {
 	// Always emit captured output even on error — the caller usually wants it.
 	os.Stdout.Write(out)
 	if execErr != nil {
+		writeAudit(auditEvent{Command: "exec", Node: nodeName, Target: nc.Target.String(),
+			Result: "error", ErrorCode: "EXEC_ERROR", Start: start})
 		return output.NewError("EXEC_ERROR", output.ExitGeneralError,
 			fmt.Sprintf("exec on %s failed: %v", nodeName, execErr))
 	}
+	// Audited like every other verb that touches a node. The entry records
+	// that an exec happened, not what ran: AuditEntry has no field for it,
+	// and the argv is the one place a caller is most likely to have put a
+	// token or key. Recording the program name would need a schema change.
+	writeAudit(auditEvent{Command: "exec", Node: nodeName, Target: nc.Target.String(),
+		Result: "success", Start: start})
 	return nil
 }

--- a/cmd/exec_guard_test.go
+++ b/cmd/exec_guard_test.go
@@ -1,0 +1,177 @@
+package cmd
+
+import (
+	"bufio"
+	"encoding/json"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/tronprotocol/tron-deployment/internal/guard"
+	"github.com/tronprotocol/tron-deployment/internal/paths"
+	"github.com/tronprotocol/tron-deployment/internal/state"
+)
+
+// `trond exec` runs a caller-supplied program against a node — on a jar
+// node, directly on the target host. It shipped without the
+// --require-private gate and without an audit entry, while its nine
+// sibling node verbs had both. These tests pin both halves.
+//
+// The gate itself is covered for every verb by
+// TestMutators_RefuseMainnetUnderRequirePrivate; what is here is the
+// exec-specific behaviour that table cannot express.
+
+// seedLocalJarNode writes one node the local target can actually exec
+// against, with the gate OFF. The node is always named "n0" — these
+// tests never need two, and the guard keys off the recorded network, not
+// the name.
+func seedLocalJarNode(t *testing.T, network string) {
+	t.Helper()
+	paths.SetBaseDir(t.TempDir())
+	t.Cleanup(func() { paths.SetBaseDir("") })
+
+	store, err := state.NewStore(paths.State())
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	if err := store.Save(&state.DeploymentState{
+		Version: 1,
+		Nodes: []state.ManagedNode{{
+			Name: "n0", Status: "running", Runtime: "jar", Network: network,
+			Target:      state.NodeTarget{Type: "local"},
+			LastApplied: time.Now().UTC(),
+		}},
+	}); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+}
+
+// auditCommands returns the `command` field of every audit line written.
+func auditCommands(t *testing.T) []string {
+	t.Helper()
+	f, err := os.Open(paths.AuditLog())
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		t.Fatalf("open audit log: %v", err)
+	}
+	defer f.Close()
+
+	var got []string
+	sc := bufio.NewScanner(f)
+	for sc.Scan() {
+		var entry map[string]any
+		if err := json.Unmarshal(sc.Bytes(), &entry); err != nil {
+			t.Fatalf("audit line is not JSON: %v\nraw: %s", err, sc.Bytes())
+		}
+		if c, _ := entry["command"].(string); c != "" {
+			got = append(got, c)
+		}
+	}
+	if err := sc.Err(); err != nil {
+		t.Fatalf("scan audit log: %v", err)
+	}
+	return got
+}
+
+// TestExec_WritesAuditEntry pins that an exec leaves a trace. Without it
+// the one verb that runs arbitrary code is also the only one that runs
+// unrecorded — there is no way to answer "what was run against this
+// node" after the fact.
+func TestExec_WritesAuditEntry(t *testing.T) {
+	tests := []struct {
+		name       string
+		argv       []string
+		wantResult string
+		wantErr    bool
+	}{
+		{"success", []string{"n0", "/bin/echo", "audit-probe"}, "success", false},
+		// The failure path must be audited too: an exec that failed still
+		// ran, and is the more interesting line in an incident review.
+		{"failure", []string{"n0", "/bin/sh", "-c", "exit 3"}, "error", true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			seedLocalJarNode(t, "private")
+
+			err := runExec(newCmd(), tc.argv)
+			if tc.wantErr && err == nil {
+				t.Fatal("want an error from the failing command, got nil")
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("runExec: %v", err)
+			}
+
+			if got := auditCommands(t); len(got) != 1 || got[0] != "exec" {
+				t.Fatalf("audit commands = %v, want exactly [exec]", got)
+			}
+
+			// And the recorded result must match what happened.
+			f, err := os.ReadFile(paths.AuditLog())
+			if err != nil {
+				t.Fatalf("read audit log: %v", err)
+			}
+			var entry map[string]any
+			if err := json.Unmarshal([]byte(strings.TrimSpace(string(f))), &entry); err != nil {
+				t.Fatalf("audit line is not JSON: %v", err)
+			}
+			if entry["result"] != tc.wantResult {
+				t.Errorf("audit result = %v, want %q", entry["result"], tc.wantResult)
+			}
+			if entry["node"] != "n0" {
+				t.Errorf("audit node = %v, want n0", entry["node"])
+			}
+		})
+	}
+}
+
+// TestExec_GateOutranksUsageError pins the precedence: with the gate on
+// and no command supplied, exec reports PRIVATE_NETWORK_REQUIRED rather
+// than a usage error. Same principle as remove's gate-before-confirm —
+// an agent should learn "this node is not private" before it learns it
+// typed the command wrong, because only one of those facts is a safety
+// fact.
+func TestExec_GateOutranksUsageError(t *testing.T) {
+	seedMainnetNode(t, "n0")
+	wantPrivateRequired(t, runExec(newCmd(), []string{"n0"}))
+}
+
+// TestExec_UsageErrorWithoutGate pins the other side: with the gate off,
+// a missing command is still a usage error and not a silent success.
+func TestExec_UsageErrorWithoutGate(t *testing.T) {
+	seedLocalJarNode(t, "private")
+	err := runExec(newCmd(), []string{"n0"})
+	if err == nil {
+		t.Fatal("want VALIDATION_ERROR for a missing command, got nil")
+	}
+	if !strings.Contains(err.Error(), "usage:") {
+		t.Errorf("error = %v, want a usage error", err)
+	}
+	if got := auditCommands(t); len(got) != 0 {
+		t.Errorf("audit written for an invocation that never ran anything: %v", got)
+	}
+}
+
+// TestExec_GateAppliesToDockerRuntime pins that the gate is not
+// jar-specific. A docker node's exec runs `docker exec <node> ...` inside
+// the container, which is still arbitrary code against a mainnet rig.
+func TestExec_GateAppliesToDockerRuntime(t *testing.T) {
+	// seedMainnetNode seeds Runtime: "docker" and turns the gate on.
+	seedMainnetNode(t, "n0")
+	wantPrivateRequired(t, runExec(newCmd(), []string{"n0", "/bin/echo", "hi"}))
+}
+
+// TestExec_GateOffStillRuns is the no-regression case: exec on a
+// non-private node is unchanged when the gate is not requested. The
+// guard is opt-in and must stay that way.
+func TestExec_GateOffStillRuns(t *testing.T) {
+	seedLocalJarNode(t, "mainnet")
+	if guard.Requested() {
+		t.Fatal("gate unexpectedly on; this test asserts default behaviour")
+	}
+	if err := runExec(newCmd(), []string{"n0", "/bin/echo", "unchanged"}); err != nil {
+		t.Fatalf("exec on a mainnet node without the gate must still work: %v", err)
+	}
+}

--- a/cmd/files.go
+++ b/cmd/files.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/spf13/cobra"
 
@@ -58,6 +59,19 @@ func runFilesPut(cmd *cobra.Command, args []string) error {
 	nodeName, localSrc, remoteDst := args[0], args[1], args[2]
 	outputFmt, _ := cmd.Flags().GetString("output")
 
+	// put writes caller-supplied bytes to a caller-supplied path on the
+	// node — on a jar node that is the target host, so it can land a
+	// systemd unit, a node config, or an authorized_keys. That is a
+	// mutation of the rig whatever the file happens to contain, so it
+	// takes the gate. `files get` is the read counterpart and stays
+	// allowed.
+	//
+	// Ahead of resolveNodeContext, per requirePrivateForNode's contract.
+	start := time.Now()
+	if err := requirePrivateForNode(nodeName); err != nil {
+		return err
+	}
+
 	nc, err := resolveNodeContext(nodeName)
 	if err != nil {
 		return err
@@ -74,6 +88,8 @@ func runFilesPut(cmd *cobra.Command, args []string) error {
 	if nc.Node.Runtime == "jar" {
 		// Direct host write via Target.WriteFile.
 		if err := nc.Target.WriteFile(ctx, remoteDst, data, 0o644); err != nil {
+			writeAudit(auditEvent{Command: "files put", Node: nodeName, Target: nc.Target.String(),
+				Result: "error", ErrorCode: "FILES_ERROR", Start: start})
 			return output.NewError("FILES_ERROR", output.ExitGeneralError,
 				fmt.Sprintf("write to %s: %v", remoteDst, err))
 		}
@@ -98,11 +114,17 @@ func runFilesPut(cmd *cobra.Command, args []string) error {
 		stage.Close()
 
 		if _, err := nc.Target.Exec(ctx, "docker", "cp", stagePath, fmt.Sprintf("%s:%s", nodeName, remoteDst)); err != nil {
+			writeAudit(auditEvent{Command: "files put", Node: nodeName, Target: nc.Target.String(),
+				Result: "error", ErrorCode: "FILES_ERROR", Start: start})
 			return output.NewError("FILES_ERROR", output.ExitGeneralError,
 				fmt.Sprintf("docker cp into %s: %v", nodeName, err))
 		}
 	}
 
+	// Audited like the other verbs that change a node. Records that bytes
+	// were written and where, not their contents.
+	writeAudit(auditEvent{Command: "files put", Node: nodeName, Target: nc.Target.String(),
+		Result: "success", Start: start})
 	return writeFilesResult(outputFmt, "put", nodeName, localSrc, remoteDst, len(data))
 }
 

--- a/cmd/require_private_coverage_test.go
+++ b/cmd/require_private_coverage_test.go
@@ -1,0 +1,98 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// `trond exec`, `trond wait --exec` and `trond files put` all shipped able
+// to act on a mainnet node while --require-private was set. Each was an
+// individual oversight, but they share one shape: the file resolves a node
+// context and then does something to that node, and nobody noticed the
+// guard was missing because there was no place that would notice.
+//
+// TestNodeTouchingCommandsCallTheGuard is that place. It derives the set
+// of node-touching commands from the source rather than from a hand-kept
+// list, so a new command cannot be added to the tree and quietly skip the
+// gate: resolving a node makes you either call the guard or write down
+// here, with a reason, why you don't need to.
+//
+// The behavioural half — that the guard actually refuses — lives in
+// TestMutators_RefuseMainnetUnderRequirePrivate and the exec/wait/files
+// tests. This test only pins that nothing is *unconsidered*.
+func TestNodeTouchingCommandsCallTheGuard(t *testing.T) {
+	// Files that resolve a node context but legitimately need no gate.
+	// Every entry is a read: the gate exists to stop mutation of a
+	// non-private rig, and refusing reads would make it useless for the
+	// thing it is for (waiting on, inspecting and debugging real nodes).
+	//
+	// Adding a name here is a decision, not a formality. If the command
+	// can change the node or run code against it, it belongs on the other
+	// side.
+	readOnly := map[string]string{
+		"diagnose.go": "read-only diagnostics: inspects state, container status and logs, " +
+			"writes nothing to the node",
+		"health.go": "read-only probe: curls the node's own HTTP endpoint",
+		"logs.go":   "streams the node's logs; no writes, no caller-supplied execution",
+		"verify_config.go": "reads the deployed config back off the node (cat) to diff it " +
+			"against the intent; no writes",
+	}
+
+	entries, err := os.ReadDir(".")
+	if err != nil {
+		t.Fatalf("read cmd dir: %v", err)
+	}
+
+	var unguarded []string
+	seenReadOnly := map[string]bool{}
+	for _, e := range entries {
+		name := e.Name()
+		if e.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		src, err := os.ReadFile(filepath.Join(".", name))
+		if err != nil {
+			t.Fatalf("read %s: %v", name, err)
+		}
+		body := string(src)
+		if !strings.Contains(body, "resolveNodeContext(") {
+			continue
+		}
+		if strings.Contains(body, "requirePrivateForNode") {
+			// Guarded. If it is ALSO on the read-only list that is a
+			// contradiction worth surfacing.
+			if _, ok := readOnly[name]; ok {
+				t.Errorf("%s calls requirePrivateForNode but is listed as read-only; "+
+					"remove it from the readOnly map", name)
+			}
+			continue
+		}
+		if reason, ok := readOnly[name]; ok {
+			seenReadOnly[name] = true
+			if strings.TrimSpace(reason) == "" {
+				t.Errorf("%s is listed as read-only with an empty reason", name)
+			}
+			continue
+		}
+		unguarded = append(unguarded, name)
+	}
+
+	if len(unguarded) > 0 {
+		t.Errorf("these files resolve a node but never call requirePrivateForNode: %v\n"+
+			"Either add the guard (see cmd/stop.go for the canonical shape), or add the "+
+			"file to the readOnly map above with the reason it cannot mutate the node.\n"+
+			"This is the check that `trond exec`, `trond wait --exec` and `trond files put` "+
+			"each got past.", unguarded)
+	}
+
+	// A stale allowlist is its own bug: it means someone added the guard
+	// (or deleted the command) and left a note claiming otherwise.
+	for name := range readOnly {
+		if !seenReadOnly[name] {
+			t.Errorf("readOnly lists %q, but that file no longer resolves a node "+
+				"without a guard — drop the entry", name)
+		}
+	}
+}

--- a/cmd/require_private_mutators_test.go
+++ b/cmd/require_private_mutators_test.go
@@ -76,6 +76,13 @@ func TestMutators_RefuseMainnetUnderRequirePrivate(t *testing.T) {
 		"upgrade":   runUpgrade,
 		"remove":    runRemove,
 		"auto-heal": runAutoHeal,
+		// exec runs a caller-supplied program against the node — on a jar
+		// node directly on the target host. Its absence from this table is
+		// what let it ship ungated: every sibling was covered, so the table
+		// looked exhaustive. Note the args here are just {"n0"}: exec gates
+		// before its own "no command supplied" usage check precisely so the
+		// safety fact outranks the usage error.
+		"exec": runExec,
 	}
 	for name, run := range mutators {
 		t.Run(name, func(t *testing.T) {

--- a/cmd/wait.go
+++ b/cmd/wait.go
@@ -98,6 +98,20 @@ func runWait(cmd *cobra.Command, args []string) error {
 			"specify exactly one of --port, --http, --exec")
 	}
 
+	// --exec runs `sh -c <caller string>` on the node (probeExec below), so
+	// under the gate it is the same capability as `trond exec` and takes
+	// the same refusal. --port and --http stay allowed: those are read
+	// probes, and waiting for a mainnet node to come up is exactly the
+	// non-mutating call the gate is documented to permit (same reasoning
+	// as `auto-heal --dry-run`).
+	//
+	// Ahead of resolveNodeContext, per requirePrivateForNode's contract.
+	if waitExec != "" {
+		if err := requirePrivateForNode(nodeName); err != nil {
+			return err
+		}
+	}
+
 	nc, err := resolveNodeContext(nodeName)
 	if err != nil {
 		return err

--- a/cmd/wait_files_guard_test.go
+++ b/cmd/wait_files_guard_test.go
@@ -1,0 +1,159 @@
+package cmd
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/tronprotocol/tron-deployment/internal/guard"
+	"github.com/tronprotocol/tron-deployment/internal/output"
+)
+
+// `trond wait --exec` and `trond files put` were the two capabilities that
+// survived gating `trond exec`: --exec runs `sh -c <caller string>` on the
+// node (cmd/wait.go probeExec) and files put writes caller bytes to a
+// caller path on it. Both reached a mainnet node with --require-private
+// set, and neither left an audit entry.
+//
+// The asymmetry each pair pins is the point: the mutating half refuses,
+// the reading half must keep working. A gate that also blocks reads would
+// be turned off, and then it protects nothing.
+
+// newWaitCmd is newCmd plus the flags runWait reads directly off the
+// command (json-gt, whose Changed bit disambiguates "0" from "unset").
+func newWaitCmd() *cobra.Command {
+	c := newCmd()
+	c.Flags().Float64("json-gt", 0, "")
+	return c
+}
+
+// resetWaitFlags clears the package-level probe selectors between cases —
+// runWait requires exactly one to be set.
+func resetWaitFlags(t *testing.T) {
+	t.Helper()
+	oPort, oHTTP, oExec := waitPort, waitHTTP, waitExec
+	oTimeout, oInterval := waitTimeout, waitInterval
+	waitPort, waitHTTP, waitExec = 0, "", ""
+	waitTimeout, waitInterval = 300*time.Millisecond, 50*time.Millisecond
+	t.Cleanup(func() {
+		waitPort, waitHTTP, waitExec = oPort, oHTTP, oExec
+		waitTimeout, waitInterval = oTimeout, oInterval
+	})
+}
+
+func TestWaitExec_RefusesNonPrivateNodeUnderGate(t *testing.T) {
+	resetWaitFlags(t)
+	seedMainnetNode(t, "n0")
+	waitExec = "echo owned"
+
+	// Pre-fix this returned "ready", exit 0, having run the command.
+	wantPrivateRequired(t, runWait(newWaitCmd(), []string{"n0"}))
+}
+
+// TestWaitReadProbes_StillAllowedUnderGate is the half that must NOT
+// regress: waiting for a mainnet node to answer is a read, and the gate
+// is documented to permit non-mutating calls (the `auto-heal --dry-run`
+// precedent). These probes fail here — nothing is listening — but they
+// must fail as probes, not as PRIVATE_NETWORK_REQUIRED.
+func TestWaitReadProbes_StillAllowedUnderGate(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		apply func()
+	}{
+		{"port", func() { waitPort = 1 }},
+		{"http", func() { waitHTTP = "http://127.0.0.1:1/health" }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			resetWaitFlags(t)
+			seedMainnetNode(t, "n0")
+			tc.apply()
+
+			err := runWait(newWaitCmd(), []string{"n0"})
+			if err == nil {
+				return // nothing is listening, but a pass is not a gate failure
+			}
+			var se *output.StructuredError
+			if errors.As(err, &se) && se.Code == "PRIVATE_NETWORK_REQUIRED" {
+				t.Fatalf("read probe --%s refused by the private gate; the gate is for "+
+					"mutation, and blocking reads makes it something people switch off", tc.name)
+			}
+		})
+	}
+}
+
+func TestFilesPut_RefusesNonPrivateNodeUnderGate(t *testing.T) {
+	seedMainnetNode(t, "n0")
+	src := filepath.Join(t.TempDir(), "payload")
+	if err := os.WriteFile(src, []byte("payload"), 0o600); err != nil {
+		t.Fatalf("write payload: %v", err)
+	}
+	dst := filepath.Join(t.TempDir(), "written")
+
+	// Pre-fix this wrote the file and reported success.
+	wantPrivateRequired(t, runFilesPut(newCmd(), []string{"n0", src, dst}))
+
+	if _, err := os.Stat(dst); !os.IsNotExist(err) {
+		t.Errorf("destination exists after a refused put — the guard ran too late")
+	}
+}
+
+// TestFilesGet_AllowedUnderGate pins the read counterpart. get pulls a
+// file off the node and changes nothing on it, so the gate must not
+// refuse it.
+func TestFilesGet_AllowedUnderGate(t *testing.T) {
+	seedLocalJarNode(t, "mainnet")
+	old := guard.FlagValue
+	guard.FlagValue = true
+	t.Cleanup(func() { guard.FlagValue = old })
+
+	src := filepath.Join(t.TempDir(), "on-node")
+	if err := os.WriteFile(src, []byte("readable"), 0o600); err != nil {
+		t.Fatalf("seed remote file: %v", err)
+	}
+	dst := filepath.Join(t.TempDir(), "pulled")
+
+	if err := runFilesGet(newCmd(), []string{"n0", src, dst}); err != nil {
+		t.Fatalf("files get refused under the gate: %v", err)
+	}
+	got, err := os.ReadFile(dst)
+	if err != nil || string(got) != "readable" {
+		t.Errorf("get did not deliver the file: %q, %v", got, err)
+	}
+}
+
+func TestFilesPut_WritesAuditEntry(t *testing.T) {
+	seedLocalJarNode(t, "private")
+	src := filepath.Join(t.TempDir(), "payload")
+	if err := os.WriteFile(src, []byte("payload"), 0o600); err != nil {
+		t.Fatalf("write payload: %v", err)
+	}
+	dst := filepath.Join(t.TempDir(), "written")
+
+	if err := runFilesPut(newCmd(), []string{"n0", src, dst}); err != nil {
+		t.Fatalf("runFilesPut: %v", err)
+	}
+	got := auditCommands(t)
+	if len(got) != 1 || got[0] != "files put" {
+		t.Fatalf("audit commands = %v, want exactly [\"files put\"] — writing bytes to a "+
+			"node is a change to it and has to be recoverable from the log", got)
+	}
+}
+
+// TestWaitExec_GateOffStillRuns is the no-regression case for wait.
+func TestWaitExec_GateOffStillRuns(t *testing.T) {
+	resetWaitFlags(t)
+	seedLocalJarNode(t, "mainnet")
+	marker := filepath.Join(t.TempDir(), "ran")
+	waitExec = "touch " + marker
+
+	if err := runWait(newWaitCmd(), []string{"n0"}); err != nil {
+		t.Fatalf("wait --exec without the gate must still work: %v", err)
+	}
+	if _, err := os.Stat(marker); err != nil {
+		t.Errorf("wait --exec did not run the command: %v", err)
+	}
+}


### PR DESCRIPTION
`--require-private` / `TROND_REQUIRE_PRIVATE` is documented as a one-way floor that makes an unattended agent *"mechanically incapable of mutating a mainnet/nile rig"* (`AGENTS.md:701-704`). Three commands reached a mainnet node with the gate fully on, and none of them left an audit entry.

## What was open

| command | what it does on the node | gated | audited |
|---|---|---|---|
| `trond exec <node> -- <cmd>` | on a `runtime:jar` node, `rest[0]` → `Target.Exec` → bare `exec.CommandContext` on the host | no | no |
| `trond wait <node> --exec '<cmd>'` | `probeExec` runs `sh -c <caller string>` on the node | no | no |
| `trond files put <node> <src> <dst>` | writes caller bytes to a caller path; on a jar node, the target host | no | no |

`exec` is the plainest case: `cmd/exec.go` called neither `requirePrivateForNode` nor `writeAudit`, while nine sibling node verbs called the guard and seven wrote audit.

`wait --exec` is the same capability with a poll loop around it — and worse in one respect, because it reports `ready` and exits 0, so it does not read as having run anything.

`files put` is the write primitive to pair with them: on a jar node it can land a systemd unit, a node config, or an `authorized_keys`.

## Reproduction

Seeded state, one node `prod-mainnet` with `"network":"mainnet"`, `"runtime":"jar"`, `"target":{"type":"local"}`. Gate on via the flag **and** the env floor.

Before:

```
$ trond --require-private stop prod-mainnet -o json
{"error_code":"PRIVATE_NETWORK_REQUIRED", ..., "exit_code":2}

$ trond --require-private exec prod-mainnet -- /bin/sh -c 'id -un'
barbatos

$ trond --require-private wait prod-mainnet --exec 'echo owned > /tmp/PWNED'
ready after 1 attempts (67ms)          # file written

$ TROND_REQUIRE_PRIVATE=1 trond files put prod-mainnet ./payload /tmp/WRITTEN
put prod-mainnet: ./payload -> /tmp/WRITTEN (21 bytes)

$ ls audit.log
(no such file)
```

After: all three return `PRIVATE_NETWORK_REQUIRED`, neither payload file is created, and `exec` / `files put` write audit entries.

## The fix

Each calls `requirePrivateForNode` **ahead of** `resolveNodeContext`, per that helper's documented contract — otherwise an unreachable mainnet node masks the gate with `TARGET_UNREACHABLE`. `exec` and `files put` also `writeAudit` on both the success and error paths.

**The read halves stay allowed, deliberately.** `wait --port`, `wait --http` and `files get` change nothing on the node, and waiting on or reading from a real node is exactly what the gate is documented to permit (the `auto-heal --dry-run` precedent). A gate that also blocks reads is a gate people switch off, and then it protects nothing. `wait` therefore gates only when `--exec` is supplied. Tests pin both directions.

`exec` gates before its own "no command supplied" usage check, so `--require-private exec <mainnet-node>` reports `PRIVATE_NETWORK_REQUIRED` rather than a usage error — the same precedence `remove` already applies between the gate and its confirmation prompt (`TestRemove_PrivateGuardPrecedesConfirm`). An agent should learn the safety fact first.

## Why it went unnoticed, and the second commit

`cmd/require_private_mutators_test.go` enumerated the gated verbs. Every sibling was in it, so the table looked exhaustive — but a table can only prove the verbs listed in it behave; it cannot report one nobody thought to add.

The second commit adds `TestNodeTouchingCommandsCallTheGuard`, which **derives** the set from the source rather than from a hand-kept list: any `cmd/*.go` calling `resolveNodeContext` must either call `requirePrivateForNode` or appear in an explicit read-only map with a reason. It also fails on a *stale* allowlist entry, since a note claiming something untrue is how this class survives review.

Modelled on `TestSchemaCoverage`, which already walks the command tree with an explicit gaps-with-reasons map.

Verified effective: removing the guard from `wait.go` makes it fail naming `wait.go`. It also caught a mistake in its own first draft — `resolve.go` was listed as read-only when it actually defines the guard.

## Testing

- `make test -race` — 25 packages, 0 failures
- `make lint` — no findings
- `exec` added to the existing mutator table; confirmed the subtest fails against the unfixed code
- New behavioural tests: audit written on success **and** failure, gate/usage precedence, gate applies to the docker runtime, read probes still allowed, `files get` still allowed, and a gate-off no-regression case for each of the three commands

## Deliberately not done

- **The audit entries record the capability and the node, not the payload.** `AuditEntry` has no field for it, and argv / file contents are exactly where a caller is most likely to have put a token or key. Adding a field pulls in the schema drift test and the version baseline, so it is flagged rather than done quietly here — but for the verbs whose payload *is* the action, this is a real gap worth a follow-up.
- **`wait --http` and `health` pass a caller-controlled URL into `curl`'s argv** (`-K<path>`, `-o<path>` are reachable). That is argv, not shell, and read-side rather than mutating, so it is a different class from the above and not addressed here. Worth a validation pass on the URL.
- **`files get` and `verify-config` can read arbitrary paths off a node**, which is a disclosure question (a jar node's config carries `localwitness`) rather than a mutation one. The gate is scoped to mutation; this needs its own decision.
