### PR TITLE
fix(recipe): steps ran outside the parent's state and safety context

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -705,7 +705,11 @@ An automated caller that should only ever touch a throwaway private chain
   refusing them would only make the gate something people switch off.
   A test derives this list from the source
   (`cmd/require_private_coverage_test.go`), so a new command that resolves
-  a node must either take the guard or record why it needs none. The MCP `apply` tool takes the same
+  a node must either take the guard or record why it needs none.
+  `recipe run` forwards the gate (and `--state-dir`) into every step it
+  re-execs, so a gated recipe run is gated all the way down — previously
+  only the `TROND_REQUIRE_PRIVATE` form crossed that boundary, because a
+  child process inherits the environment but not a flag. The MCP `apply` tool takes the same
   gate via a `require_private` argument, and the MCP `auto_heal` tool honours
   the flag/env floor. Proposal-only calls stay allowed: `auto-heal --dry-run`
   / `auto_heal dry_run=true` never starts a node or writes state, so the

--- a/cmd/recipe.go
+++ b/cmd/recipe.go
@@ -7,7 +7,9 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/tronprotocol/tron-deployment/internal/guard"
 	"github.com/tronprotocol/tron-deployment/internal/output"
+	"github.com/tronprotocol/tron-deployment/internal/paths"
 	"github.com/tronprotocol/tron-deployment/internal/recipe"
 )
 
@@ -165,13 +167,28 @@ func runRecipeRun(cmd *cobra.Command, args []string) error {
 		exe = os.Args[0]
 	}
 
+	// Dry-run prints its plan to Out. In json mode that is the same stream
+	// the RunResult goes to, so the plan lines land in front of the JSON
+	// and nothing downstream can parse it. Send progress to stderr there
+	// and leave text mode's stdout behaviour alone.
+	planOut := cmd.OutOrStdout()
+	if outputFmt == "json" {
+		planOut = cmd.ErrOrStderr()
+	}
+
 	res, runErr := recipe.Run(cmd.Context(), r, recipe.RunOptions{
 		Binary:     exe,
 		Params:     params,
 		DryRun:     recipeRunDryRun,
 		ResumeFrom: recipeRunResumeFrom,
-		Out:        cmd.OutOrStdout(),
+		Out:        planOut,
 		Err:        cmd.ErrOrStderr(),
+		// Steps are re-execs of this binary and inherit none of our flags.
+		// Forward the two that decide WHERE a step acts and WHETHER it is
+		// allowed to. paths.BaseDir() is the parent's already-resolved
+		// directory, so this covers --state-dir and TROND_STATE_DIR alike.
+		StateDir:       paths.BaseDir(),
+		RequirePrivate: guard.Requested(),
 	})
 
 	if outputFmt == "json" && res != nil {
@@ -181,9 +198,19 @@ func runRecipeRun(cmd *cobra.Command, args []string) error {
 			res.Recipe, res.Status, len(res.Steps), res.DurationMs)
 	}
 	if runErr != nil {
-		// Already-structured error envelope for the runErr path; if
-		// not structured, wrap it once.
-		return output.NewError("RECIPE_FAILED", output.ExitGeneralError, runErr.Error())
+		// Carry the failing step's exit code rather than flattening every
+		// failure to 1. A step refused by the private gate exits 2, and an
+		// agent that sees 1 learns "something broke" where the truth was
+		// "refused, and here is why".
+		exit := output.ExitGeneralError
+		if res != nil && res.FailedAt != "" {
+			for _, st := range res.Steps {
+				if st.ID == res.FailedAt && st.ExitCode > 0 {
+					exit = st.ExitCode
+				}
+			}
+		}
+		return output.NewError("RECIPE_FAILED", exit, runErr.Error())
 	}
 	return nil
 }

--- a/internal/recipe/runner.go
+++ b/internal/recipe/runner.go
@@ -39,6 +39,22 @@ type RunOptions struct {
 	// final RunResult.
 	Out io.Writer
 	Err io.Writer
+
+	// StateDir is the parent's resolved state directory, forwarded to
+	// every step. Without it a run started with --state-dir reads its
+	// recipe from one state and executes every step against ~/.trond —
+	// two different states, with nothing in the output to say so.
+	StateDir string
+
+	// RequirePrivate mirrors guard.Requested() in the parent.
+	//
+	// The gate is `flag OR inherited env` (internal/guard). The env form
+	// crosses into a re-exec'd step for free; the flag form is a
+	// process-local package var and does not. So without this,
+	// `trond --require-private recipe run X` runs every step ungated,
+	// while the identical run started with TROND_REQUIRE_PRIVATE=1 is
+	// gated — the safety floor would depend on which way you asked for it.
+	RequirePrivate bool
 }
 
 // Run executes a recipe. Returns a RunResult plus error; the error is
