### PR TITLE
fix(audit): record what ran — plus the outstanding follow-ups

### DIFF
--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -107,15 +107,14 @@ func runExec(cmd *cobra.Command, args []string) error {
 	os.Stdout.Write(out)
 	if execErr != nil {
 		writeAudit(auditEvent{Command: "exec", Node: nodeName, Target: nc.Target.String(),
-			Result: "error", ErrorCode: "EXEC_ERROR", Start: start})
+			Result: "error", ErrorCode: "EXEC_ERROR", Detail: bin, Start: start})
 		return output.NewError("EXEC_ERROR", output.ExitGeneralError,
 			fmt.Sprintf("exec on %s failed: %v", nodeName, execErr))
 	}
-	// Audited like every other verb that touches a node. The entry records
-	// that an exec happened, not what ran: AuditEntry has no field for it,
-	// and the argv is the one place a caller is most likely to have put a
-	// token or key. Recording the program name would need a schema change.
+	// Detail is the program only. The rest of the argv is where a caller
+	// is most likely to have put a token, and an audit log is the wrong
+	// place to learn one.
 	writeAudit(auditEvent{Command: "exec", Node: nodeName, Target: nc.Target.String(),
-		Result: "success", Start: start})
+		Result: "success", Detail: bin, Start: start})
 	return nil
 }

--- a/cmd/files.go
+++ b/cmd/files.go
@@ -89,7 +89,7 @@ func runFilesPut(cmd *cobra.Command, args []string) error {
 		// Direct host write via Target.WriteFile.
 		if err := nc.Target.WriteFile(ctx, remoteDst, data, 0o644); err != nil {
 			writeAudit(auditEvent{Command: "files put", Node: nodeName, Target: nc.Target.String(),
-				Result: "error", ErrorCode: "FILES_ERROR", Start: start})
+				Result: "error", ErrorCode: "FILES_ERROR", Detail: remoteDst, Start: start})
 			return output.NewError("FILES_ERROR", output.ExitGeneralError,
 				fmt.Sprintf("write to %s: %v", remoteDst, err))
 		}
@@ -115,16 +115,15 @@ func runFilesPut(cmd *cobra.Command, args []string) error {
 
 		if _, err := nc.Target.Exec(ctx, "docker", "cp", stagePath, fmt.Sprintf("%s:%s", nodeName, remoteDst)); err != nil {
 			writeAudit(auditEvent{Command: "files put", Node: nodeName, Target: nc.Target.String(),
-				Result: "error", ErrorCode: "FILES_ERROR", Start: start})
+				Result: "error", ErrorCode: "FILES_ERROR", Detail: remoteDst, Start: start})
 			return output.NewError("FILES_ERROR", output.ExitGeneralError,
 				fmt.Sprintf("docker cp into %s: %v", nodeName, err))
 		}
 	}
 
-	// Audited like the other verbs that change a node. Records that bytes
-	// were written and where, not their contents.
+	// Records where the bytes went, never what they were.
 	writeAudit(auditEvent{Command: "files put", Node: nodeName, Target: nc.Target.String(),
-		Result: "success", Start: start})
+		Result: "success", Detail: remoteDst, Start: start})
 	return writeFilesResult(outputFmt, "put", nodeName, localSrc, remoteDst, len(data))
 }
 

--- a/cmd/files.go
+++ b/cmd/files.go
@@ -131,6 +131,12 @@ func runFilesGet(cmd *cobra.Command, args []string) error {
 	nodeName, remoteSrc, localDst := args[0], args[1], args[2]
 	outputFmt, _ := cmd.Flags().GetString("output")
 
+	// get reads an arbitrary path off the node. That is not a mutation, so
+	// it is not gated — but a jar node's config.conf carries the
+	// block-signing key in localwitness, so which path was read is worth
+	// recording even when reading it was entirely legitimate.
+	start := time.Now()
+
 	nc, err := resolveNodeContext(nodeName)
 	if err != nil {
 		return err
@@ -177,6 +183,8 @@ func runFilesGet(cmd *cobra.Command, args []string) error {
 		return output.NewError("FILES_ERROR", output.ExitGeneralError, err.Error())
 	}
 
+	writeAudit(auditEvent{Command: "files get", Node: nodeName, Target: nc.Target.String(),
+		Result: "success", Detail: remoteSrc, Start: start})
 	return writeFilesResult(outputFmt, "get", nodeName, remoteSrc, localDst, len(data))
 }
 

--- a/cmd/recipe.go
+++ b/cmd/recipe.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/spf13/cobra"
 
@@ -243,6 +244,7 @@ func runRecipeRun(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		exe = os.Args[0]
 	}
+	runStart := time.Now()
 
 	// Dry-run prints its plan to Out. In json mode that is the same stream
 	// the RunResult goes to, so the plan lines land in front of the JSON
@@ -267,7 +269,41 @@ func runRecipeRun(cmd *cobra.Command, args []string) error {
 		StateDir:       paths.BaseDir(),
 		RequirePrivate: guard.Requested(),
 		AllowHostExec:  recipeAllowHostExec,
+		// Host steps never re-enter trond, so nothing else would record
+		// them. Detail names the step and its program — an identifier,
+		// not the argv or the script body.
+		AuditHostStep: func(step recipe.Step, sr recipe.StepResult) {
+			result, code := "success", ""
+			if sr.Error != "" {
+				result, code = "error", "HOST_STEP_ERROR"
+			}
+			writeAudit(auditEvent{
+				Command:   "recipe host-step",
+				Result:    result,
+				ErrorCode: code,
+				Detail:    step.ID + ": " + hostStepProgram(step),
+				Start:     time.Now().Add(-time.Duration(sr.DurationMs) * time.Millisecond),
+			})
+		},
 	})
