### PR TITLE
feat(recipe): kind: host steps, behind two refusals

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -912,7 +912,30 @@ trond recipe show <name>                            # YAML + params + steps
 trond recipe run <name> --param key=value [...]     # execute end-to-end
 trond recipe run <name> ... --dry-run               # print resolved chain, no exec
 trond recipe run <name> ... --resume-from <step>    # skip ahead after a partial run
+
+trond recipe run --file ./my.yaml --param k=v        # a recipe of your own
+trond recipe show --file ./my.yaml                   # inspect one without running it
+trond recipe validate --file ./my.yaml               # parse + check, execute nothing
 ```
+
+Files passed to `--file` are parsed **strictly** — unknown fields, a
+second YAML document, or a structural problem are refused up front,
+with every problem reported at once. A recipe is a sequence of real
+operations; the expensive place to find a typo is step four.
+
+Steps come in two kinds:
+
+- **`kind: command`** (the default) re-execs trond with a subcommand
+  path. The run's `--state-dir` and `--require-private` are forwarded, so
+  a step acts in the same place and under the same policy as the run that
+  launched it.
+- **`kind: host`** runs a program on the machine running trond, via
+  `run: [prog, arg]` (argv, no shell) or `script: |` (a shell body). It
+  is the only step that escapes trond's own surface, so it needs
+  `--allow-host-exec`, **and it is refused outright under
+  `--require-private`** — a host step names no node, so the gate has
+  nothing to check and cannot vouch for it. `--dry-run` still previews
+  host steps under either refusal.
 
 The runner re-execs the trond binary itself for each step (no shell
 dependency beyond `exec`), captures stdout JSON, and feeds named

--- a/cmd/recipe.go
+++ b/cmd/recipe.go
@@ -65,6 +65,7 @@ var (
 	recipeRunDryRun     bool
 	recipeRunResumeFrom string
 	recipeFile          string
+	recipeAllowHostExec bool
 	recipeShowFile      string
 	recipeValidateFile  string
 )
@@ -152,6 +153,8 @@ func init() {
 		"Skip every step before this step ID (use the recipe's `id:` value)")
 	recipeRunCmd.Flags().StringVar(&recipeFile, "file", "",
 		"Run a recipe from this YAML file instead of a built-in name")
+	recipeRunCmd.Flags().BoolVar(&recipeAllowHostExec, "allow-host-exec", false,
+		"Permit `kind: host` steps, which run arbitrary programs on this machine")
 	recipeShowCmd.Flags().StringVar(&recipeShowFile, "file", "",
 		"Show a recipe from this YAML file instead of a built-in name")
 	recipeValidateCmd.Flags().StringVar(&recipeValidateFile, "file", "",
@@ -263,6 +266,7 @@ func runRecipeRun(cmd *cobra.Command, args []string) error {
 		// directory, so this covers --state-dir and TROND_STATE_DIR alike.
 		StateDir:       paths.BaseDir(),
 		RequirePrivate: guard.Requested(),
+		AllowHostExec:  recipeAllowHostExec,
 	})
 
 	if res != nil {

--- a/internal/recipe/host_step_test.go
+++ b/internal/recipe/host_step_test.go
@@ -1,0 +1,228 @@
+package recipe
+
+import (
+	"context"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// `kind: host` is the only step that escapes trond's own surface: a
+// command step is bounded by what trond will do, and every node-touching
+// trond verb is individually gated and audited. A host step is bounded by
+// nothing.
+//
+// So the tests that matter here are the ones that prove it does NOT run.
+
+func hostRecipe(step Step) Recipe {
+	step.Kind = KindHost
+	if step.ID == "" {
+		step.ID = "h1"
+	}
+	return Recipe{Name: "t", Steps: []Step{step}}
+}
+
+func TestHostStep_RunsWhenAllowed(t *testing.T) {
+	marker := filepath.Join(t.TempDir(), "ran")
+	r := hostRecipe(Step{Run: []string{"touch", marker}})
+
+	if _, err := Run(context.Background(), r, RunOptions{
+		Out: io.Discard, Err: io.Discard, AllowHostExec: true,
+	}); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if _, err := os.Stat(marker); err != nil {
+		t.Errorf("host step did not run: %v", err)
+	}
+}
+
+// TestHostStep_RefusedWithoutOptIn: choosing a recipe file and opting into
+// arbitrary execution are separate decisions, and --file makes the file
+// come from anywhere.
+func TestHostStep_RefusedWithoutOptIn(t *testing.T) {
+	marker := filepath.Join(t.TempDir(), "ran")
+	r := hostRecipe(Step{Run: []string{"touch", marker}})
+
+	_, err := Run(context.Background(), r, RunOptions{Out: io.Discard, Err: io.Discard})
+	if err == nil {
+		t.Fatal("want a refusal without --allow-host-exec, got nil")
+	}
+	if !strings.Contains(err.Error(), "allow-host-exec") {
+		t.Errorf("error %q should name the flag that would permit it", err)
+	}
+	if _, statErr := os.Stat(marker); statErr == nil {
+		t.Error("the refused step ran anyway")
+	}
+}
+
+// TestHostStep_RefusedUnderPrivateGate is the load-bearing one.
+// --require-private promises an agent is "mechanically incapable of
+// mutating a mainnet/nile rig". A host step can delete a mainnet node's
+// data directory without ever naming the node, so the gate must refuse
+// rather than inspect the command and guess.
+func TestHostStep_RefusedUnderPrivateGate(t *testing.T) {
+	marker := filepath.Join(t.TempDir(), "ran")
+	r := hostRecipe(Step{Run: []string{"touch", marker}})
+
+	// Even with the explicit opt-in: the gate is a floor, not a default.
+	_, err := Run(context.Background(), r, RunOptions{
+		Out: io.Discard, Err: io.Discard,
+		AllowHostExec: true, RequirePrivate: true,
+	})
+	if err == nil {
+		t.Fatal("want a refusal under --require-private, got nil")
+	}
+	if !strings.Contains(err.Error(), "require-private") {
+		t.Errorf("error %q should say the gate refused it", err)
+	}
+	if _, statErr := os.Stat(marker); statErr == nil {
+		t.Error("a host step ran with the private gate on; --allow-host-exec must not " +
+			"be able to lift the floor")
+	}
+}
+
+// TestHostStep_DryRunPreviewsUnderBothRefusals: printing what would run
+// changes nothing, and the same reasoning already lets `auto-heal
+// --dry-run` through the gate.
+func TestHostStep_DryRunPreviewsUnderBothRefusals(t *testing.T) {
+	marker := filepath.Join(t.TempDir(), "ran")
+	r := hostRecipe(Step{Run: []string{"touch", marker}})
+
+	var out strings.Builder
+	if _, err := Run(context.Background(), r, RunOptions{
+		Out: &out, Err: io.Discard, DryRun: true, RequirePrivate: true,
+	}); err != nil {
+		t.Fatalf("dry-run should preview, not refuse: %v", err)
+	}
+	if !strings.Contains(out.String(), "touch") {
+		t.Errorf("dry-run did not show the host command: %q", out.String())
+	}
+	if _, statErr := os.Stat(marker); statErr == nil {
+		t.Error("dry-run executed the step")
+	}
+}
+
+func TestHostStep_ScriptGetsAShell(t *testing.T) {
+	dir := t.TempDir()
+	r := hostRecipe(Step{Script: "echo shell-ran > " + filepath.Join(dir, "out")})
+
+	if _, err := Run(context.Background(), r, RunOptions{
+		Out: io.Discard, Err: io.Discard, AllowHostExec: true,
+	}); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	got, err := os.ReadFile(filepath.Join(dir, "out"))
+	if err != nil || strings.TrimSpace(string(got)) != "shell-ran" {
+		t.Errorf("script step produced %q, %v", got, err)
+	}
+}
+
+// TestHostStep_RunIsArgvNotShell: run: is argv, so shell metacharacters
+// are inert. If they were not, "run" and "script" would differ only in
+// spelling and the grep-for-script census would be worthless.
+func TestHostStep_RunIsArgvNotShell(t *testing.T) {
+	dir := t.TempDir()
+	sentinel := filepath.Join(dir, "should-not-exist")
+	r := hostRecipe(Step{Run: []string{"echo", "hello > " + sentinel}})
+
+	if _, err := Run(context.Background(), r, RunOptions{
+		Out: io.Discard, Err: io.Discard, AllowHostExec: true,
+	}); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if _, err := os.Stat(sentinel); err == nil {
+		t.Error("a redirection inside an argv item was interpreted by a shell")
+	}
+}
+
+func TestHostStep_SubstitutesArgsAndEnv(t *testing.T) {
+	dir := t.TempDir()
+	r := Recipe{
+		Name:   "t",
+		Params: []Param{{Name: "target", Required: true}},
+		Steps: []Step{{
+			ID: "h1", Kind: KindHost,
+			Script: `printf '%s' "$WHERE" > ` + filepath.Join(dir, "out"),
+			Env:    map[string]string{"WHERE": "{{ params.target }}"},
+		}},
+	}
+	if _, err := Run(context.Background(), r, RunOptions{
+		Out: io.Discard, Err: io.Discard, AllowHostExec: true,
+		Params: map[string]string{"target": "substituted"},
+	}); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	got, _ := os.ReadFile(filepath.Join(dir, "out"))
+	if string(got) != "substituted" {
+		t.Errorf("env value = %q, want %q", got, "substituted")
+	}
+}
+
+func TestHostStep_DirIsHonoured(t *testing.T) {
+	dir := t.TempDir()
+	r := hostRecipe(Step{Run: []string{"touch", "made-here"}, Dir: dir})
+
+	if _, err := Run(context.Background(), r, RunOptions{
+		Out: io.Discard, Err: io.Discard, AllowHostExec: true,
+	}); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "made-here")); err != nil {
+		t.Errorf("dir: was not applied: %v", err)
+	}
+}
+
+func TestValidate_HostStepShapes(t *testing.T) {
+	tests := []struct {
+		name string
+		yaml string
+		want string
+	}{
+		{
+			"neither run nor script",
+			"name: t\nsteps:\n  - id: a\n    kind: host\n",
+			"needs run or script",
+		},
+		{
+			"both run and script",
+			"name: t\nsteps:\n  - id: a\n    kind: host\n    run: [\"echo\"]\n    script: echo hi\n",
+			"not both",
+		},
+		{
+			"command on a host step",
+			"name: t\nsteps:\n  - id: a\n    kind: host\n    run: [\"echo\"]\n    command: status\n",
+			"a host step uses run or script",
+		},
+		{
+			"host fields on a command step",
+			"name: t\nsteps:\n  - id: a\n    command: status\n    run: [\"echo\"]\n",
+			"belong to `kind: host` steps",
+		},
+		{
+			"unknown kind",
+			"name: t\nsteps:\n  - id: a\n    kind: sidecar\n    command: status\n",
+			`kind "sidecar" is not one of command, host`,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := Parse([]byte(tc.yaml))
+			if err == nil {
+				t.Fatalf("want an error containing %q, got nil", tc.want)
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Errorf("error = %v, want it to contain %q", err, tc.want)
+			}
+		})
+	}
+}
+
+// TestValidate_CommandStepsUnchanged: the zero Kind must keep meaning
+// "command", or every recipe written before this field existed breaks.
+func TestValidate_CommandStepsUnchanged(t *testing.T) {
+	if _, err := Parse([]byte(minimalRecipe)); err != nil {
+		t.Fatalf("a recipe with no kind: field must still parse: %v", err)
+	}
+}

