### PR TITLE
feat(recipe): run a recipe from a file, parsed strictly

### DIFF
--- a/cmd/recipe.go
+++ b/cmd/recipe.go
@@ -40,17 +40,84 @@ var recipeListCmd = &cobra.Command{
 }
 
 var recipeShowCmd = &cobra.Command{
-	Use:   "show <name>",
+	Use:   "show [name]",
 	Short: "Print one recipe's YAML and parameter list",
-	Args:  cobra.ExactArgs(1),
+	Args:  cobra.RangeArgs(0, 1),
 	RunE:  runRecipeShow,
+}
+
+var recipeValidateCmd = &cobra.Command{
+	Use:   "validate --file <path>",
+	Short: "Parse and check a recipe file without running it",
+	Long: `Load a recipe from disk, parse it strictly and report every structural
+problem at once, without executing a single step.
+
+Running a recipe is a sequence of real operations against real nodes.
+The expensive place to find out that a step id is missing, or that
+on_failure was misspelled, is step four — after steps one to three have
+already changed something. This is the cheap place.`,
+	Args: cobra.NoArgs,
+	RunE: runRecipeValidate,
 }
 
 var (
 	recipeRunParams     []string
 	recipeRunDryRun     bool
 	recipeRunResumeFrom string
+	recipeFile          string
+	recipeShowFile      string
+	recipeValidateFile  string
 )