@@ -105,6 +121,15 @@ func Run(ctx context.Context, r Recipe, opts RunOptions) (*RunResult, error) {
 		stepResult, err := runStep(ctx, opts, step, args)
 		result.Steps = append(result.Steps, stepResult)
 
+		// Persist BEFORE the failure switch. Rollback steps exist to clean
+		// up after a failed step and routinely need that step's output —
+		// the shipped fresh-mainnet recipe's rollback references
+		// {{ steps.apply.name }}, and its own comment says rollback runs
+		// only when apply fails. Persisting after the switch meant the one
+		// case the reference was written for was the one case where the
+		// key did not exist. `on_failure: continue` lost it the same way.
+		persistStep(stepsState, step, stepResult)
+
 		if err != nil {
 			switch step.OnFailure {
 			case "continue":
@@ -127,22 +152,44 @@ func Run(ctx context.Context, r Recipe, opts RunOptions) (*RunResult, error) {
 			}
 		}
 
-		// Persist the named output fields for downstream substitution.
-		if len(step.Persist) > 0 && stepResult.Output != nil {
-			persisted := map[string]any{}
-			for _, k := range step.Persist {
-				if v, ok := stepResult.Output[k]; ok {
-					persisted[k] = v
-				}
-			}
-			stepsState[step.ID] = persisted
-		} else {
-			stepsState[step.ID] = stepResult.Output
-		}
+	}
+
+	// A --resume-from that matched nothing skipped every step and returned
+	// "success" with no work done. A typo'd step ID is the likely cause,
+	// and reporting it as a clean run is the worst possible answer.
+	if skipping {
+		result.Status = "failed"
+		result.DurationMs = time.Since(start).Milliseconds()
+		return result, fmt.Errorf("--resume-from %q matched no step in recipe %q (steps: %s)",
+			opts.ResumeFrom, r.Name, stepIDs(r.Steps))
 	}
 
 	result.DurationMs = time.Since(start).Milliseconds()
 	return result, nil
+}
+
+// persistStep records the step's output for {{ steps.<id>.<field> }}
+// substitution, honouring an explicit persist list when present.
+func persistStep(state map[string]map[string]any, step Step, res StepResult) {
+	if len(step.Persist) > 0 && res.Output != nil {
+		persisted := map[string]any{}
+		for _, k := range step.Persist {
+			if v, ok := res.Output[k]; ok {
+				persisted[k] = v
+			}
+		}
+		state[step.ID] = persisted
+		return
+	}
+	state[step.ID] = res.Output
+}
+
+func stepIDs(steps []Step) string {
+	ids := make([]string, 0, len(steps))
+	for _, s := range steps {
+		ids = append(ids, s.ID)
+	}
+	return strings.Join(ids, ", ")
 }
 
 // runStep handles a single step's exec + output capture.
@@ -153,8 +200,22 @@ func runStep(ctx context.Context, opts RunOptions, step Step, args []string) (St
 		return res, errors.New(res.Error)
 	}
 
-	full := append(strings.Fields(step.Command), args...)
+	// Global flags go immediately after the subcommand path, never at the
+	// end. A step's own args may contain "--" (every `exec` step does),
+	// and anything after it belongs to the inner command: appending
+	// "--output json" there passed those two tokens to the program being
+	// exec'd AND left trond itself in text mode. Cobra accepts persistent
+	// flags anywhere before the "--", so this position is both correct
+	// and the only one that stays correct for every step.
+	full := strings.Fields(step.Command)
 	full = append(full, "--output", "json")