--- a/internal/recipe/load.go
+++ b/internal/recipe/load.go
@@ -127,8 +127,33 @@ func validateSteps(section string, steps []Step) []string {
 		if strings.TrimSpace(s.ID) == "" {
 			problems = append(problems, where+": id is required")
 		}
-		if strings.TrimSpace(s.Command) == "" {
-			problems = append(problems, where+": command is required")
+		switch s.Kind {
+		case "", KindCommand:
+			if strings.TrimSpace(s.Command) == "" {
+				problems = append(problems, where+": command is required")
+			}
+			if len(s.Run) > 0 || s.Script != "" || s.Dir != "" || len(s.Env) > 0 {
+				problems = append(problems, where+
+					": run/script/dir/env belong to `kind: host` steps")
+			}
+		case KindHost:
+			// Exactly one of run/script. Accepting both would leave the
+			// recipe's own text ambiguous about what it executes.
+			switch {
+			case len(s.Run) > 0 && s.Script != "":
+				problems = append(problems, where+": set run or script, not both")
+			case len(s.Run) == 0 && s.Script == "":
+				problems = append(problems, where+": a host step needs run or script")
+			case len(s.Run) > 0 && strings.TrimSpace(s.Run[0]) == "":
+				problems = append(problems, where+": run[0] (the program) is empty")
+			}
+			if s.Command != "" {
+				problems = append(problems, where+
+					": command belongs to `kind: command` steps; a host step uses run or script")
+			}
+		default:
+			problems = append(problems, fmt.Sprintf(
+				"%s: kind %q is not one of command, host", where, s.Kind))
 		}
 		if !validOnFailure[s.OnFailure] {
 			problems = append(problems, fmt.Sprintf(

--- a/internal/recipe/runner.go
+++ b/internal/recipe/runner.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"sort"
 	"strings"
 	"time"
 )
@@ -55,6 +56,16 @@ type RunOptions struct {
 	// while the identical run started with TROND_REQUIRE_PRIVATE=1 is
 	// gated — the safety floor would depend on which way you asked for it.
 	RequirePrivate bool
+
+	// AllowHostExec permits `kind: host` steps, which run arbitrary
+	// programs on the machine running trond rather than trond
+	// subcommands. Off by default: every other step kind is bounded by
+	// what trond itself will do (and each of those is individually gated
+	// and audited), while a host step is bounded by nothing. Requiring
+	// the caller to say so makes "this run may execute arbitrary
+	// programs" an explicit, greppable decision rather than a property
+	// of whichever file was passed to --file.
+	AllowHostExec bool
 }
 
 // Run executes a recipe. Returns a RunResult plus error; the error is
@@ -113,12 +124,31 @@ func Run(ctx context.Context, r Recipe, opts RunOptions) (*RunResult, error) {
 			}
 		}
 
-		args, err := substituteAll(step.Args, resolved, stepsState)
+		// A host step's arguments live in run[1:] (run[0] is the program
+		// and is never templated — a substituted program name would make
+		// "what does this recipe execute" unanswerable by reading it).
+		toSubstitute := step.Args
+		if step.Kind == KindHost && len(step.Run) > 1 {
+			toSubstitute = step.Run[1:]
+		}
+		args, err := substituteAll(toSubstitute, resolved, stepsState)
 		if err != nil {
 			return result, fmt.Errorf("step %s: %w", step.ID, err)
 		}
 
-		stepResult, err := runStep(ctx, opts, step, args)
+		st := step
+		if len(step.Env) > 0 {
+			st.Env = make(map[string]string, len(step.Env))
+			for k, v := range step.Env {
+				sv, err := substitute(v, resolved, stepsState)
+				if err != nil {
+					return result, fmt.Errorf("step %s: env %s: %w", step.ID, k, err)
+				}
+				st.Env[k] = sv
+			}
+		}
+
+		stepResult, err := runStep(ctx, opts, st, args)
 		result.Steps = append(result.Steps, stepResult)
 
 		// Persist BEFORE the failure switch. Rollback steps exist to clean
@@ -194,6 +224,10 @@ func stepIDs(steps []Step) string {
 
 // runStep handles a single step's exec + output capture.
 func runStep(ctx context.Context, opts RunOptions, step Step, args []string) (StepResult, error) {
+	if step.Kind == KindHost {
+		return runHostStep(ctx, opts, step, args)
+	}
+
 	res := StepResult{ID: step.ID}
 	if step.Command == "" {
 		res.Error = "step has no command"
@@ -295,4 +329,91 @@ func paramNames(ps []Param) string {
 		names = append(names, p.Name)
 	}
 	return strings.Join(names, ", ")
+}
+
+// runHostStep runs a program on the machine running trond.
+//
+// Two refusals happen here rather than at load time, because both depend
+// on how the run was invoked rather than on what the recipe says:
+//
+//   - Without AllowHostExec the step does not run. A recipe file is
+//     content, and --file makes it content from anywhere; the operator
+//     opting into arbitrary execution is a separate decision from
+//     choosing the file.
+//
+//   - Under the private gate it does not run either, and that one is not
+//     negotiable. `--require-private` promises an agent is "mechanically
+//     incapable of mutating a mainnet/nile rig" (AGENTS.md). A host step
+//     can delete a mainnet node's data directory without ever naming the
+//     node, so honouring that promise means refusing, not inspecting the
+//     command and guessing. The gate has no node to check here — which is
+//     precisely why it must refuse rather than allow.
+//
+// --dry-run still previews host steps under either refusal: printing what
+// would run changes nothing, and the same reasoning already lets
+// `auto-heal --dry-run` through the gate.
+func runHostStep(ctx context.Context, opts RunOptions, step Step, args []string) (StepResult, error) {
+	res := StepResult{ID: step.ID}
+
+	var argv []string
+	switch {
+	case len(step.Run) > 0:
+		argv = append([]string{step.Run[0]}, args...)
+	case step.Script != "":
+		argv = []string{"sh", "-c", step.Script}
+	default:
+		res.Error = "host step has neither run nor script"
+		return res, errors.New(res.Error)
+	}
+
+	if opts.DryRun {
+		fmt.Fprintf(opts.Out, "  [%s] would run on host: %s\n", step.ID, strings.Join(argv, " "))
+		return res, nil
+	}
+	if opts.RequirePrivate {
+		res.Error = "host step refused: --require-private is set, and a host step runs " +
+			"outside any node's network so the gate cannot vouch for it"
+		return res, errors.New(res.Error)
+	}
+	if !opts.AllowHostExec {
+		res.Error = "host step refused: pass --allow-host-exec to permit `kind: host` steps, " +
+			"which run arbitrary programs on this machine"
+		return res, errors.New(res.Error)
+	}
+
+	fmt.Fprintf(opts.Err, "  [%s] host: %s\n", step.ID, strings.Join(argv, " "))
+	start := time.Now()
+
+	cmd := exec.CommandContext(ctx, argv[0], argv[1:]...)
+	cmd.Dir = step.Dir
+	cmd.Stderr = opts.Err
+	if len(step.Env) > 0 {
+		cmd.Env = os.Environ()
+		for _, k := range sortedEnvKeys(step.Env) {
+			cmd.Env = append(cmd.Env, k+"="+step.Env[k])
+		}
+	}
+	stdout, err := cmd.Output()
+	res.DurationMs = time.Since(start).Milliseconds()
+	if cmd.ProcessState != nil {
+		res.ExitCode = cmd.ProcessState.ExitCode()
+	}
+	// A host step is not obliged to emit JSON; captureOutput returns an
+	// empty map when it does not, and one that does emit JSON feeds
+	// {{ steps.<id>.<field> }} exactly like a command step.
+	res.Output = captureOutput(stdout)
+	if err != nil {
+		res.Error = err.Error()
+		return res, err
+	}
+	return res, nil
+}
+
+func sortedEnvKeys(m map[string]string) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
 }

--- a/internal/recipe/types.go
+++ b/internal/recipe/types.go
@@ -1,16 +1,25 @@
 // Package recipe runs declarative trond multi-step workflows.
 //
-// A recipe is a YAML document in recipes/*.yaml that codifies one of
-// the canonical workflows from AGENTS.md (deploy fresh node, snapshot
-// then apply, recover from failed upgrade, etc.). Each step calls a
-// trond subcommand with arguments that can reference the user-supplied
-// parameters and outputs from earlier steps via {{ params.* }} /
-// {{ steps.<id>.<field> }} template substitution.
+// A recipe is a YAML document — one of the built-ins embedded from
+// files/*.yaml, or any file passed to `recipe run --file` — codifying a
+// workflow from AGENTS.md (deploy fresh node, snapshot then apply,
+// recover from failed upgrade, etc.). Arguments can reference the
+// user-supplied parameters and the outputs of earlier steps via
+// {{ params.* }} / {{ steps.<id>.<field> }} substitution.
 //
-// The runner re-execs the trond binary itself for each step (no shell
-// dependency beyond exec) and captures the JSON output for downstream
-// references. This keeps every step idempotent and testable in
-// isolation.
+// There are two kinds of step:
+//
+//   - kind: command (the default) re-execs the trond binary with a
+//     subcommand path, and captures its JSON for downstream references.
+//     The run's --state-dir and --require-private are forwarded, so a
+//     step acts in the same place and under the same safety policy as
+//     the run that launched it.
+//
+//   - kind: host runs a program on the machine running trond. It is the
+//     only step that escapes trond's own surface, so it is refused
+//     unless --allow-host-exec is passed, and refused outright under
+//     --require-private: a host step names no node, so the gate has
+//     nothing to check and cannot vouch for it.
 package recipe
 
 import "encoding/json"
@@ -43,12 +52,55 @@ type Param struct {
 	Description string `yaml:"description,omitempty" json:"description,omitempty"`
 }
 
-// Step is one unit of work. Today only command steps are supported;
-// future kinds (poll, sleep, branch) live behind the same struct so
-// recipes don't need migration when added.
+// Step kinds.
+//
+// The zero value is KindCommand, and that is load-bearing: it is what
+// keeps every recipe written before this field existed parsing and
+// running byte-identically.
+//
+// "host" rather than "exec" or "local": `trond exec <node>` already means
+// the opposite of this (run something INSIDE a managed node), and "local"
+// collides with `target: {type: local}`, which is about where a node
+// lives, not where a step runs.
+const (
+	KindCommand = "command" // re-exec the trond binary with a subcommand path
+	KindHost    = "host"    // run a program on the machine running trond
+)
+
+// Step is one unit of work.
 type Step struct {
 	ID          string `yaml:"id"                   json:"id"`
 	Description string `yaml:"description,omitempty" json:"description,omitempty"`
+
+	// Kind selects the executor: "command" (default) or "host". Never
+	// normalised on the wire, so `recipe show -o json` for an existing
+	// recipe stays byte-identical to what it printed before.
+	Kind string `yaml:"kind,omitempty" json:"kind,omitempty"`
+
+	// Run is the argv of a host step: run[0] is the program, one YAML
+	// item per token. Deliberately NOT whitespace-split — a path with a
+	// space in it would otherwise become two arguments — and deliberately
+	// not a shell, so `script:` is the only way to get one and
+	// `grep -l 'script:'` is a complete census of shell usage in a
+	// recipe tree. Mutually exclusive with Script.
+	Run []string `yaml:"run,omitempty" json:"run,omitempty"`
+
+	// Script is a shell body run as `sh -c <script>`. Mutually exclusive
+	// with Run. Use it when you need pipes, globs or conditionals;
+	// prefer Run when you do not, because argv has no quoting rules to
+	// get wrong.
+	Script string `yaml:"script,omitempty" json:"script,omitempty"`
+
+	// Dir is the working directory for a host step. Relative paths are
+	// resolved against the process's cwd, not the recipe's location —
+	// a recipe should not silently depend on where its file happens to
+	// sit.
+	Dir string `yaml:"dir,omitempty" json:"dir,omitempty"`
+
+	// Env adds environment variables to a host step, on top of the
+	// inherited environment. Values go through the same substitution as
+	// args.
+	Env map[string]string `yaml:"env,omitempty" json:"env,omitempty"`
 
 	// Command is the trond subcommand path to invoke, e.g.
 	// "config validate", "snapshot download", "apply". Trond's own


### PR DESCRIPTION
Recipes could only call trond subcommands, so a workflow needing `Toolkit.jar`, a funding script, or anything else outside trond could not be expressed. This is the third and last piece of the recipe work, after #212 (steps inherit the parent's state and gate) and #213 (`--file`).

```yaml
steps:
  - id: stage
    kind: host
    run: ["java", "-jar", "Toolkit.jar", "db", "fork"]

  - id: fund
    kind: host
    script: |
      for a in $(cat addrs.txt); do ./fund.sh "$a"; done
```

`run:` is argv and never sees a shell; `script:` is the only way to get one. That separation is the point — shell metacharacters in a `run:` item are inert, so `grep -l 'script:'` is a complete census of shell usage across a recipe tree. `run[0]` is never templated either: a substituted program name makes "what does this recipe execute" unanswerable by reading it.

## Two refusals

This is the only step kind that escapes trond's own surface. A command step is bounded by what trond will do, and after #211 every node-touching trond verb is individually gated and audited. A host step is bounded by nothing.

**Without `--allow-host-exec`, it does not run.** Choosing a recipe file and opting into arbitrary execution are separate decisions, and `--file` means the file can come from anywhere. The flag makes "this run may execute arbitrary programs" an explicit, greppable decision rather than a property of whichever file was passed.

**Under `--require-private` it does not run either — including with `--allow-host-exec`.** The gate promises an agent is *"mechanically incapable of mutating a mainnet/nile rig"*. A host step can delete a mainnet node's data directory without ever naming the node, so honouring that promise means refusing outright rather than inspecting the command and guessing what it does. The gate has no node to check here, which is precisely why it must refuse rather than allow. `--allow-host-exec` cannot lift the floor, and a test pins that.

`--dry-run` previews host steps under either refusal — printing what would run changes nothing, and the same reasoning already lets `auto-heal --dry-run` through the gate.

Verified end to end:

```
$ trond recipe run --file host.yaml                            # no opt-in
Error [RECIPE_FAILED]: step stage failed: host step refused: pass --allow-host-exec ...

$ trond --require-private recipe run --file host.yaml --allow-host-exec
Error [RECIPE_FAILED]: step stage failed: host step refused: --require-private is set,
and a host step runs outside any node's network so the gate cannot vouch for it

$ trond recipe run --file host.yaml --allow-host-exec           # permitted
  [stage] host: touch /tmp/…/RAN
recipe host-demo: status=success, 1 steps, 4ms

$ trond --require-private recipe run --file host.yaml --dry-run # preview survives
  [stage] would run on host: touch /tmp/…/RAN
```

In every refused case the target file was confirmed absent afterwards, not just the exit code checked.

## Compatibility

The zero value of `Kind` is `command`, so every recipe written before this field existed parses and runs byte-identically — a test pins that too. Validation rejects the shapes that would otherwise be ambiguous: both `run` and `script`, neither, `command` on a host step, host fields on a command step, an unknown kind.

`recipe-show.schema.json` does not constrain step properties, so no schema change and no version bump.

## Testing

- `make test -race` — 25 packages, 0 failures
- `make lint` — no findings
- 14 new tests: the three-way permit/refuse matrix, dry-run preview under both refusals, argv-is-not-a-shell, `dir:`/`env:` handling with substitution, and five validation shapes

## Not here

- **No per-step timeout.** The runner has none for command steps either, and adding one for a single kind would be asymmetric — it wants to arrive for both at once.
- **No per-host-step audit entry.** Recipe runs are not audited at all today; that is worth fixing as its own change rather than bolting onto one step kind.