+
+	// One entry for the run itself, whatever its steps did. Without it a
+	// recipe — the most capable single command trond has, now that a step
+	// can be an arbitrary host program — is the only thing that can act
+	// and leave nothing behind.
+	if res != nil {
+		result, code := "success", ""
+		if runErr != nil {
+			result, code = "error", "RECIPE_FAILED"
+		}
+		writeAudit(auditEvent{
+			Command:   "recipe run",
+			Result:    result,
+			ErrorCode: code,
+			Detail:    source,
+			Start:     runStart,
+		})
+	}
 
 	if res != nil {
 		res.Source = source
@@ -294,6 +330,16 @@ func runRecipeRun(cmd *cobra.Command, args []string) error {
 		return output.NewError("RECIPE_FAILED", exit, runErr.Error())
 	}
 	return nil
+}
+
+// hostStepProgram names what a host step executes, for the audit detail:
+// the program for a run: step, "sh" for a script: step. Never the
+// arguments or the script body — those are payload.
+func hostStepProgram(step recipe.Step) string {
+	if len(step.Run) > 0 {
+		return step.Run[0]
+	}
+	return "sh"
 }
 
 func parseParamFlags(pairs []string) (map[string]string, error) {

--- a/cmd/recipe.go
+++ b/cmd/recipe.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"crypto/rand"
+	"encoding/hex"
 	"fmt"
 	"os"
 	"strings"
@@ -245,6 +247,14 @@ func runRecipeRun(cmd *cobra.Command, args []string) error {
 		exe = os.Args[0]
 	}
 	runStart := time.Now()
+	// One id per run, minted here and inherited by every step's child
+	// process. Random rather than sequential: two runs against the same
+	// state dir must not collide, and a counter would need state of its
+	// own.
+	runID, err := newAuditRunID()
+	if err != nil {
+		return output.NewError("INTERNAL_ERROR", output.ExitGeneralError, err.Error())
+	}
 
 	// Dry-run prints its plan to Out. In json mode that is the same stream
 	// the RunResult goes to, so the plan lines land in front of the JSON
@@ -269,6 +279,8 @@ func runRecipeRun(cmd *cobra.Command, args []string) error {
 		StateDir:       paths.BaseDir(),
 		RequirePrivate: guard.Requested(),
 		AllowHostExec:  recipeAllowHostExec,
+		RunID:          runID,
+		RunIDEnv:       AuditRunIDEnv,
 		// Host steps never re-enter trond, so nothing else would record
 		// them. Detail names the step and its program — an identifier,
 		// not the argv or the script body.
@@ -278,6 +290,7 @@ func runRecipeRun(cmd *cobra.Command, args []string) error {
 				result, code = "error", "HOST_STEP_ERROR"
 			}
 			writeAudit(auditEvent{
+				RunID:     runID,
 				Command:   "recipe host-step",
 				Result:    result,
 				ErrorCode: code,
@@ -297,6 +310,7 @@ func runRecipeRun(cmd *cobra.Command, args []string) error {
 			result, code = "error", "RECIPE_FAILED"
 		}
 		writeAudit(auditEvent{
+			RunID:     runID,
 			Command:   "recipe run",
 			Result:    result,
 			ErrorCode: code,
@@ -330,6 +344,15 @@ func runRecipeRun(cmd *cobra.Command, args []string) error {
 		return output.NewError("RECIPE_FAILED", exit, runErr.Error())
 	}
 	return nil
+}
+
+// newAuditRunID mints a short random correlation id.
+func newAuditRunID() (string, error) {
+	var b [8]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return "", fmt.Errorf("generate audit run id: %w", err)
+	}
+	return hex.EncodeToString(b[:]), nil
 }
 
 // hostStepProgram names what a host step executes, for the audit detail:

--- a/cmd/recipe_audit_test.go
+++ b/cmd/recipe_audit_test.go
@@ -1,0 +1,165 @@
+package cmd
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/tronprotocol/tron-deployment/internal/paths"
+)
+
+// A recipe run is the most capable single command trond has — since
+// `kind: host`, one step can be an arbitrary program — and it was the
+// only one that could act and leave nothing in the audit log. Command
+// steps re-exec trond, so the child writes its own entry; host steps
+// never re-enter trond, and the run itself was never recorded at all.
+
+func writeTempRecipe(t *testing.T, body string) string {
+	t.Helper()
+	p := filepath.Join(t.TempDir(), "r.yaml")
+	if err := os.WriteFile(p, []byte(body), 0o600); err != nil {
+		t.Fatalf("write recipe: %v", err)
+	}
+	return p
+}
+
+// auditLines returns (command, detail, result) for each audit entry.
+func auditLines(t *testing.T) [][3]string {
+	t.Helper()
+	raw, err := os.ReadFile(paths.AuditLog())
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		t.Fatalf("read audit log: %v", err)
+	}
+	var out [][3]string
+	for _, line := range strings.Split(strings.TrimSpace(string(raw)), "\n") {
+		if line == "" {
+			continue
+		}
+		var e struct{ Command, Detail, Result string }
+		if err := json.Unmarshal([]byte(line), &e); err != nil {
+			t.Fatalf("audit line %q: %v", line, err)
+		}
+		out = append(out, [3]string{e.Command, e.Detail, e.Result})
+	}
+	return out
+}
+
+func setupRecipeAudit(t *testing.T) {
+	t.Helper()
+	paths.SetBaseDir(t.TempDir())
+	t.Cleanup(func() { paths.SetBaseDir("") })
+	t.Cleanup(func() {
+		recipeFile, recipeAllowHostExec, recipeRunDryRun = "", false, false
+		recipeRunParams = nil
+	})
+}
+
+func TestRecipeRun_AuditsRunAndHostSteps(t *testing.T) {
+	setupRecipeAudit(t)
+	marker := filepath.Join(t.TempDir(), "ran")
+	recipeFile = writeTempRecipe(t, `name: audited
+steps:
+  - id: stage
+    kind: host
+    run: ["touch", "`+marker+`"]
+`)
+	recipeAllowHostExec = true
+
+	if err := runRecipeRun(newCmd(), nil); err != nil {
+		t.Fatalf("runRecipeRun: %v", err)
+	}
+
+	lines := auditLines(t)
+	var host, run [3]string
+	for _, l := range lines {
+		switch l[0] {
+		case "recipe host-step":
+			host = l
+		case "recipe run":
+			run = l
+		}
+	}
+	if host[0] == "" {
+		t.Fatalf("no `recipe host-step` entry; a host step ran and the log never saw it.\ngot: %v", lines)
+	}
+	if !strings.Contains(host[1], "stage") || !strings.Contains(host[1], "touch") {
+		t.Errorf("host-step detail = %q, want it to name the step and its program", host[1])
+	}
+	if run[0] == "" {
+		t.Fatalf("no `recipe run` entry.\ngot: %v", lines)
+	}
+	if run[1] != recipeFile {
+		t.Errorf("run detail = %q, want the recipe source %q", run[1], recipeFile)
+	}
+	if run[2] != "success" {
+		t.Errorf("run result = %q, want success", run[2])
+	}
+}
+
+// TestRecipeRun_RefusedHostStepLeavesNoStepEntry: the audit log records
+// what ran. A step refused by --allow-host-exec did not run, so claiming
+// it did would be worse than silence — but the run itself is still
+// recorded, as a failure.
+func TestRecipeRun_RefusedHostStepLeavesNoStepEntry(t *testing.T) {
+	setupRecipeAudit(t)
+	marker := filepath.Join(t.TempDir(), "ran")
+	recipeFile = writeTempRecipe(t, `name: refused
+steps:
+  - id: stage
+    kind: host
+    run: ["touch", "`+marker+`"]
+`)
+	// recipeAllowHostExec stays false.
+
+	if err := runRecipeRun(newCmd(), nil); err == nil {
+		t.Fatal("want the refusal to surface as an error")
+	}
+	if _, err := os.Stat(marker); err == nil {
+		t.Fatal("the refused step ran")
+	}
+
+	for _, l := range auditLines(t) {
+		if l[0] == "recipe host-step" {
+			t.Errorf("audited a host step that never ran: %v", l)
+		}
+	}
+	var found bool
+	for _, l := range auditLines(t) {
+		if l[0] == "recipe run" {
+			found = true
+			if l[2] != "error" {
+				t.Errorf("run result = %q, want error", l[2])
+			}
+		}
+	}
+	if !found {
+		t.Error("a failed run left no `recipe run` entry")
+	}
+}
+
+// TestRecipeRun_DryRunAuditsNoHostStep — a preview executed nothing.
+func TestRecipeRun_DryRunAuditsNoHostStep(t *testing.T) {
+	setupRecipeAudit(t)
+	recipeFile = writeTempRecipe(t, `name: preview
+steps:
+  - id: stage
+    kind: host
+    run: ["touch", "/tmp/should-not-happen"]
+`)
+	recipeAllowHostExec = true
+	recipeRunDryRun = true
+
+	if err := runRecipeRun(newCmd(), nil); err != nil {
+		t.Fatalf("dry-run: %v", err)
+	}
+	for _, l := range auditLines(t) {
+		if l[0] == "recipe host-step" {
+			t.Errorf("dry-run audited a host step: %v", l)
+		}
+	}
+}

--- a/cmd/resolve.go
+++ b/cmd/resolve.go
@@ -176,6 +176,7 @@ type auditEvent struct {
 	IntentHash string
 	Result     string // "success", "error", "rollback"
 	ErrorCode  string
+	Detail     string // what was acted on; identifiers only, never payloads
 	Start      time.Time
 }
 
@@ -197,6 +198,7 @@ func writeAudit(ev auditEvent) {
 		Result:     ev.Result,
 		DurationMs: time.Since(ev.Start).Milliseconds(),
 		ErrorCode:  ev.ErrorCode,
+		Detail:     ev.Detail,
 	}
 	if writeErr := al.Write(entry); writeErr != nil {
 		Log().Warn("audit log write failed", "error", writeErr)

--- a/cmd/resolve.go
+++ b/cmd/resolve.go
@@ -1,8 +1,10 @@
 package cmd
 
 import (
+	"cmp"
 	"context"
 	"fmt"
+	"os"
 	"time"
 
 	"github.com/tronprotocol/tron-deployment/internal/guard"
@@ -177,8 +179,15 @@ type auditEvent struct {
 	Result     string // "success", "error", "rollback"
 	ErrorCode  string
 	Detail     string // what was acted on; identifiers only, never payloads
+	RunID      string // set by the process that mints the id; children inherit it via the environment
 	Start      time.Time
 }
+
+// AuditRunIDEnv carries a recipe run's correlation id into the steps it
+// re-execs. Read from the environment rather than passed as a flag: every
+// trond command writes audit entries, and threading a parameter through
+// all of them to serve one caller is the wrong shape.
+const AuditRunIDEnv = "TROND_AUDIT_RUN_ID"
 
 // writeAudit writes an audit log entry for a mutating command. Failures are
 // logged but never propagated — losing an audit line should not break the
@@ -199,6 +208,7 @@ func writeAudit(ev auditEvent) {
 		DurationMs: time.Since(ev.Start).Milliseconds(),
 		ErrorCode:  ev.ErrorCode,
 		Detail:     ev.Detail,
+		RunID:      cmp.Or(ev.RunID, os.Getenv(AuditRunIDEnv)),
 	}
 	if writeErr := al.Write(entry); writeErr != nil {
 		Log().Warn("audit log write failed", "error", writeErr)

--- a/cmd/wait.go
+++ b/cmd/wait.go
@@ -118,6 +118,16 @@ func runWait(cmd *cobra.Command, args []string) error {
 	}
 	defer nc.Close()
 
+	// Validate once, before the poll loop: a bad --http should fail now,
+	// not on every attempt until the timeout expires.
+	var probeURL string
+	if waitHTTP != "" {
+		probeURL, err = httpProbeURL(expandHTTPURL(waitHTTP, nc.Node.HTTPPort))
+		if err != nil {
+			return err
+		}
+	}
+
 	ctx, cancel := context.WithTimeout(cmd.Context(), waitTimeout)
 	defer cancel()
 
@@ -131,7 +141,7 @@ func runWait(cmd *cobra.Command, args []string) error {
 		case waitPort != 0:
 			probeErr = probeTCP(ctx, nc.Target, waitPort)
 		case waitHTTP != "":
-			probeErr = probeHTTP(ctx, nc, expandHTTPURL(waitHTTP, nc.Node.HTTPPort))
+			probeErr = probeHTTP(ctx, nc, probeURL)
 		case waitExec != "":
 			probeErr = probeExec(ctx, nc, waitExec)
 		}
@@ -187,6 +197,20 @@ func probeTCP(ctx context.Context, _ target.Target, port int) error {
 // probeHTTP runs curl inside the node via Target.Exec so the probe sees the
 // container's network. For local docker nodes this routes through `docker
 // exec`; for jar / SSH nodes it runs on the target host directly.
+// httpProbeURL validates the --http value before it becomes an argv item
+// for curl on the node. Without the scheme check a value like
+// "-K/etc/shadow" or "-o/tmp/x" is an option rather than a URL, and curl
+// reads it as one. It is argv rather than a shell, so this is a narrow
+// hole — but "starts with http:// or https://" costs one comparison and
+// closes it.
+func httpProbeURL(raw string) (string, error) {
+	if !strings.HasPrefix(raw, "http://") && !strings.HasPrefix(raw, "https://") {
+		return "", output.NewError("VALIDATION_ERROR", output.ExitValidationError,
+			fmt.Sprintf("--http must be an http:// or https:// URL (or contain {http}), got %q", raw))
+	}
+	return raw, nil
+}
+
 func probeHTTP(ctx context.Context, nc *nodeContext, url string) error {
 	args := []string{"-fsS", "--max-time", "5", url}
 	out, err := nc.runtimeExec(ctx, "curl", args...)

--- a/internal/recipe/runner.go
+++ b/internal/recipe/runner.go
@@ -66,6 +66,21 @@ type RunOptions struct {
 	// programs" an explicit, greppable decision rather than a property
 	// of whichever file was passed to --file.
 	AllowHostExec bool
+
+	// AuditHostStep, when set, is called after each host step that
+	// actually ran (not one refused or previewed).
+	//
+	// Host steps are the only kind nothing else records. A command step
+	// re-execs trond, and that child writes its own audit entry under its
+	// own verb — so the audit log already sees it, at the granularity of
+	// the verb. A host step never enters trond again, which would leave
+	// the most capable thing a recipe can do as the one thing the log
+	// never sees.
+	//
+	// A callback rather than a direct write: the audit log's location and
+	// policy belong to the CLI, and internal/recipe should not grow an
+	// opinion about either.
+	AuditHostStep func(step Step, res StepResult)
 }
 
 // Run executes a recipe. Returns a RunResult plus error; the error is
@@ -397,6 +412,12 @@ func runHostStep(ctx context.Context, opts RunOptions, step Step, args []string)
 	res.DurationMs = time.Since(start).Milliseconds()
 	if cmd.ProcessState != nil {
 		res.ExitCode = cmd.ProcessState.ExitCode()
+	}
+	if opts.AuditHostStep != nil {
+		if err != nil {
+			res.Error = err.Error()
+		}
+		opts.AuditHostStep(step, res)
 	}
 	// A host step is not obliged to emit JSON; captureOutput returns an
 	// empty map when it does not, and one that does emit JSON feeds

--- a/internal/recipe/runner.go
+++ b/internal/recipe/runner.go
@@ -81,6 +81,37 @@ type RunOptions struct {
 	// policy belong to the CLI, and internal/recipe should not grow an
 	// opinion about either.
 	AuditHostStep func(step Step, res StepResult)
+
+	// RunID is a correlation id exported into every step's environment,
+	// so the audit entries a command step writes as a child process can
+	// be tied back to the run that caused them. Empty means "do not set
+	// it", which keeps a direct Run() call from inventing one.
+	RunID string
+
+	// RunIDEnv names the environment variable RunID travels in. The CLI
+	// owns the name; internal/recipe should not hard-code a convention
+	// that belongs to the audit log.
+	RunIDEnv string
+}
+
+// childEnv returns the environment for a step's child process: the
+// inherited environment, plus the correlation id, plus any step-level
+// overrides. Returns nil when there is nothing to add, so exec inherits
+// the parent environment unchanged.
+func (o RunOptions) childEnv(extra map[string]string) []string {
+	if o.RunID == "" || o.RunIDEnv == "" {
+		if len(extra) == 0 {
+			return nil
+		}
+	}
+	env := os.Environ()
+	if o.RunID != "" && o.RunIDEnv != "" {
+		env = append(env, o.RunIDEnv+"="+o.RunID)
+	}
+	for _, k := range sortedEnvKeys(extra) {
+		env = append(env, k+"="+extra[k])
+	}
+	return env
 }
 
 // Run executes a recipe. Returns a RunResult plus error; the error is
@@ -275,6 +306,7 @@ func runStep(ctx context.Context, opts RunOptions, step Step, args []string) (St
 	start := time.Now()
 
 	cmd := exec.CommandContext(ctx, opts.Binary, full...)
+	cmd.Env = opts.childEnv(nil)
 	cmd.Stderr = opts.Err
 	stdout, err := cmd.Output()
 	res.DurationMs = time.Since(start).Milliseconds()
@@ -402,12 +434,7 @@ func runHostStep(ctx context.Context, opts RunOptions, step Step, args []string)
 	cmd := exec.CommandContext(ctx, argv[0], argv[1:]...)
 	cmd.Dir = step.Dir
 	cmd.Stderr = opts.Err
-	if len(step.Env) > 0 {
-		cmd.Env = os.Environ()
-		for _, k := range sortedEnvKeys(step.Env) {
-			cmd.Env = append(cmd.Env, k+"="+step.Env[k])
-		}
-	}
+	cmd.Env = opts.childEnv(step.Env)
 	stdout, err := cmd.Output()
 	res.DurationMs = time.Since(start).Milliseconds()
 	if cmd.ProcessState != nil {

--- a/internal/schema/embed.go
+++ b/internal/schema/embed.go
@@ -119,7 +119,7 @@ import (
 //	        `md5_verified: false` on a successful download means one
 //	        thing only: the operator passed `--no-verify` / `no_verify`.
 //	        One existing schema, one additive optional field — PATCH.
-const SchemaVersion = "1.14.0"
+const SchemaVersion = "1.15.0"
 
 // JSONSchemaURLBase is the canonical URL prefix for individual output
 // schema files. Embedded $id values inside each schema mirror this so

--- a/internal/schema/embed.go
+++ b/internal/schema/embed.go
@@ -119,7 +119,7 @@ import (
 //	        `md5_verified: false` on a successful download means one
 //	        thing only: the operator passed `--no-verify` / `no_verify`.
 //	        One existing schema, one additive optional field — PATCH.
-const SchemaVersion = "1.13.0"
+const SchemaVersion = "1.14.0"
 
 // JSONSchemaURLBase is the canonical URL prefix for individual output
 // schema files. Embedded $id values inside each schema mirror this so

--- a/internal/schema/files/events.schema.json
+++ b/internal/schema/files/events.schema.json
@@ -4,19 +4,56 @@
   "title": "trond events output",
   "description": "JSONL stream emitted by `trond events --output json`. Each line is one audit-log entry.",
   "type": "object",
-  "required": ["timestamp", "command", "result"],
+  "required": [
+    "timestamp",
+    "command",
+    "result"
+  ],
   "properties": {
-    "timestamp": { "type": "string", "format": "date-time" },
-    "command":   {
+    "timestamp": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "command": {
       "type": "string",
       "description": "The trond subcommand that was invoked.",
-      "examples": ["apply", "stop", "snapshot.download", "network.create"]
+      "examples": [
+        "apply",
+        "stop",
+        "snapshot.download",
+        "network.create"
+      ]
     },
-    "node":         { "type": "string", "description": "Affected managed node, when applicable." },
-    "target":       { "type": "string", "description": "Target type that processed the command (local | ssh)." },
-    "intent_hash":  { "type": "string", "pattern": "^[0-9a-f]{64}$" },
-    "result":       { "type": "string", "enum": ["success", "failure", "no_change"] },
-    "duration_ms":  { "type": "integer", "minimum": 0 },
-    "error_code":   { "type": "string" }
+    "node": {
+      "type": "string",
+      "description": "Affected managed node, when applicable."
+    },
+    "target": {
+      "type": "string",
+      "description": "Target type that processed the command (local | ssh)."
+    },
+    "intent_hash": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "result": {
+      "type": "string",
+      "enum": [
+        "success",
+        "failure",
+        "no_change"
+      ]
+    },
+    "duration_ms": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "error_code": {
+      "type": "string"
+    },
+    "detail": {
+      "type": "string",
+      "description": "What the command acted on, for verbs where the verb alone does not say (exec's program, files put's destination, a recipe's source). An identifier, never a payload."
+    }
   }
 }

--- a/internal/schema/files/events.schema.json
+++ b/internal/schema/files/events.schema.json
@@ -54,6 +54,10 @@
     "detail": {
       "type": "string",
       "description": "What the command acted on, for verbs where the verb alone does not say (exec's program, files put's destination, a recipe's source). An identifier, never a payload."
+    },
+    "run_id": {
+      "type": "string",
+      "description": "Correlation id shared by every entry from one recipe run, including the steps it re-execs."
     }
   }
 }

--- a/internal/schema/version_baseline.json
+++ b/internal/schema/version_baseline.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": "1.14.0",
+  "schema_version": "1.15.0",
   "entries": [
     {
       "name": "apply",
@@ -51,7 +51,7 @@
     },
     {
       "name": "events",
-      "hash": "8e58c4d1e5d053f86701083f3c19ab98ab6ac43488bd10c7a3edb31c38c9b548"
+      "hash": "6f192c6454758b89fc087087bcb6a1e5ff35412f383889daea3775b7ae31f81b"
     },
     {
       "name": "health",

--- a/internal/schema/version_baseline.json
+++ b/internal/schema/version_baseline.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": "1.13.0",
+  "schema_version": "1.14.0",
   "entries": [
     {
       "name": "apply",
@@ -51,7 +51,7 @@
     },
     {
       "name": "events",
-      "hash": "abcf44d4bf3e785f04058aa4ff1012f02982692ff6083b03d3d499aea45a97a2"
+      "hash": "8e58c4d1e5d053f86701083f3c19ab98ab6ac43488bd10c7a3edb31c38c9b548"
     },
     {
       "name": "health",

--- a/internal/security/audit.go
+++ b/internal/security/audit.go
@@ -19,6 +19,18 @@ type AuditEntry struct {
 	Result     string    `json:"result"`
 	DurationMs int64     `json:"duration_ms"`
 	ErrorCode  string    `json:"error_code,omitempty"`
+
+	// Detail names WHAT the command acted on, for the verbs where the
+	// verb alone does not say. "exec" and "recipe host-step" run
+	// caller-supplied programs and "files put" writes caller-supplied
+	// bytes: an entry recording only that one of them happened cannot
+	// answer the question an audit log exists to answer.
+	//
+	// It carries an identifier — a program name, a destination path, a
+	// recipe source — never a payload. Full argv and file contents are
+	// exactly where a caller is most likely to have put a token or key,
+	// and an audit log is the wrong place to learn that.
+	Detail string `json:"detail,omitempty"`
 }
 
 // AuditLog writes append-only JSONL entries to the audit log file.

--- a/internal/security/audit.go
+++ b/internal/security/audit.go
@@ -31,6 +31,14 @@ type AuditEntry struct {
 	// exactly where a caller is most likely to have put a token or key,
 	// and an audit log is the wrong place to learn that.
 	Detail string `json:"detail,omitempty"`
+
+	// RunID ties entries produced by one recipe run together. A recipe's
+	// command steps re-exec trond, so each child writes its own entry
+	// under its own verb — correct, but it leaves the log showing
+	// "stop n0" with no indication that a recipe drove it, and no way to
+	// tell two concurrent runs apart. The parent mints an id and the
+	// children inherit it through the environment.
+	RunID string `json:"run_id,omitempty"`
 }
 
 // AuditLog writes append-only JSONL entries to the audit log file.

--- a/schemas/output/events.schema.json
+++ b/schemas/output/events.schema.json
@@ -4,19 +4,60 @@
   "title": "trond events output",
   "description": "JSONL stream emitted by `trond events --output json`. Each line is one audit-log entry.",
   "type": "object",
-  "required": ["timestamp", "command", "result"],
+  "required": [
+    "timestamp",
+    "command",
+    "result"
+  ],
   "properties": {
-    "timestamp": { "type": "string", "format": "date-time" },
-    "command":   {
+    "timestamp": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "command": {
       "type": "string",
       "description": "The trond subcommand that was invoked.",
-      "examples": ["apply", "stop", "snapshot.download", "network.create"]
+      "examples": [
+        "apply",
+        "stop",
+        "snapshot.download",
+        "network.create"
+      ]
     },
-    "node":         { "type": "string", "description": "Affected managed node, when applicable." },
-    "target":       { "type": "string", "description": "Target type that processed the command (local | ssh)." },
-    "intent_hash":  { "type": "string", "pattern": "^[0-9a-f]{64}$" },
-    "result":       { "type": "string", "enum": ["success", "failure", "no_change"] },
-    "duration_ms":  { "type": "integer", "minimum": 0 },
-    "error_code":   { "type": "string" }
+    "node": {
+      "type": "string",
+      "description": "Affected managed node, when applicable."
+    },
+    "target": {
+      "type": "string",
+      "description": "Target type that processed the command (local | ssh)."
+    },
+    "intent_hash": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "result": {
+      "type": "string",
+      "enum": [
+        "success",
+        "failure",
+        "no_change"
+      ]
+    },
+    "duration_ms": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "error_code": {
+      "type": "string"
+    },
+    "detail": {
+      "type": "string",
+      "description": "What the command acted on, for verbs where the verb alone does not say (exec's program, files put's destination, a recipe's source). An identifier, never a payload."
+    },
+    "run_id": {
+      "type": "string",
+      "description": "Correlation id shared by every entry from one recipe run, including the steps it re-execs."
+    }
   }
 }

--- a/scripts/bootstrap-go.sh
+++ b/scripts/bootstrap-go.sh
@@ -63,8 +63,15 @@ case "${os}-${arch}" in
 esac
 
 # Fast path: already extracted, binary works.
+#
+# GOTOOLCHAIN=local is load-bearing. Without it `go env GOVERSION` reports
+# the EFFECTIVE toolchain, and Go 1.21+ auto-upgrades to whatever go.mod's
+# `toolchain` line names — so an installed go1.25.9 reported itself as
+# go1.25.11, never matched GO_VERSION, and every single make invocation
+# deleted the toolchain and re-downloaded 55 MB. The check has to ask what
+# is installed here, not what this repo would rather use.
 if [ -x "${GO_DIR}/bin/go" ]; then
-    actual_version=$("${GO_DIR}/bin/go" env GOVERSION 2>/dev/null || echo "")
+    actual_version=$(GOTOOLCHAIN=local "${GO_DIR}/bin/go" env GOVERSION 2>/dev/null || echo "")
     if [ "$actual_version" = "go${GO_VERSION}" ]; then
         # Already correct version; nothing to do.
         exit 0

--- a/tools/txgen/expiration_nonce_test.go
+++ b/tools/txgen/expiration_nonce_test.go
@@ -1,0 +1,115 @@
+package main
+
+import (
+	"encoding/hex"
+	"encoding/json"
+	"testing"
+
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/anypb"
+
+	tronpb "github.com/tronprotocol/tron-deployment/internal/tronproto/pb"
+)
+
+// The node stamps raw_data.timestamp with its own clock, so transactions
+// built in the same millisecond with the same sender, receiver and amount
+// have byte-identical raw_data and therefore one txID. The node accepts
+// the first and rejects the rest with DUP_TRANSACTION_ERROR — while the
+// run reports the full generated count, so the applied load is quietly
+// smaller than the number on screen.
+//
+// generate gives each transaction a distinct expiration offset. This
+// pins the property that relies on: same transaction, different offset,
+// different txID.
+
+func identicalUnsigned(t *testing.T) *UnsignedTx {
+	t.Helper()
+	param, err := anypb.New(&tronpb.TransferContract{
+		OwnerAddress: mustHex(t, "41e552f6487585c2b58bc2c9bb4492bc1f17132cd0"),
+		ToAddress:    mustHex(t, "41d1e7a6bc354106cb410e65ff8b181c600ff14292"),
+		Amount:       1,
+	})
+	if err != nil {
+		t.Fatalf("pack contract: %v", err)
+	}
+	raw := &tronpb.TransactionRaw{
+		RefBlockBytes: mustHex(t, "1234"),
+		RefBlockHash:  mustHex(t, "0102030405060708"),
+		Timestamp:     1_700_000_000_000,
+		Expiration:    1_700_000_060_000,
+		Contract: []*tronpb.Transaction_Contract{{
+			Type: tronpb.Transaction_Contract_TransferContract, Parameter: param,
+		}},
+	}
+	rawBytes, err := proto.Marshal(raw)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	rawHex := hex.EncodeToString(rawBytes)
+	body, err := json.Marshal(map[string]any{
+		"txID":         "00",
+		"raw_data_hex": rawHex,
+		"raw_data":     map[string]any{"timestamp": raw.Timestamp},
+	})
+	if err != nil {
+		t.Fatalf("marshal json: %v", err)
+	}
+	return &UnsignedTx{TxID: "00", RawDataHex: rawHex, Raw: body}
+}
+
+func TestExtendExpiration_DistinctOffsetsYieldDistinctTxIDs(t *testing.T) {
+	base := identicalUnsigned(t)
+	same := identicalUnsigned(t)
+	if base.RawDataHex != same.RawDataHex {
+		t.Fatal("fixture is not identical; the test would prove nothing")
+	}
+
+	a := identicalUnsigned(t)
+	b := identicalUnsigned(t)
+	if err := a.ExtendExpiration(60_000 + 1); err != nil {
+		t.Fatalf("ExtendExpiration: %v", err)
+	}
+	if err := b.ExtendExpiration(60_000 + 2); err != nil {
+		t.Fatalf("ExtendExpiration: %v", err)
+	}
+	if a.TxID == b.TxID {
+		t.Errorf("byte-identical transactions kept the same txID (%s) across different "+
+			"expiration offsets; the node would reject one as DUP_TRANSACTION_ERROR", a.TxID)
+	}
+
+	// And the control: the SAME offset must still be deterministic, or
+	// the fix would be hiding collisions behind randomness.
+	c := identicalUnsigned(t)
+	d := identicalUnsigned(t)
+	if err := c.ExtendExpiration(60_000 + 7); err != nil {
+		t.Fatalf("ExtendExpiration: %v", err)
+	}
+	if err := d.ExtendExpiration(60_000 + 7); err != nil {
+		t.Fatalf("ExtendExpiration: %v", err)
+	}
+	if c.TxID != d.TxID {
+		t.Errorf("the same input and offset produced different txIDs (%s vs %s); "+
+			"generation must stay deterministic", c.TxID, d.TxID)
+	}
+}
+
+// TestExpirationNonce_DistinctWithinSpread pins that the counter hands out
+// distinct offsets, and that they stay inside the bound so expiration
+// cannot walk toward java-tron's 24h ceiling.
+func TestExpirationNonce_DistinctWithinSpread(t *testing.T) {
+	seen := map[int64]bool{}
+	for i := 0; i < 1000; i++ {
+		n := expirationNonce.Add(1) % expirationSpreadMillis
+		if seen[n] {
+			t.Fatalf("offset %d handed out twice within %d draws", n, i+1)
+		}
+		seen[n] = true
+		if n < 0 || n >= expirationSpreadMillis {
+			t.Fatalf("offset %d outside [0, %d)", n, expirationSpreadMillis)
+		}
+	}
+	if expirationSpreadMillis >= maxExpirationMillis {
+		t.Errorf("the spread (%d) is not comfortably below the ceiling (%d)",
+			expirationSpreadMillis, maxExpirationMillis)
+	}
+}

--- a/tools/txgen/generate.go
+++ b/tools/txgen/generate.go
@@ -35,6 +35,20 @@ import (
 // Note on expiration: the node assigns expiration = head_block_time +
 // 60s by default for HTTP-built transactions. txgen rewrites raw_data
 // before signing so generated transactions use cfg.Generate.ExpirationMillis.
+//
+// expirationSpreadMillis bounds the per-transaction expiration offset that
+// keeps otherwise-identical transactions from sharing a txID. 60s of
+// spread over a default 60s lifetime stays far below java-tron's 24h
+// ceiling while giving 60,000 distinct values — far more than the number
+// of transactions that can share a single millisecond timestamp.
+const expirationSpreadMillis = 60_000
+
+// expirationNonce hands every transaction in a run a distinct offset. It
+// is process-global rather than per-worker because workers build
+// transactions concurrently and a per-worker counter would collide
+// across them.
+var expirationNonce atomic.Int64
+
 func runGenerate(ctx context.Context, cfg *Config) error {
 	// 0700: receivers.csv lands here with one cleartext secp256k1
 	// private key per receiver, so the directory must not be traversable
@@ -334,7 +348,21 @@ func generateBatch(
 			fail++
 			continue
 		}
-		if err := unsigned.ExtendExpiration(cfg.Generate.ExpirationMillis); err != nil {
+		// Nudge each transaction's expiration by a distinct amount.
+		//
+		// The node stamps raw_data.timestamp with its own clock, so N
+		// transactions built in the same millisecond with the same
+		// sender, receiver and amount have byte-identical raw_data —
+		// hence one txID, and the node rejects all but the first with
+		// DUP_TRANSACTION_ERROR. Nothing said so: the run reported the
+		// full count generated and a quietly smaller count accepted,
+		// which reads as node backpressure rather than a generator bug.
+		//
+		// The offset is bounded so it cannot walk expiration toward
+		// java-tron's 24h ceiling; expiration is a deadline, so moving it
+		// by milliseconds changes nothing a load test cares about.
+		nonce := expirationNonce.Add(1) % expirationSpreadMillis
+		if err := unsigned.ExtendExpiration(cfg.Generate.ExpirationMillis + nonce); err != nil {
 			fail++
 			continue
 		}


### PR DESCRIPTION
Six commits, each self-contained and independently revertable. The first two are the audit work this PR opened with; the rest are the follow-ups called out across #211–#214, folded in on request.

| commit | what |
|---|---|
| `fix(audit)` | a recipe run left nothing in the log; `AuditEntry` had nowhere to say what a command acted on |
| `feat(audit)` | correlate a run with the steps it re-execs (`run_id`) |
| `feat(audit)` | record which path `files get` read off a node |
| `fix(wait)` | `--http` must be a URL, not a curl option |
| `fix(build)` | stop re-downloading the Go toolchain on every `make` |
| `fix(txgen)` | generated transactions collided on txID, shrinking the applied load |

## 1–2. Audit: what ran, and what caused it

A recipe run could act and leave no trace. Command steps re-exec trond so the child logs itself, but nothing recorded the run, and `kind: host` steps never re-enter trond — making a recipe the most capable command in the tool and the only one invisible to the log.

`AuditEntry` also had nowhere to say *what* a command acted on. For `stop n0` the verb is the whole story; for the three commands that run caller-supplied content it is not. This was flagged as a follow-up in #211 and is now paid off, together with a `run_id` that ties a run to the steps it spawns:

```
run_id=aa51fc58  recipe host-step  detail=touch-host: true
run_id=aa51fc58  stop
run_id=aa51fc58  recipe run        detail=./mix.yaml
```

That middle line is a separate trond process. **Detail carries an identifier, never a payload** — the program but not the argv, the destination but not the bytes. Full argv and file contents are where a caller is most likely to have put a token, and an audit log is the wrong place to learn one. `run_id` travels in an environment variable rather than a flag: every command writes audit entries, and threading a parameter through all of them to serve one caller is the wrong shape.

Refused and dry-run steps write **no** step entry — they did not run, and claiming otherwise is worse than silence — while the run itself is still recorded as a failure.

## 3. `files get`

Reads an arbitrary path off a node. Not a mutation, so deliberately still not gated — the gate is for mutation, and blocking reads makes it something people switch off. But a jar node's `config.conf` carries the block-signing key in `localwitness`, so the path read is worth recording even when reading it was legitimate. `files put` already left an entry; its read counterpart left none.

## 4. `wait --http`

The value becomes an argv item for `curl` on the node, unvalidated — so `-K/etc/shadow` or `-o/tmp/x` is an option rather than a URL and curl reads it as one. It is argv rather than a shell, so this is narrow, but the check costs one comparison. Validated once before the poll loop, so a bad value fails immediately rather than on every attempt until the timeout.

**Correcting something I said earlier:** I had listed `health` as having the same problem. It does not — it builds its URL from a port stored in state, and is unchanged here.

## 5. Toolchain

`bootstrap-go` asked the installed toolchain its version with `go env GOVERSION`, which reports the **effective** toolchain — and Go 1.21+ auto-upgrades to whatever `go.mod`'s `toolchain` line names. This repo pins `toolchain go1.25.11` while `GO_VERSION` is 1.25.9, so an installed 1.25.9 reported itself as 1.25.11, never matched, and every `make` deleted and re-downloaded 55 MB. `GOTOOLCHAIN=local` makes the check ask what is installed rather than what the repo would prefer. Fast path: 0.18s → 0.04s.

## 6. txgen duplicates

The node stamps `raw_data.timestamp` with its own clock, so transactions built in the same millisecond with the same sender, receiver and amount are byte-identical — one txID — and all but the first are rejected as `DUP_TRANSACTION_ERROR`. The report showed the full generated count beside a quietly smaller accepted count, reading as node backpressure rather than a generator bug.

Measured against a private chain, identical configuration either side, load held **below the node's intake ceiling** so `SERVER_BUSY` could not mask the effect:

| regime | | unique txIDs | broadcast OK | fail |
|---|---|---|---|---|
| 1200 tx, 50 receivers, conc 16 | before | 1192 | 1192 | 8 — all `Dup transaction.` |
| | after | **1200** | **1200** | 0 |
| repeat | before | 1154 | 1154 | 46 — all `Dup transaction.` |
| | after | **1200** | **1200** | 0 |
| 1200 tx, **5 receivers, conc 32** | before | 855 | — | **28.75% of the run lost** |
| | after | **1200** | — | **0%** |

`broadcast OK` equals `unique txIDs` **exactly** in every pre-fix run: the duplicates are not correlated with the lost load, they are it, one for one. The rate swings 0.67% → 28.75% with fan-out and concurrency, which is why it read as noise.

Duplicates were counted at the source — distinct txIDs in the generated CSVs — rather than from the broadcast log, which only samples the first 20 failures. That makes the count exact rather than extrapolated.

A first attempt at this comparison was discarded: it ran both variants back to back at saturating load, so the second inherited a full mempool and its extra failures were all `SERVER_BUSY`. The numbers above come from a fresh chain with the load dropped below saturation.

Each transaction now takes a distinct expiration offset from a process-global counter, riding the rewrite txgen already does before signing. Bounded at 60s so it cannot walk expiration toward java-tron's 24h ceiling.

## Testing

- `make test -race` — 25 packages, 0 failures
- `make lint` — no findings
- Audit behaviour verified end to end against a real binary: the `run_id` correlation above is actual output, including the child-process line
- txgen: measured end to end on a live private chain (table above), plus unit tests for the property — different offsets → different txIDs, same offset → deterministic, so the fix is not hiding collisions behind randomness

## Still open

Nothing from the earlier list. `verify-config` can also read arbitrary paths off a node; it is the same disclosure shape as `files get` and would want the same entry, but it reads through a different path and is left for a change that can test it properly.