+	if opts.StateDir != "" {
+		full = append(full, "--state-dir", opts.StateDir)
+	}
+	if opts.RequirePrivate {
+		full = append(full, "--require-private")
+	}
+	full = append(full, args...)
 
 	if opts.DryRun {
 		fmt.Fprintf(opts.Out, "  [%s] would run: %s %s\n", step.ID, opts.Binary, strings.Join(full, " "))

--- a/internal/recipe/step_context_test.go
+++ b/internal/recipe/step_context_test.go
@@ -1,0 +1,250 @@
+package recipe
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// A recipe step is a re-exec of the trond binary, and it inherits none of
+// the parent's flags. That made a step act in a different place, and under
+// a different safety policy, than the run that launched it — with nothing
+// in the output to say so.
+//
+// These tests assert on the argv the runner actually builds, because argv
+// is the only thing that decides what the child does.
+
+// argvRecorder returns a fake "trond" that appends its own argv, one JSON
+// array per invocation, to a file — plus the path of that file.
+func argvRecorder(t *testing.T) (bin, log string) {
+	t.Helper()
+	dir := t.TempDir()
+	log = filepath.Join(dir, "argv.jsonl")
+	bin = filepath.Join(dir, "fake-trond")
+	script := "#!/bin/sh\n" +
+		"printf '[' >> " + log + "\n" +
+		"sep=''\n" +
+		"for a in \"$@\"; do printf '%s\"%s\"' \"$sep\" \"$a\" >> " + log + "; sep=','; done\n" +
+		"printf ']\\n' >> " + log + "\n" +
+		"echo '{}'\n"
+	if err := os.WriteFile(bin, []byte(script), 0o700); err != nil {
+		t.Fatalf("write fake binary: %v", err)
+	}
+	return bin, log
+}
+
+func readArgv(t *testing.T, log string) [][]string {
+	t.Helper()
+	raw, err := os.ReadFile(log)
+	if err != nil {
+		t.Fatalf("read argv log: %v", err)
+	}
+	var out [][]string
+	for _, line := range strings.Split(strings.TrimSpace(string(raw)), "\n") {
+		if line == "" {
+			continue
+		}
+		var argv []string
+		if err := json.Unmarshal([]byte(line), &argv); err != nil {
+			t.Fatalf("argv line %q: %v", line, err)
+		}
+		out = append(out, argv)
+	}
+	return out
+}
+
+func TestRun_ForwardsStateDirAndGateToSteps(t *testing.T) {
+	bin, log := argvRecorder(t)
+	r := Recipe{Name: "t", Steps: []Step{{ID: "s1", Command: "status", Args: []string{"n0"}}}}
+
+	if _, err := Run(context.Background(), r, RunOptions{
+		Binary: bin, Out: io.Discard, Err: io.Discard,
+		StateDir: "/tmp/isolated-state", RequirePrivate: true,
+	}); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	argv := readArgv(t, log)
+	if len(argv) != 1 {
+		t.Fatalf("want 1 invocation, got %d: %v", len(argv), argv)
+	}
+	joined := strings.Join(argv[0], " ")
+	for _, want := range []string{"--state-dir /tmp/isolated-state", "--require-private"} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("child argv missing %q — the step would act outside the parent's "+
+				"state/safety context.\ngot: %v", want, argv[0])
+		}
+	}
+}
+
+// TestRun_OmitsUnsetForwarding keeps the forwarding honest: a run with no
+// state dir and no gate must not invent either.
+func TestRun_OmitsUnsetForwarding(t *testing.T) {
+	bin, log := argvRecorder(t)
+	r := Recipe{Name: "t", Steps: []Step{{ID: "s1", Command: "status", Args: []string{"n0"}}}}
+
+	if _, err := Run(context.Background(), r, RunOptions{
+		Binary: bin, Out: io.Discard, Err: io.Discard,
+	}); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	joined := strings.Join(readArgv(t, log)[0], " ")
+	if strings.Contains(joined, "--state-dir") || strings.Contains(joined, "--require-private") {
+		t.Errorf("forwarded a flag that was never set: %s", joined)
+	}
+}
+
+// TestRun_GlobalFlagsPrecedeDoubleDash is the argv-position property.
+// Every `exec` step carries a "--", and everything after it belongs to the
+// inner command: trond's own flags appended at the end were handed to the
+// program being exec'd instead, while trond stayed in text mode.
+func TestRun_GlobalFlagsPrecedeDoubleDash(t *testing.T) {
+	bin, log := argvRecorder(t)
+	r := Recipe{Name: "t", Steps: []Step{{
+		ID: "s1", Command: "exec",
+		Args: []string{"n0", "--", "/bin/echo", "hello"},
+	}}}
+
+	if _, err := Run(context.Background(), r, RunOptions{
+		Binary: bin, Out: io.Discard, Err: io.Discard,
+		StateDir: "/tmp/sd", RequirePrivate: true,
+	}); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	argv := readArgv(t, log)[0]
+	dash := -1
+	for i, a := range argv {
+		if a == "--" {
+			dash = i
+			break
+		}
+	}
+	if dash == -1 {
+		t.Fatalf("the step's own -- vanished from argv: %v", argv)
+	}
+	for i, a := range argv {
+		switch a {
+		case "--output", "--state-dir", "--require-private":
+			if i > dash {
+				t.Errorf("%s at index %d is AFTER the -- at %d; it would be passed to the "+
+					"inner command instead of to trond.\nargv: %v", a, i, dash, argv)
+			}
+		}
+	}
+	// And the inner command must arrive intact.
+	if got := strings.Join(argv[dash+1:], " "); got != "/bin/echo hello" {
+		t.Errorf("inner command = %q, want %q", got, "/bin/echo hello")
+	}
+}
+
+// TestRun_ResumeFromUnknownStepFails: a --resume-from that matches nothing
+// skipped every step and returned status "success" with no work done.
+func TestRun_ResumeFromUnknownStepFails(t *testing.T) {
+	bin, _ := argvRecorder(t)
+	r := Recipe{Name: "t", Steps: []Step{
+		{ID: "first", Command: "status"},
+		{ID: "second", Command: "status"},
+	}}
+
+	res, err := Run(context.Background(), r, RunOptions{
+		Binary: bin, Out: io.Discard, Err: io.Discard,
+		ResumeFrom: "secnod", // typo
+	})
+	if err == nil {
+		t.Fatal("want an error for an unmatched --resume-from, got nil (a run that did " +
+			"nothing at all reported success)")
+	}
+	if res.Status != "failed" {
+		t.Errorf("status = %q, want failed", res.Status)
+	}
+	for _, want := range []string{"secnod", "first, second"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error %q should name %q so the typo is obvious", err, want)
+		}
+	}
+}
+
+// TestRun_RollbackSeesFailedStepOutput: rollback exists to clean up after
+// the step that failed, so it needs that step's output. Persisting after
+// the failure switch meant the one case the reference was written for was
+// the one case where the key was missing.
+func TestRun_RollbackSeesFailedStepOutput(t *testing.T) {
+	dir := t.TempDir()
+	log := filepath.Join(dir, "argv.jsonl")
+	bin := filepath.Join(dir, "fake-trond")
+	// First call emits a name then fails; later calls (the rollback)
+	// record their argv so we can see what was substituted.
+	script := "#!/bin/sh\n" +
+		"if [ ! -f " + dir + "/ran ]; then touch " + dir + "/ran; echo '{\"name\":\"node-7\"}'; exit 1; fi\n" +
+		"printf '[' >> " + log + "; sep=''\n" +
+		"for a in \"$@\"; do printf '%s\"%s\"' \"$sep\" \"$a\" >> " + log + "; sep=','; done\n" +
+		"printf ']\\n' >> " + log + "\n" +
+		"echo '{}'\n"
+	if err := os.WriteFile(bin, []byte(script), 0o700); err != nil {
+		t.Fatalf("write fake binary: %v", err)
+	}
+
+	r := Recipe{
+		Name:  "t",
+		Steps: []Step{{ID: "apply", Command: "apply", OnFailure: "rollback"}},
+		Rollback: []Step{{
+			ID: "stop-failed-node", Command: "stop",
+			Args: []string{"{{ steps.apply.name }}"},
+		}},
+	}
+	res, err := Run(context.Background(), r, RunOptions{Binary: bin, Out: io.Discard, Err: io.Discard})
+	if err == nil {
+		t.Fatal("want the apply failure to surface")
+	}
+	if !res.RollbackRan {
+		t.Fatal("rollback did not run")
+	}
+	if len(res.RollbackSteps) != 1 || res.RollbackSteps[0].Error != "" {
+		t.Fatalf("rollback step errored: %+v", res.RollbackSteps)
+	}
+	argv := readArgv(t, log)
+	if len(argv) != 1 {
+		t.Fatalf("want 1 rollback invocation, got %v", argv)
+	}
+	if got := strings.Join(argv[0], " "); !strings.Contains(got, "node-7") {
+		t.Errorf("rollback argv = %v; {{ steps.apply.name }} did not resolve to the failed "+
+			"step's output", argv[0])
+	}
+}
+
+// TestRun_ContinueKeepsStepOutput: on_failure: continue jumped the persist
+// block too, so a later step referencing the failed one got a missing key.
+func TestRun_ContinueKeepsStepOutput(t *testing.T) {
+	dir := t.TempDir()
+	log := filepath.Join(dir, "argv.jsonl")
+	bin := filepath.Join(dir, "fake-trond")
+	script := "#!/bin/sh\n" +
+		"if [ ! -f " + dir + "/ran ]; then touch " + dir + "/ran; echo '{\"name\":\"node-9\"}'; exit 1; fi\n" +
+		"printf '[' >> " + log + "; sep=''\n" +
+		"for a in \"$@\"; do printf '%s\"%s\"' \"$sep\" \"$a\" >> " + log + "; sep=','; done\n" +
+		"printf ']\\n' >> " + log + "\n" +
+		"echo '{}'\n"
+	if err := os.WriteFile(bin, []byte(script), 0o700); err != nil {
+		t.Fatalf("write fake binary: %v", err)
+	}
+
+	r := Recipe{Name: "t", Steps: []Step{
+		{ID: "probe", Command: "health", OnFailure: "continue"},
+		{ID: "after", Command: "status", Args: []string{"{{ steps.probe.name }}"}},
+	}}
+	if _, err := Run(context.Background(), r, RunOptions{Binary: bin, Out: io.Discard, Err: io.Discard}); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	argv := readArgv(t, log)
+	if len(argv) != 1 {
+		t.Fatalf("want the second step to have run, got %v", argv)
+	}
+	if got := strings.Join(argv[0], " "); !strings.Contains(got, "node-9") {
+		t.Errorf("argv = %v; a continued step's output was dropped", argv[0])
+	}
+}


