### PR TITLE
fix(recipe): host steps left dir: and script: unsubstituted

### DIFF
--- a/internal/recipe/host_step_test.go
+++ b/internal/recipe/host_step_test.go
@@ -226,3 +226,78 @@ func TestValidate_CommandStepsUnchanged(t *testing.T) {
 		t.Fatalf("a recipe with no kind: field must still parse: %v", err)
 	}
 }
+
+// TestValidate_ScriptRejectsTemplateSyntax covers a defect shipped in the
+// kind: host change: script is not substituted, so `{{ params.x }}` inside
+// it reached the shell as literal text. The step ran, nothing errored, and
+// it operated on the template string — a recipe whose await-loop curled a
+// literal "{{ params.node_url }}" span until the caller gave up.
+//
+// Substituting into a shell body is not the fix: a param of "; rm -rf /"
+// would execute. env: is substituted and the shell sees it as data, so the
+// trap becomes a load-time error pointing there.
+func TestValidate_ScriptRejectsTemplateSyntax(t *testing.T) {
+	body := "name: t\nsteps:\n  - id: a\n    kind: host\n" +
+		"    script: curl -sf {{ params.node_url }}/health\n"
+	_, err := Parse([]byte(body))
+	if err == nil {
+		t.Fatal("want {{ }} in a script rejected, got nil — it would have run as literal text")
+	}
+	for _, want := range []string{"script is not substituted", "env:"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error %v should contain %q so the author knows what to do instead", err, want)
+		}
+	}
+}
+
+// TestHostStep_EnvIsTheSubstitutionChannel is the other half: the escape
+// hatch the error points at has to actually work.
+func TestHostStep_EnvIsTheSubstitutionChannel(t *testing.T) {
+	dir := t.TempDir()
+	r := Recipe{
+		Name:   "t",
+		Params: []Param{{Name: "target", Required: true}},
+		Steps: []Step{{
+			ID: "h1", Kind: KindHost,
+			Env:    map[string]string{"TARGET": "{{ params.target }}"},
+			Script: `printf '%s' "$TARGET" > ` + filepath.Join(dir, "out"),
+		}},
+	}
+	if _, err := Run(context.Background(), r, RunOptions{
+		Out: io.Discard, Err: io.Discard, AllowHostExec: true,
+		Params: map[string]string{"target": "http://example:8090"},
+	}); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	got, _ := os.ReadFile(filepath.Join(dir, "out"))
+	if string(got) != "http://example:8090" {
+		t.Errorf("script saw %q; env: must carry substituted values into the shell", got)
+	}
+}
+
+// TestHostStep_DirIsSubstituted: dir: was shipped unsubstituted alongside
+// script:, but the right answer differs. cmd.Dir is a path handed to
+// chdir — a hostile value can only fail to open — so it substitutes,
+// where a script body is code and does not.
+func TestHostStep_DirIsSubstituted(t *testing.T) {
+	dir := t.TempDir()
+	r := Recipe{
+		Name:   "t",
+		Params: []Param{{Name: "workdir", Required: true}},
+		Steps: []Step{{
+			ID: "h1", Kind: KindHost,
+			Dir: "{{ params.workdir }}",
+			Run: []string{"touch", "made-here"},
+		}},
+	}
+	if _, err := Run(context.Background(), r, RunOptions{
+		Out: io.Discard, Err: io.Discard, AllowHostExec: true,
+		Params: map[string]string{"workdir": dir},
+	}); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "made-here")); err != nil {
+		t.Errorf("dir: was not substituted — the step would chdir to a literal "+
+			"{{ }} path: %v", err)
+	}
+}

--- a/internal/recipe/load.go
+++ b/internal/recipe/load.go
@@ -147,6 +147,12 @@ func validateSteps(section string, steps []Step) []string {
 			case len(s.Run) > 0 && strings.TrimSpace(s.Run[0]) == "":
 				problems = append(problems, where+": run[0] (the program) is empty")
 			}