+
+// resolveRecipe picks the recipe a command should act on: either a
+// built-in by name, or a file via --file. Exactly one, never both — a
+// command that silently preferred one would run something other than
+// what the caller named.
+func resolveRecipe(args []string, file string) (recipe.Recipe, string, error) {
+	switch {
+	case file != "" && len(args) > 0:
+		return recipe.Recipe{}, "", output.NewError("VALIDATION_ERROR", output.ExitValidationError,
+			fmt.Sprintf("give a recipe name or --file, not both (got name %q and --file %q)", args[0], file))
+	case file != "":
+		r, err := recipe.LoadFile(file)
+		if err != nil {
+			return recipe.Recipe{}, "", output.NewError("VALIDATION_ERROR", output.ExitValidationError, err.Error())
+		}
+		return r, file, nil
+	case len(args) > 0:
+		r, err := recipe.Get(args[0])
+		if err != nil {
+			return recipe.Recipe{}, "", output.NewError("NOT_FOUND", output.ExitGeneralError, err.Error())
+		}
+		return r, "builtin:" + args[0], nil
+	default:
+		return recipe.Recipe{}, "", output.NewError("VALIDATION_ERROR", output.ExitValidationError,
+			"specify a recipe name or --file <path>")
+	}
+}
+
+func runRecipeValidate(cmd *cobra.Command, _ []string) error {
+	outputFmt, _ := cmd.Flags().GetString("output")
+	if recipeValidateFile == "" {
+		return output.NewError("VALIDATION_ERROR", output.ExitValidationError, "--file is required")
+	}
+	r, err := recipe.LoadFile(recipeValidateFile)
+	if err != nil {
+		return output.NewError("VALIDATION_ERROR", output.ExitValidationError, err.Error())
+	}
+	res := map[string]any{
+		"valid":  true,
+		"source": recipeValidateFile,
+		"name":   r.Name,
+		"steps":  len(r.Steps),
+		"params": len(r.Params),
+	}
+	if outputFmt == "json" {
+		return jsonStdout(res)
+	}
+	fmt.Printf("%s: ok — %d steps, %d params\n", r.Name, len(r.Steps), len(r.Params))
+	return nil
+}
 
 var recipeRunCmd = &cobra.Command{
 	Use:   "run <name>",
@@ -72,7 +139,7 @@ Examples:
     --param node=my-fullnode \
     --param version=4.8.1 \
     --param intent_path=examples/mainnet-fullnode.yaml`,
-	Args: cobra.ExactArgs(1),
+	Args: cobra.RangeArgs(0, 1),
 	RunE: runRecipeRun,
 }
 
@@ -83,10 +150,17 @@ func init() {
 		"Print each step's resolved command without executing")
 	recipeRunCmd.Flags().StringVar(&recipeRunResumeFrom, "resume-from", "",
 		"Skip every step before this step ID (use the recipe's `id:` value)")
+	recipeRunCmd.Flags().StringVar(&recipeFile, "file", "",
+		"Run a recipe from this YAML file instead of a built-in name")
+	recipeShowCmd.Flags().StringVar(&recipeShowFile, "file", "",
+		"Show a recipe from this YAML file instead of a built-in name")
+	recipeValidateCmd.Flags().StringVar(&recipeValidateFile, "file", "",
+		"Recipe YAML file to parse and check")
 
 	recipeCmd.AddCommand(recipeListCmd)
 	recipeCmd.AddCommand(recipeShowCmd)
 	recipeCmd.AddCommand(recipeRunCmd)
+	recipeCmd.AddCommand(recipeValidateCmd)
 	rootCmd.AddCommand(recipeCmd)
 }
 
@@ -116,9 +190,9 @@ func runRecipeList(cmd *cobra.Command, _ []string) error {
 
 func runRecipeShow(cmd *cobra.Command, args []string) error {
 	outputFmt, _ := cmd.Flags().GetString("output")
-	r, err := recipe.Get(args[0])
+	r, _, err := resolveRecipe(args, recipeShowFile)
 	if err != nil {
-		return output.NewError("NOT_FOUND", output.ExitGeneralError, err.Error())
+		return err
 	}
 	if outputFmt == "json" {
 		return jsonStdout(r)
@@ -152,9 +226,9 @@ func runRecipeShow(cmd *cobra.Command, args []string) error {
 
 func runRecipeRun(cmd *cobra.Command, args []string) error {
 	outputFmt, _ := cmd.Flags().GetString("output")
-	r, err := recipe.Get(args[0])
+	r, source, err := resolveRecipe(args, recipeFile)
 	if err != nil {
-		return output.NewError("NOT_FOUND", output.ExitGeneralError, err.Error())
+		return err
 	}
 
 	params, err := parseParamFlags(recipeRunParams)
@@ -191,6 +265,9 @@ func runRecipeRun(cmd *cobra.Command, args []string) error {
 		RequirePrivate: guard.Requested(),
 	})
 
+	if res != nil {
+		res.Source = source
+	}
 	if outputFmt == "json" && res != nil {
 		_ = jsonStdout(res)
 	} else if res != nil && !recipeRunDryRun {

--- a/cmd/schema_coverage_test.go
+++ b/cmd/schema_coverage_test.go
@@ -97,6 +97,7 @@ func TestSchemaCoverage(t *testing.T) {
 		"trond snapshot clone":     "snapshot-clone",
 		"trond snapshot jobs":      "snapshot-jobs",
 		"trond snapshot list":      "snapshot-list",
+		"trond recipe validate":    "recipe-validate",
 		"trond snapshot sources":   "snapshot-sources",
 		"trond status":             "status",
 		"trond verify":             "verify",

--- a/internal/recipe/load.go
+++ b/internal/recipe/load.go
@@ -1,0 +1,139 @@
+package recipe
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// LoadFile reads a recipe from disk for `recipe run --file` / `--show`.
+//
+// Parsing is strict where the embedded loader is lenient, because the two
+// have different failure modes. An embedded recipe is reviewed at build
+// time and its tests run in CI; a file handed to --file is typed by
+// someone who wants it to run *now*, and a silently-ignored field there
+// means the run does something other than what the file says. A recipe is
+// also a sequence of real operations against real nodes: the expensive
+// place to discover a typo is step four, half-applied.
+func LoadFile(path string) (Recipe, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return Recipe{}, fmt.Errorf("read recipe %s: %w", path, err)
+	}
+	r, err := Parse(data)
+	if err != nil {
+		return Recipe{}, fmt.Errorf("%s: %w", path, err)
+	}
+	return r, nil
+}
+
+// Parse decodes recipe YAML strictly and validates it.
+func Parse(data []byte) (Recipe, error) {
+	dec := yaml.NewDecoder(bytes.NewReader(data))
+	// Unknown fields are errors: `on_failre: continue` would otherwise
+	// parse clean and silently mean "abort".
+	dec.KnownFields(true)
+
+	var r Recipe
+	if err := dec.Decode(&r); err != nil {
+		if errors.Is(err, io.EOF) {
+			return Recipe{}, errors.New("recipe is empty")
+		}
+		return Recipe{}, fmt.Errorf("parse: %w", err)
+	}
+
+	// A second document would be dropped on the floor. yaml.Unmarshal
+	// returns document 1 and says nothing, so a file holding two recipes
+	// runs half of what it contains.
+	var extra Recipe
+	if err := dec.Decode(&extra); err == nil {
+		return Recipe{}, errors.New("recipe file holds more than one YAML document; " +
+			"only the first would run — split them into separate files")
+	} else if !errors.Is(err, io.EOF) {
+		return Recipe{}, fmt.Errorf("parse (document 2): %w", err)
+	}
+
+	if err := r.Validate(); err != nil {
+		return Recipe{}, err
+	}
+	return r, nil
+}
+
+// Validate checks the structural rules a recipe must satisfy before any
+// step runs. Every violation here is one that would otherwise surface
+// mid-run, after earlier steps have already changed something.
+func (r Recipe) Validate() error {
+	var problems []string
+
+	if strings.TrimSpace(r.Name) == "" {
+		problems = append(problems, "name is required")
+	}
+	if len(r.Steps) == 0 {
+		problems = append(problems, "steps is required and must not be empty")
+	}
+
+	declared := map[string]bool{}
+	for _, p := range r.Params {
+		if strings.TrimSpace(p.Name) == "" {
+			problems = append(problems, "a param has no name")
+			continue
+		}
+		if declared[p.Name] {
+			problems = append(problems, fmt.Sprintf("duplicate param %q", p.Name))
+		}
+		declared[p.Name] = true
+	}
+
+	problems = append(problems, validateSteps("steps", r.Steps)...)
+	problems = append(problems, validateSteps("rollback", r.Rollback)...)
+
+	// Step IDs must be unique within `steps`: they are the key for
+	// {{ steps.<id>.* }} and for --resume-from, and a duplicate silently
+	// makes the later one win.
+	seen := map[string]bool{}
+	for _, s := range r.Steps {
+		if s.ID == "" {
+			continue // already reported by validateSteps
+		}
+		if seen[s.ID] {
+			problems = append(problems, fmt.Sprintf("duplicate step id %q", s.ID))
+		}
+		seen[s.ID] = true
+	}
+
+	if len(problems) > 0 {
+		return fmt.Errorf("invalid recipe:\n  - %s", strings.Join(problems, "\n  - "))
+	}
+	return nil
+}
+
+// validOnFailure mirrors the runner's switch. Anything else falls to the
+// default there, which is "abort" — so `on_failure: rollbck` would abort
+// a recipe that was written to roll back.
+var validOnFailure = map[string]bool{"": true, "abort": true, "continue": true, "rollback": true}
+
+func validateSteps(section string, steps []Step) []string {
+	var problems []string
+	for i, s := range steps {
+		where := fmt.Sprintf("%s[%d]", section, i)
+		if s.ID != "" {
+			where = fmt.Sprintf("%s (%s)", where, s.ID)
+		}
+		if strings.TrimSpace(s.ID) == "" {
+			problems = append(problems, where+": id is required")
+		}
+		if strings.TrimSpace(s.Command) == "" {
+			problems = append(problems, where+": command is required")
+		}
+		if !validOnFailure[s.OnFailure] {
+			problems = append(problems, fmt.Sprintf(
+				"%s: on_failure %q is not one of abort, continue, rollback", where, s.OnFailure))
+		}
+	}
+	return problems
+}

--- a/internal/recipe/load_test.go
+++ b/internal/recipe/load_test.go
@@ -1,0 +1,157 @@
+package recipe
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const minimalRecipe = `name: probe
+description: a probe
+steps:
+  - id: first
+    command: status
+    args: ["n0"]
+`
+
+func writeRecipe(t *testing.T, body string) string {
+	t.Helper()
+	p := filepath.Join(t.TempDir(), "r.yaml")
+	if err := os.WriteFile(p, []byte(body), 0o600); err != nil {
+		t.Fatalf("write recipe: %v", err)
+	}
+	return p
+}
+
+func TestLoadFile_Minimal(t *testing.T) {
+	r, err := LoadFile(writeRecipe(t, minimalRecipe))
+	if err != nil {
+		t.Fatalf("LoadFile: %v", err)
+	}
+	if r.Name != "probe" || len(r.Steps) != 1 || r.Steps[0].ID != "first" {
+		t.Errorf("parsed recipe = %+v", r)
+	}
+}
+
+// TestParse_RejectsUnknownFields is the reason the file loader is strict
+// where the embedded loader is not. `on_failre: continue` parses clean
+// under lenient YAML and silently means "abort" — the recipe does the
+// opposite of what it says, at the moment a step has already failed.
+func TestParse_RejectsUnknownFields(t *testing.T) {
+	body := `name: probe
+steps:
+  - id: first
+    command: status
+    on_failre: continue
+`
+	_, err := Parse([]byte(body))
+	if err == nil {
+		t.Fatal("want an error for a misspelled field, got nil")
+	}
+	if !strings.Contains(err.Error(), "on_failre") {
+		t.Errorf("error %q should name the offending field", err)
+	}
+}
+
+// TestParse_RejectsMultiDocument: yaml.Unmarshal returns document 1 and
+// says nothing, so a file holding two recipes silently runs half of what
+// it contains.
+func TestParse_RejectsMultiDocument(t *testing.T) {
+	body := minimalRecipe + "---\n" + strings.Replace(minimalRecipe, "probe", "second", 1)
+	_, err := Parse([]byte(body))
+	if err == nil {
+		t.Fatal("want an error for a multi-document recipe file, got nil")
+	}
+	if !strings.Contains(err.Error(), "more than one YAML document") {
+		t.Errorf("error %q should explain that only the first would run", err)
+	}
+}
+
+func TestParse_Empty(t *testing.T) {
+	if _, err := Parse([]byte("")); err == nil {
+		t.Fatal("want an error for an empty recipe, got nil")
+	}
+}
+
+// TestValidate_ReportsEveryProblemAtOnce: a recipe is a sequence of real
+// operations, so the caller should learn about all the structural
+// problems before the first one runs, not one per attempt.
+func TestValidate_ReportsEveryProblemAtOnce(t *testing.T) {
+	body := `name: ""
+steps:
+  - id: ""
+    command: ""
+    on_failure: rollbck
+  - id: dup
+    command: status
+  - id: dup
+    command: status
+rollback:
+  - id: ""
+    command: stop
+`
+	_, err := Parse([]byte(body))
+	if err == nil {
+		t.Fatal("want validation errors, got nil")
+	}
+	for _, want := range []string{
+		"name is required",
+		"id is required",
+		"command is required",
+		`on_failure "rollbck"`,
+		`duplicate step id "dup"`,
+		"rollback[0]",
+	} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("validation output is missing %q; a caller fixing one problem at a "+
+				"time re-runs the recipe once per typo.\ngot:\n%s", want, err)
+		}
+	}
+}
+
+func TestValidate_RequiresSteps(t *testing.T) {
+	_, err := Parse([]byte("name: probe\n"))
+	if err == nil || !strings.Contains(err.Error(), "steps is required") {
+		t.Fatalf("want a steps-required error, got %v", err)
+	}
+}
+
+// TestValidate_AcceptsEveryEmbeddedRecipe keeps the new strictness honest:
+// if a rule here would reject a recipe that ships in the binary, the rule
+// is wrong (or the shipped recipe is, which is equally worth knowing).
+func TestValidate_AcceptsEveryEmbeddedRecipe(t *testing.T) {
+	all, err := LoadEmbedded()
+	if err != nil {
+		t.Fatalf("LoadEmbedded: %v", err)
+	}
+	if len(all) == 0 {
+		t.Fatal("no embedded recipes found")
+	}
+	for name, r := range all {
+		if err := r.Validate(); err != nil {
+			t.Errorf("embedded recipe %q fails the file-loader's validation: %v", name, err)
+		}
+	}
+}
+
+// TestLoadFile_ParseErrorNamesThePath — a validation failure reported
+// without the file it came from is useless when a recipe references
+// others by path.
+func TestLoadFile_ParseErrorNamesThePath(t *testing.T) {
+	p := writeRecipe(t, "name: probe\n")
+	_, err := LoadFile(p)
+	if err == nil {
+		t.Fatal("want an error")
+	}
+	if !strings.Contains(err.Error(), p) {
+		t.Errorf("error %q should name %q", err, p)
+	}
+}
+
+func TestLoadFile_MissingFile(t *testing.T) {
+	_, err := LoadFile(filepath.Join(t.TempDir(), "nope.yaml"))
+	if err == nil || !strings.Contains(err.Error(), "read recipe") {
+		t.Fatalf("want a read error, got %v", err)
+	}
+}

--- a/internal/recipe/types.go
+++ b/internal/recipe/types.go
@@ -92,7 +92,15 @@ type StepResult struct {
 // RunResult is what `recipe run` returns at the end. Stable JSON
 // shape so an MCP recipe-runner tool can return it verbatim.
 type RunResult struct {
-	Recipe        string       `json:"recipe"`
+	Recipe string `json:"recipe"`
+
+	// Source records where the recipe came from: "builtin:<name>" or the
+	// path passed to --file. Set by the CLI, not the runner — the runner
+	// is handed a parsed Recipe and has no idea where it was read from.
+	// A run against a file on disk is otherwise indistinguishable in its
+	// output from a run of the built-in with the same name.
+	Source string `json:"source,omitempty"`
+
 	Status        string       `json:"status"` // success | failed | aborted | rolled_back
 	StartedAt     string       `json:"started_at"`
 	DurationMs    int64        `json:"duration_ms"`

--- a/internal/schema/embed.go
+++ b/internal/schema/embed.go
@@ -119,7 +119,7 @@ import (
 //	        `md5_verified: false` on a successful download means one
 //	        thing only: the operator passed `--no-verify` / `no_verify`.
 //	        One existing schema, one additive optional field — PATCH.
-const SchemaVersion = "1.12.5"
+const SchemaVersion = "1.13.0"
 
 // JSONSchemaURLBase is the canonical URL prefix for individual output
 // schema files. Embedded $id values inside each schema mirror this so

--- a/internal/schema/files/recipe-run.schema.json
+++ b/internal/schema/files/recipe-run.schema.json
@@ -4,43 +4,90 @@
   "title": "trond recipe run output",
   "description": "Returned by `trond recipe run <name> -o json`. Stable shape so an MCP recipe.run tool can pass it through verbatim.",
   "type": "object",
-  "required": ["recipe", "status", "started_at", "duration_ms", "steps"],
+  "required": [
+    "recipe",
+    "status",
+    "started_at",
+    "duration_ms",
+    "steps"
+  ],
   "properties": {
-    "recipe":      { "type": "string", "description": "The .name of the recipe that was run." },
+    "recipe": {
+      "type": "string",
+      "description": "The .name of the recipe that was run."
+    },
+    "source": {
+      "type": "string",
+      "description": "Where the recipe came from: \"builtin:<name>\" or the --file path."
+    },
     "status": {
       "type": "string",
-      "enum": ["success", "failed", "rolled_back"],
+      "enum": [
+        "success",
+        "failed",
+        "rolled_back"
+      ],
       "description": "Aggregate verdict. failed=a step's on_failure=abort triggered; rolled_back=on_failure=rollback triggered and the rollback section ran."
     },
-    "started_at":  { "type": "string", "format": "date-time" },
-    "duration_ms": { "type": "integer", "minimum": 0 },
-    "failed_at":   { "type": "string", "description": "Step ID that triggered failure; absent on success." },
-    "rollback_ran":  { "type": "boolean" },
+    "started_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "duration_ms": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "failed_at": {
+      "type": "string",
+      "description": "Step ID that triggered failure; absent on success."
+    },
+    "rollback_ran": {
+      "type": "boolean"
+    },
     "steps": {
       "type": "array",
-      "items": { "$ref": "#/$defs/stepResult" }
+      "items": {
+        "$ref": "#/$defs/stepResult"
+      }
     },
     "rollback_steps": {
       "type": "array",
       "description": "Records for each rollback step that ran (only set when rollback_ran=true).",
-      "items": { "$ref": "#/$defs/stepResult" }
+      "items": {
+        "$ref": "#/$defs/stepResult"
+      }
     }
   },
   "$defs": {
     "stepResult": {
       "type": "object",
-      "required": ["id"],
+      "required": [
+        "id"
+      ],
       "properties": {
-        "id":          { "type": "string" },
-        "skipped":     { "type": "boolean", "description": "True when --resume-from passed this step or its skip predicate evaluated true." },
-        "exit_code":   { "type": "integer" },
-        "duration_ms": { "type": "integer", "minimum": 0 },
+        "id": {
+          "type": "string"
+        },
+        "skipped": {
+          "type": "boolean",
+          "description": "True when --resume-from passed this step or its skip predicate evaluated true."
+        },
+        "exit_code": {
+          "type": "integer"
+        },
+        "duration_ms": {
+          "type": "integer",
+          "minimum": 0
+        },
         "output": {
           "type": "object",
           "description": "JSON object captured from the step's stdout (when the step's command supports -o json).",
           "additionalProperties": true
         },
-        "error":       { "type": "string", "description": "Set when the step's command exited non-zero." }
+        "error": {
+          "type": "string",
+          "description": "Set when the step's command exited non-zero."
+        }
       }
     }
   }

--- a/internal/schema/files/recipe-validate.schema.json
+++ b/internal/schema/files/recipe-validate.schema.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/tronprotocol/tron-deployment/blob/master/schemas/output/recipe-validate.schema.json",
+  "title": "trond recipe validate --output json",
+  "description": "Result of parsing and checking a recipe file without executing it. A structural problem is reported through the standard error envelope (VALIDATION_ERROR, exit 2), so this shape is only ever emitted for a recipe that passed.",
+  "type": "object",
+  "required": [
+    "valid",
+    "source",
+    "name",
+    "steps",
+    "params"
+  ],
+  "properties": {
+    "valid": {
+      "type": "boolean",
+      "description": "Always true when this shape is emitted; a failure uses the error envelope instead."
+    },
+    "source": {
+      "type": "string",
+      "description": "Path the recipe was read from."
+    },
+    "name": {
+      "type": "string",
+      "description": "The recipe's declared name field."
+    },
+    "steps": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "Number of steps in the recipe's steps list."
+    },
+    "params": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Number of declared params."
+    }
+  }
+}

--- a/internal/schema/version_baseline.json
+++ b/internal/schema/version_baseline.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": "1.12.5",
+  "schema_version": "1.13.0",
   "entries": [
     {
       "name": "apply",
@@ -87,11 +87,15 @@
     },
     {
       "name": "recipe-run",
-      "hash": "8224043f170ccc4fb4afe998a3b6bf19e051a1e1eaba3e6d3b70a93a3b48f535"
+      "hash": "9bcd23e35f8dd03864905398d722b2d3e43829d89414c0b26dbacd0f536b672a"
     },
     {
       "name": "recipe-show",
       "hash": "488d34dc919a5aa0f482656c34aa43c15b92c6acf5bd7105ebbe06877b303084"
+    },
+    {
+      "name": "recipe-validate",
+      "hash": "fd7205de5915bdef541e2da867a2eb6ea8c50d1d551a42a0882c11bbf3d96d4f"
     },
     {
       "name": "shadow-fork-mutate",

--- a/schemas/output/recipe-run.schema.json
+++ b/schemas/output/recipe-run.schema.json
@@ -4,43 +4,90 @@
   "title": "trond recipe run output",
   "description": "Returned by `trond recipe run <name> -o json`. Stable shape so an MCP recipe.run tool can pass it through verbatim.",
   "type": "object",
-  "required": ["recipe", "status", "started_at", "duration_ms", "steps"],
+  "required": [
+    "recipe",
+    "status",
+    "started_at",
+    "duration_ms",
+    "steps"
+  ],
   "properties": {
-    "recipe":      { "type": "string", "description": "The .name of the recipe that was run." },
+    "recipe": {
+      "type": "string",
+      "description": "The .name of the recipe that was run."
+    },
+    "source": {
+      "type": "string",
+      "description": "Where the recipe came from: \"builtin:<name>\" or the --file path."
+    },
     "status": {
       "type": "string",
-      "enum": ["success", "failed", "rolled_back"],
+      "enum": [
+        "success",
+        "failed",
+        "rolled_back"
+      ],
       "description": "Aggregate verdict. failed=a step's on_failure=abort triggered; rolled_back=on_failure=rollback triggered and the rollback section ran."
     },
-    "started_at":  { "type": "string", "format": "date-time" },
-    "duration_ms": { "type": "integer", "minimum": 0 },
-    "failed_at":   { "type": "string", "description": "Step ID that triggered failure; absent on success." },
-    "rollback_ran":  { "type": "boolean" },
+    "started_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "duration_ms": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "failed_at": {
+      "type": "string",
+      "description": "Step ID that triggered failure; absent on success."
+    },
+    "rollback_ran": {
+      "type": "boolean"
+    },
     "steps": {
       "type": "array",
-      "items": { "$ref": "#/$defs/stepResult" }
+      "items": {
+        "$ref": "#/$defs/stepResult"
+      }
     },
     "rollback_steps": {
       "type": "array",
       "description": "Records for each rollback step that ran (only set when rollback_ran=true).",
-      "items": { "$ref": "#/$defs/stepResult" }
+      "items": {
+        "$ref": "#/$defs/stepResult"
+      }
     }
   },
   "$defs": {
     "stepResult": {
       "type": "object",
-      "required": ["id"],
+      "required": [
+        "id"
+      ],
       "properties": {
-        "id":          { "type": "string" },
-        "skipped":     { "type": "boolean", "description": "True when --resume-from passed this step or its skip predicate evaluated true." },
-        "exit_code":   { "type": "integer" },
-        "duration_ms": { "type": "integer", "minimum": 0 },
+        "id": {
+          "type": "string"
+        },
+        "skipped": {
+          "type": "boolean",
+          "description": "True when --resume-from passed this step or its skip predicate evaluated true."
+        },
+        "exit_code": {
+          "type": "integer"
+        },
+        "duration_ms": {
+          "type": "integer",
+          "minimum": 0
+        },
         "output": {
           "type": "object",
           "description": "JSON object captured from the step's stdout (when the step's command supports -o json).",
           "additionalProperties": true
         },
-        "error":       { "type": "string", "description": "Set when the step's command exited non-zero." }
+        "error": {
+          "type": "string",
+          "description": "Set when the step's command exited non-zero."
+        }
       }
     }
   }

--- a/schemas/output/recipe-validate.schema.json
+++ b/schemas/output/recipe-validate.schema.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/tronprotocol/tron-deployment/blob/master/schemas/output/recipe-validate.schema.json",
+  "title": "trond recipe validate --output json",
+  "description": "Result of parsing and checking a recipe file without executing it. A structural problem is reported through the standard error envelope (VALIDATION_ERROR, exit 2), so this shape is only ever emitted for a recipe that passed.",
+  "type": "object",
+  "required": [
+    "valid",
+    "source",
+    "name",
+    "steps",
+    "params"
+  ],
+  "properties": {
+    "valid": {
+      "type": "boolean",
+      "description": "Always true when this shape is emitted; a failure uses the error envelope instead."
+    },
+    "source": {
+      "type": "string",
+      "description": "Path the recipe was read from."
+    },
+    "name": {
+      "type": "string",
+      "description": "The recipe's declared name field."
+    },
+    "steps": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "Number of steps in the recipe's steps list."
+    },
+    "params": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Number of declared params."
+    }
+  }
+}


### PR DESCRIPTION
`recipe run` and `recipe show` could only reach the five recipes embedded in the binary, so the workflows this is meant to replace could not be expressed at all. Both now take `--file <path>`, and a new `recipe validate --file` parses and checks one without running a step.

```
$ trond recipe validate --file ./my.yaml
my-own-recipe: ok — 1 steps, 1 params

$ trond --require-private recipe run --file ./my.yaml --param node=n1 --dry-run
  [check] would run: trond status --output json --state-dir SD --require-private n1

$ trond recipe run --file ./my.yaml --param node=n1 --dry-run -o json | jq -r .source
./my.yaml
```

Exactly one source, never both: a command handed a name **and** a `--file` refuses rather than silently preferring one, since the caller would then be running something other than what they named. The result records where the recipe came from (`source`: `"builtin:<name>"` or the path) — without it a run from disk is indistinguishable in its output from a run of the built-in with the same name.

## Why the file loader is strict where the embedded one is not

The two have different failure modes. An embedded recipe is reviewed at build time and its tests run in CI. A file handed to `--file` is typed by someone who wants it to run *now*, against real nodes.

- **Unknown fields are errors.** `on_failre: continue` parses clean under lenient YAML and silently means "abort" — the recipe does the opposite of what it says, at the moment a step has already failed.
- **Multi-document files are refused.** `yaml.Unmarshal` returns document one and says nothing, so a file holding two recipes runs half of what it contains.
- **Structure is validated up front, reporting every problem at once** — missing ids, missing commands, an `on_failure` outside abort/continue/rollback, duplicate step ids, duplicate params. A recipe is a sequence of real operations: the expensive place to discover a typo is step four, after steps one to three have already changed something. Reporting one problem per run means one run per typo.

A test asserts **every embedded recipe passes the new validation**, so a rule that would reject something we ship fails here rather than in a user's hands.

## Schema

`recipe validate` gets a real schema rather than an entry in `TestSchemaCoverage`'s accepted-gaps list, whose own comment says the goal is to drive that list to zero.

`SchemaVersion` 1.12.5 → 1.13.0 — two additive changes (the `source` property on recipe-run, the new recipe-validate file), baseline re-snapshotted. Both copies under `schemas/output/` and `internal/schema/files/` are byte-identical, as the drift test requires.

## Testing

- `make test -race` — 25 packages, 0 failures
- `make lint` — no findings
- Nine new tests in `internal/recipe/load_test.go` covering strict parsing, multi-document rejection, empty input, the all-problems-at-once validator, and the embedded-recipe compatibility check
- Exercised end to end through the CLI: `validate`, `run --file` with the gate forwarded, `source` in the JSON result, the both-sources refusal, and the error text for a misspelled field

## Deliberately not here

**No `--expect-sha256` provenance pin.** A recipe's steps are trond subcommands, each individually gated (#211) and audited, so `--file` does not widen what trond can do — it changes who typed the sequence. A checksum pin protects against a file changing between review and run, which is a real concern but a separate one, and it belongs with `kind: host`, where the capability ceiling actually moves.