### PR DESCRIPTION
A recipe step is a re-exec of the trond binary, and `runStep` built its argv as exactly `command + args + ["--output","json"]`. Nothing else was forwarded, so every step ran with none of the parent's global flags.

## The safety consequence

The private gate is `flag OR inherited env` (`internal/guard`). A child process inherits the environment but not a flag, so:

```
TROND_REQUIRE_PRIVATE=1 trond recipe run X   -> steps gated
trond --require-private recipe run X         -> steps NOT gated
```

Confirmed by probe: an in-memory recipe whose step was `exec` against a mainnet node returned exit 2 under the env form and exit 0 otherwise. The floor depended on which way you asked for it, which is the one property a floor must not have.

## The correctness consequence

`--state-dir` was dropped the same way, so a run against an isolated state dir read its recipe from one state and executed every step against `~/.trond`.

Both are now forwarded, positioned immediately after the subcommand path rather than appended. **Position matters:** a step's own args may contain `--` (every `exec` step does), and everything after it belongs to the inner command — appending `--output json` there passed those two tokens to the program being exec'd *and* left trond in text mode. Cobra accepts persistent flags anywhere before the `--`.

## Three further bugs in the same function

Each verified against the code before fixing.

- **Rollback could not see the failed step's output.** The persist block sat below the failure switch, so `rollback:` — which exists to tidy up after a failed step — never had that step's fields. The shipped `fresh-mainnet-fullnode-with-snapshot` recipe's rollback references `{{ steps.apply.name }}`, and its own comment says rollback runs only when apply fails: the one case the reference was written for was the one case the key was missing. `on_failure: continue` lost it identically.
- **`--resume-from <typo>` reported success having done nothing.** An ID matching no step left every step skipped and returned status `"success"`. It now fails and names the valid IDs.
- **`-o json --dry-run` emitted unparseable output.** The plan lines went to the same stdout as the `RunResult`. Text mode keeps its stdout behaviour; json mode sends progress to stderr.