+			if strings.Contains(s.Script, "{{") {
+				problems = append(problems, where+
+					": script is not substituted, and {{ }} in it would run as literal text. "+
+					"Pass values through env: (which is substituted) and read them as shell "+
+					`variables: env: {NODE_URL: "{{ params.node_url }}"} then "$NODE_URL"`)
+			}
 			if s.Command != "" {
 				problems = append(problems, where+
 					": command belongs to `kind: command` steps; a host step uses run or script")

--- a/internal/recipe/runner.go
+++ b/internal/recipe/runner.go
@@ -183,6 +183,19 @@ func Run(ctx context.Context, r Recipe, opts RunOptions) (*RunResult, error) {
 		}
 
 		st := step
+		// dir: is substituted; script: is not. The difference is where the
+		// value lands: cmd.Dir is a path handed to chdir, where a hostile
+		// value can only fail to open, while a script body is code. Both
+		// were unsubstituted at first, and the failures looked nothing
+		// alike — the script silently ran on literal "{{ ... }}" text,
+		// the dir failed loudly at chdir.
+		if step.Dir != "" {
+			sd, err := substitute(step.Dir, resolved, stepsState)
+			if err != nil {
+				return result, fmt.Errorf("step %s: dir: %w", step.ID, err)
+			}
+			st.Dir = sd
+		}
 		if len(step.Env) > 0 {
 			st.Env = make(map[string]string, len(step.Env))
 			for k, v := range step.Env {

--- a/internal/recipe/types.go
+++ b/internal/recipe/types.go
@@ -89,6 +89,19 @@ type Step struct {
 	// with Run. Use it when you need pipes, globs or conditionals;
 	// prefer Run when you do not, because argv has no quoting rules to
 	// get wrong.
+	//
+	// Script is NOT substituted, and {{ }} inside it is rejected at load
+	// time rather than passed through. Interpolating a value into a shell
+	// body is command injection by construction — a param of
+	// "; rm -rf /" would execute — and passing the template text through
+	// silently is worse still: the script runs, nothing errors, and it
+	// operates on the literal string "{{ params.x }}".
+	//
+	// Reach values through env: instead, which IS substituted and which
+	// the shell sees as data rather than code:
+	//
+	//	env:    {NODE_URL: "{{ params.node_url }}"}
+	//	script: curl -sf "$NODE_URL/wallet/getnowblock"
 	Script string `yaml:"script,omitempty" json:"script,omitempty"`
 
 	// Dir is the working directory for a host step. Relative paths are


### PR DESCRIPTION
`kind: host` (#214) wired substitution for `args`, `run[1:]` and `env:` — and missed the other two fields it accepts. Found by writing the first real recipe that uses them: a private chain, a TRC20 deploy, and a load run. Both fields were broken, and only one broke visibly.

## `script:` — the silent one

The template text reached the shell verbatim:

```yaml
script: until curl -sf {{ params.node_url }}/wallet/getnowblock; do sleep 2; done
```

That curled a literal `{{ params.node_url }}` forever. The step ran, nothing errored, and the recipe hung until I gave up and killed it.

**Substituting it is not the fix.** Interpolating a value into a shell body is command injection by construction — a param of `; rm -rf /` would execute. `env:` is already substituted and the shell sees it as data, so `{{ }}` inside `script:` is now rejected at load time with a message naming that alternative:

```yaml
env:    {NODE_URL: "{{ params.node_url }}"}
script: curl -sf "$NODE_URL/wallet/getnowblock"
```

## `dir:` — the opposite treatment

Now substituted. It becomes `cmd.Dir`, a path handed to chdir where a hostile value can only fail to open. No shell, no injection surface.

It failed loudly — `chdir {{ params.lab_dir }}/contract: no such file or directory` — which is the only reason it was the second bug found rather than the first.

**The two fields differing is the point, and the rule is where the value lands: a path substitutes, code does not.** Both are documented on the struct fields so the next field added has a rule to follow.

## Testing

- `make test -race` — 25 packages, 0 failures
- `make lint` — no findings
- Three new tests: `{{ }}` in `script:` is rejected and the error names `env:`; `env:` actually carries substituted values into the shell; `dir:` substitutes
- Verified by the recipe that found it — 5 steps, `status=success` in 12.6s, ending in an assertion that TRC20 receivers hold exactly `tx_count * amount`

## Still open

`kind: host` has no per-step timeout, which is why the `script:` bug presented as an unbounded hang rather than a failure. That was deliberately deferred in #214 (the runner has no timeout for command steps either, and it wants to arrive for both at once) — but this is the second time its absence turned a bug into a wedged run, so it is worth doing.