Also: a failing step's exit code now reaches the caller instead of being flattened to 1. A step refused by the gate exits 2, and an agent that sees 1 learns "something broke" where the truth was "refused".

## Verified end to end through the CLI

```
$ trond --state-dir SD --require-private recipe run destroy-private-network-cleanly \
    --param network=demo --dry-run
  [status-check] would run: trond network status  --output json --state-dir SD --require-private demo
  [destroy]      would run: trond network destroy --output json --state-dir SD --require-private demo --confirm demo
```

Before this change neither `--state-dir` nor `--require-private` appeared in either line, and `--output json` sat at the very end.

## Testing

- `make test -race` — 25 packages, 0 failures
- `make lint` — no findings
- Six new tests in `internal/recipe/step_context_test.go`, all confirmed red against the previous behaviour: reverting the three logic changes fails exactly the four behavioural tests and leaves the two forwarding tests green
- The `-o json --dry-run` output is re-parsed with a JSON decoder rather than eyeballed

Tests assert on the argv the runner actually builds, since that is the only thing that decides what the child does.

## Not in this PR

This is the safety-and-bugfix increment of the recipe work: **no new YAML fields and no new capability.** `recipe run --file` and `kind: host` steps follow separately — deliberately, since `--file` plus host exec is the pair that widens what trond can run, and it should land on a runner whose steps already inherit the gate rather than one where they do not.
